### PR TITLE
Optimize loading materials from the asset library

### DIFF
--- a/Layer.py
+++ b/Layer.py
@@ -2058,8 +2058,7 @@ class YOpenImagesFromMaterialToLayer(bpy.types.Operator, BaseMultipleImagesLayer
 
     mat_name : StringProperty(default='')
     mat_coll : CollectionProperty(type=bpy.types.PropertyGroup)
-
-    from_asset_browser : BoolProperty(default=False)
+    asset_library_path: StringProperty(default='')
 
     @classmethod
     def poll(cls, context):
@@ -2084,7 +2083,7 @@ class YOpenImagesFromMaterialToLayer(bpy.types.Operator, BaseMultipleImagesLayer
                 if self.mat_name == mat.name: 
                     mat_found = True
 
-        if not self.from_asset_browser:
+        if self.asset_library_path == '':
             if not mat_found:
                 self.mat_name = ''
 
@@ -2096,7 +2095,7 @@ class YOpenImagesFromMaterialToLayer(bpy.types.Operator, BaseMultipleImagesLayer
     def draw(self, context):
         row = split_layout(self.layout, 0.325, align=True)
         row.label(text='Material')
-        if not self.from_asset_browser:
+        if self.asset_library_path == '':
             row.prop_search(self, "mat_name", self, "mat_coll", text='', icon='MATERIAL_DATA')
         else: row.label(text=self.mat_name, icon='MATERIAL_DATA')
         self.draw_operator(context, display_relative_toggle=False)
@@ -2115,26 +2114,14 @@ class YOpenImagesFromMaterialToLayer(bpy.types.Operator, BaseMultipleImagesLayer
         # Get material from local first
         mat = bpy.data.materials.get(self.mat_name)
 
-        # Get material from asset library if not found
-        from_asset_library = False
-        if not mat and is_greater_than_300():
-            prefs = bpy.context.preferences
-            filepaths = prefs.filepaths
-            asset_libraries = filepaths.asset_libraries
-            
-            for asset_library in asset_libraries:
-                library_name = asset_library.name
-                library_path = pathlib.Path(asset_library.path)
-                blend_files = [fp for fp in library_path.glob("**/*.blend") if fp.is_file()]
-                print("Checking the content of library '" + library_name + "'")
-                for blend_file in blend_files:
-                    with bpy.data.libraries.load(str(blend_file), assets_only=True) as (data_from, data_to):
-                        for mat in data_from.materials:
-                            if mat == self.mat_name:
-                                data_to.materials.append(mat)
-
+        # If not found get from the asset library
+        from_asset_library = self.asset_library_path != ''
+        if not mat and from_asset_library and is_greater_than_300():
+            with bpy.data.libraries.load(str(self.asset_library_path), assets_only=True) as (data_from, data_to):
+                for mat in data_from.materials:
+                    if mat == self.mat_name:
+                        data_to.materials.append(mat)
             mat = bpy.data.materials.get(self.mat_name)
-            from_asset_library = True
 
         if not mat:
             self.report({'ERROR'}, "Source material cannot be found!")

--- a/ui.py
+++ b/ui.py
@@ -4058,8 +4058,8 @@ class YPAssetBrowserMenu(bpy.types.Menu):
     def draw(self, context):
         obj = context.object
         op = self.layout.operator("node.y_open_images_from_material_to_single_layer", icon_value=lib.get_icon('image'), text='Open Material Images to Layer')
-        op.from_asset_browser = True
         op.mat_name = context.mat_asset.name if hasattr(context, 'mat_asset') else ''
+        op.asset_library_path = context.mat_asset.full_library_path if hasattr(context, 'mat_asset') else ''
 
         if obj.type == 'MESH':
             op.texcoord_type = 'UV'
@@ -4330,7 +4330,7 @@ class YNewLayerMenu(bpy.types.Menu):
         col.operator("node.y_open_available_data_to_layer", text='Open Available Image').type = 'IMAGE'
 
         col.operator("node.y_open_images_to_single_layer", text='Open Images to Single Layer')
-        col.operator("node.y_open_images_from_material_to_single_layer", text='Open Images from Material').from_asset_browser = False
+        col.operator("node.y_open_images_from_material_to_single_layer", text='Open Images from Material').asset_library_path = ''
 
         # NOTE: Dedicated menu for opening images to single layer is kinda hard to see, so it's probably better be hidden for now
         #col.menu("NODE_MT_y_open_images_to_single_layer_menu", text='Open Images to Single Layer')
@@ -4633,7 +4633,7 @@ class YOpenImagesToSingleLayerMenu(bpy.types.Menu):
         col = self.layout.column()
 
         col.operator("node.y_open_images_to_single_layer", icon='FILE_FOLDER', text='From Directory')
-        col.operator("node.y_open_images_from_material_to_single_layer", icon='MATERIAL_DATA', text='From Material').from_asset_browser = False
+        col.operator("node.y_open_images_from_material_to_single_layer", icon='MATERIAL_DATA', text='From Material').asset_library_path = ''
 
 class YNewSolidColorLayerMenu(bpy.types.Menu):
     bl_idname = "NODE_MT_y_new_solid_color_layer_menu"


### PR DESCRIPTION
Makes sure only the blend file containing the selected asset is loaded instead of all of them

With a big asset library (45 blend files) this brings a 5x time reduction (5s before > 1s after)