### PR TITLE
Tweak wording of the Mute Texture Paint Overlay option

### DIFF
--- a/Root.py
+++ b/Root.py
@@ -587,8 +587,8 @@ class YQuickYPaintNodeSetup(bpy.types.Operator):
     normal : BoolProperty(name='Normal', default=True)
 
     mute_texture_paint_overlay : BoolProperty(
-            name = 'Mute Texture Paint Overlay',
-            description = 'Set Texture Paint Overlay on 3D View screen to 0. It can helps texture painting better.',
+            name = 'Mute Stencil Mask Opacity',
+            description = 'Set Stencil Mask Opacity found in the 3D Viewport\'s Overlays menu to 0.',
             default = True)
 
     @classmethod


### PR DESCRIPTION
Hey,

I forgot what the "Mute Texture Paint Overlay" setting in Quick Ucupaint Node creation does, so I looked it up in the wiki, and even then I didn't understand.
So I had to look into the source code to see what it does.

I propose to change the wording to reflect what it's literally called in Blender.

We can also include a reason _why_ it's useful, but I think the current sentence also doesn't explain that well.

> "It can help texture painting better."

So feel free to suggest a better explanation, that we could still add to the option's description. I still don't really know who exactly this setting is useful to. (Maybe it's useful to everyone?)

Let me know what you think!