### PR TITLE
Add editor setting to skip property popups

### DIFF
--- a/Bake.py
+++ b/Bake.py
@@ -868,6 +868,10 @@ class YBakeChannelToVcol(bpy.types.Operator, BaseBakeOperator):
     @classmethod
     def poll(cls, context):
         return get_active_ypaint_node() and context.object.type == 'MESH'
+    
+    @classmethod
+    def description(self, context, properties):
+        return get_operator_description(self)
 
     def invoke(self, context, event):
         self.invoke_operator(context)
@@ -894,6 +898,9 @@ class YBakeChannelToVcol(bpy.types.Operator, BaseBakeOperator):
         self.show_bake_to_alpha_only_option = False
         if channel.type == 'VALUE':
             self.show_bake_to_alpha_only_option = True
+
+        if get_user_preferences().skip_property_popups and not event.shift:
+            return self.execute(context)
 
         return context.window_manager.invoke_props_dialog(self, width=320)
 
@@ -1043,7 +1050,7 @@ class YDeleteBakedChannelImages(bpy.types.Operator):
     bl_idname = "node.y_delete_baked_channel_images"
     bl_label = "Delete All Baked Channel Images"
     bl_description = "Delete all baked channel images"
-    bl_options = {'REGISTER', 'UNDO'}
+    bl_options = {'UNDO'}
 
     also_del_vcol : BoolProperty(
         name="Also delete the vertex color",
@@ -1053,6 +1060,10 @@ class YDeleteBakedChannelImages(bpy.types.Operator):
     def poll(cls, context):
         return get_active_ypaint_node() and context.object.type == 'MESH'
 
+    @classmethod
+    def description(self, context, properties):
+        return get_operator_description(self)
+
     def invoke(self, context, event):
         node = get_active_ypaint_node()
         tree = node.node_tree
@@ -1060,12 +1071,13 @@ class YDeleteBakedChannelImages(bpy.types.Operator):
 
         self.any_channel_use_baked_vcol = False
 
-        for ch in yp.channels:
-            baked_vcol_node = tree.nodes.get(ch.baked_vcol)
-            self.baked_vcol_name = baked_vcol_node.attribute_name if baked_vcol_node else ''
-            if self.baked_vcol_name != '':
-                self.any_channel_use_baked_vcol = True
-                return context.window_manager.invoke_props_dialog(self, width=320)
+        if not get_user_preferences().skip_property_popups or event.shift:
+            for ch in yp.channels:
+                baked_vcol_node = tree.nodes.get(ch.baked_vcol)
+                self.baked_vcol_name = baked_vcol_node.attribute_name if baked_vcol_node else ''
+                if self.baked_vcol_name != '':
+                    self.any_channel_use_baked_vcol = True
+                    return context.window_manager.invoke_props_dialog(self, width=320)
 
         self.also_del_vcol = False
         return self.execute(context)
@@ -1279,6 +1291,9 @@ class YBakeChannels(bpy.types.Operator, BaseBakeOperator):
 
         if self.vcol_force_first_ch_idx == '':
             self.vcol_force_first_ch_idx = 'Do Nothing'
+
+        if get_user_preferences().skip_property_popups and not event.shift:
+            return self.execute(context)
 
         return context.window_manager.invoke_props_dialog(self, width=320)
 
@@ -2582,6 +2597,9 @@ class YBakeTempImage(bpy.types.Operator, BaseBakeOperator):
 
         if len(self.uv_map_coll) > 0:
             self.uv_map = self.uv_map_coll[0].name
+
+        if get_user_preferences().skip_property_popups and not event.shift:
+            return self.execute(context)
 
         return context.window_manager.invoke_props_dialog(self, width=320)
 

--- a/BakeToLayer.py
+++ b/BakeToLayer.py
@@ -295,6 +295,10 @@ class YBakeToLayer(bpy.types.Operator, BaseBakeOperator):
     def poll(cls, context):
         return get_active_ypaint_node() and context.object.type == 'MESH'
 
+    @classmethod
+    def description(self, context, properties):
+        return get_operator_description(self)
+
     def invoke(self, context, event):
         self.invoke_operator(context)
 
@@ -550,6 +554,10 @@ class YBakeToLayer(bpy.types.Operator, BaseBakeOperator):
         for ob in get_scene_objects():
             if ob != obj and ob not in bpy.context.selected_objects and ob.type == 'MESH':
                 self.cage_object_coll.add().name = ob.name
+ 
+        requires_popup = self.type in {'OTHER_OBJECT_NORMAL', 'OTHER_OBJECT_EMISSION', 'OTHER_OBJECT_CHANNELS', 'FLOW'}
+        if not requires_popup and get_user_preferences().skip_property_popups and not event.shift:
+            return self.execute(context)
 
         return context.window_manager.invoke_props_dialog(self, width=320)
 
@@ -2164,7 +2172,7 @@ class YBakeEntityToImage(bpy.types.Operator, BaseBakeOperator):
     bl_idname = "node.y_bake_entity_to_image"
     bl_label = "Bake Layer/Mask To Image"
     bl_description = "Bake Layer/Mask to an image"
-    bl_options = {'REGISTER', 'UNDO'}
+    bl_options = {'UNDO'}
 
     name : StringProperty(default='')
 
@@ -2213,6 +2221,10 @@ class YBakeEntityToImage(bpy.types.Operator, BaseBakeOperator):
     @classmethod
     def poll(cls, context):
         return get_active_ypaint_node() and context.object.type == 'MESH'
+
+    @classmethod
+    def description(self, context, properties):
+        return get_operator_description(self)
 
     def invoke(self, context, event):
         self.invoke_operator(context)
@@ -2326,6 +2338,9 @@ class YBakeEntityToImage(bpy.types.Operator, BaseBakeOperator):
                 self.hdr = False
                 self.fxaa = True
                 self.denoise = False
+
+        if get_user_preferences().skip_property_popups and not event.shift:
+            return self.execute(context)
 
         return context.window_manager.invoke_props_dialog(self, width=320)
 

--- a/Layer.py
+++ b/Layer.py
@@ -367,7 +367,7 @@ class YNewVcolToOverrideChannel(bpy.types.Operator):
     bl_idname = "node.y_new_vcol_to_override_channel"
     bl_label = "New Vertex Color To Override Channel Layer"
     bl_description = "New Vertex Color To Override Channel Layer"
-    bl_options = {'REGISTER', 'UNDO'}
+    bl_options = {'UNDO'}
 
     name : StringProperty(default='')
 
@@ -387,6 +387,10 @@ class YNewVcolToOverrideChannel(bpy.types.Operator):
     def poll(cls, context):
         return get_active_ypaint_node()
 
+    @classmethod
+    def description(self, context, properties):
+        return get_operator_description(self)
+
     def invoke(self, context, event):
         self.ch = context.parent
 
@@ -398,6 +402,9 @@ class YNewVcolToOverrideChannel(bpy.types.Operator):
         self.tree = get_tree(layer)
 
         self.name = layer.name + ' ' + root_ch.name +  ' Override'
+
+        if get_user_preferences().skip_property_popups and not event.shift:
+            return self.execute(context)
 
         return context.window_manager.invoke_props_dialog(self, width=320)
 
@@ -518,7 +525,7 @@ class YNewVDMLayer(bpy.types.Operator):
     bl_idname = "node.y_new_vdm_layer"
     bl_label = "New VDM Layer"
     bl_description = "New Vector Displacement Layer"
-    bl_options = {'REGISTER', 'UNDO'}
+    bl_options = {'UNDO'}
 
     name : StringProperty(default='')
 
@@ -548,6 +555,10 @@ class YNewVDMLayer(bpy.types.Operator):
     def poll(cls, context):
         return context.object and context.object.type == 'MESH' and get_active_ypaint_node()
 
+    @classmethod
+    def description(self, context, properties):
+        return get_operator_description(self)
+
     def invoke(self, context, event):
         ypup = get_user_preferences()
         obj = context.object
@@ -572,6 +583,9 @@ class YNewVDMLayer(bpy.types.Operator):
         for uv in get_uv_layers(obj):
             if not uv.name.startswith(TEMP_UV):
                 self.uv_map_coll.add().name = uv.name
+
+        if get_user_preferences().skip_property_popups and not event.shift:
+            return self.execute(context)
 
         return context.window_manager.invoke_props_dialog(self, width=320)
 
@@ -869,6 +883,10 @@ class YNewLayer(bpy.types.Operator):
         return get_active_ypaint_node()
         #return hasattr(context, 'group_node') and context.group_node
 
+    @classmethod
+    def description(self, context, properties):
+        return get_operator_description(self)
+
     def invoke(self, context, event):
 
         ypup = get_user_preferences()
@@ -943,6 +961,9 @@ class YNewLayer(bpy.types.Operator):
                 for uv in get_uv_layers(obj):
                     if not uv.name.startswith(TEMP_UV):
                         self.uv_map_coll.add().name = uv.name
+
+        if get_user_preferences().skip_property_popups and not event.shift:
+            return self.execute(context)
 
         return context.window_manager.invoke_props_dialog(self, width=320)
 
@@ -2065,6 +2086,10 @@ class YOpenImagesFromMaterialToLayer(bpy.types.Operator, BaseMultipleImagesLayer
         #return get_active_ypaint_node()
         return context.object
 
+    @classmethod
+    def description(self, context, properties):
+        return get_operator_description(self)
+
     def invoke(self, context, event):
         self.invoke_operator(context)
 
@@ -2086,6 +2111,10 @@ class YOpenImagesFromMaterialToLayer(bpy.types.Operator, BaseMultipleImagesLayer
         if self.asset_library_path == '':
             if not mat_found:
                 self.mat_name = ''
+        
+        # Only allow skipping the popup when opening through the asset library
+        if self.asset_library_path != '' and get_user_preferences().skip_property_popups and not event.shift:
+            return self.execute(context)
 
         return context.window_manager.invoke_props_dialog(self)
 
@@ -2322,6 +2351,10 @@ class YOpenImageToLayer(bpy.types.Operator, ImportHelper):
         #return hasattr(context, 'group_node') and context.group_node
         return get_active_ypaint_node()
 
+    @classmethod
+    def description(self, context, properties):
+        return get_operator_description(self)
+
     def invoke(self, context, event):
         obj = context.object
         node = get_active_ypaint_node()
@@ -2344,6 +2377,8 @@ class YOpenImageToLayer(bpy.types.Operator, ImportHelper):
         #self.normal_map_type = 'NORMAL_MAP'
 
         if self.file_browser_filepath != '':
+            if get_user_preferences().skip_property_popups and not event.shift:
+                return self.execute(context)
             return context.window_manager.invoke_props_dialog(self)
         
         context.window_manager.fileselect_add(self)
@@ -3415,7 +3450,7 @@ class YRemoveLayer(bpy.types.Operator):
     bl_idname = "node.y_remove_layer"
     bl_label = "Remove Layer"
     bl_description = "Remove Layer"
-    bl_options = {'REGISTER', 'UNDO'}
+    bl_options = {'UNDO'}
 
     remove_childs : BoolProperty(name='Remove Childs', description='Remove layer childrens', default=False)
     remove_on_disk : BoolProperty(name='Remove Image on disk', description='Remove image file on disk', default=False)
@@ -3425,10 +3460,18 @@ class YRemoveLayer(bpy.types.Operator):
         group_node = get_active_ypaint_node()
         return context.object and group_node and len(group_node.node_tree.yp.layers) > 0
 
+    @classmethod
+    def description(self, context, properties):
+        return get_operator_description(self)
+
     def invoke(self, context, event):
 
         # Remove on disk is dangerous so it's always disabled by default
         self.remove_on_disk = False
+
+        # Only allow to remove files on disk with a confirmation popup
+        if get_user_preferences().skip_property_popups and not event.shift:
+            return self.execute(context)
 
         # Removing UDIM atlas segment is can't be undoed
         node = get_active_ypaint_node()
@@ -4338,7 +4381,7 @@ class YDuplicateLayer(bpy.types.Operator):
     bl_idname = "node.y_duplicate_layer"
     bl_label = "Duplicate layer"
     bl_description = "Duplicate Layer"
-    bl_options = {'REGISTER', 'UNDO'}
+    bl_options = {'UNDO'}
 
     packed_duplicate : BoolProperty(
             name = 'Duplicate Packed Images',
@@ -4363,6 +4406,10 @@ class YDuplicateLayer(bpy.types.Operator):
         group_node = get_active_ypaint_node()
         return context.object and group_node and len(group_node.node_tree.yp.layers) > 0
 
+    @classmethod
+    def description(self, context, properties):
+        return get_operator_description(self)
+
     def invoke(self, context, event):
         node = get_active_ypaint_node()
         yp = node.node_tree.yp
@@ -4374,6 +4421,9 @@ class YDuplicateLayer(bpy.types.Operator):
         if not self.duplicate_blank:
             self.any_packed_image = any(get_layer_images(layer, packed_only=True))
             self.any_ondisk_image = any(get_layer_images(layer, ondisk_only=True))
+
+            if get_user_preferences().skip_property_popups and not event.shift:
+                return self.execute(context)
 
             if self.any_packed_image or self.any_ondisk_image:
                 return context.window_manager.invoke_props_dialog(self, width=200)
@@ -4529,7 +4579,7 @@ class YPasteLayer(bpy.types.Operator):
     bl_idname = "node.y_paste_layer"
     bl_label = "Paste Layer"
     bl_description = "Paste Layer"
-    bl_options = {'REGISTER', 'UNDO'}
+    bl_options = {'UNDO'}
 
     packed_duplicate : BoolProperty(
             name = 'Duplicate Packed Images',
@@ -4548,6 +4598,10 @@ class YPasteLayer(bpy.types.Operator):
         group_node = get_active_ypaint_node()
         return context.object and group_node
 
+    @classmethod
+    def description(self, context, properties):
+        return get_operator_description(self)
+
     def invoke(self, context, event):
         wm = context.window_manager
         wmp = wm.ypprops
@@ -4565,9 +4619,12 @@ class YPasteLayer(bpy.types.Operator):
                 self.any_ondisk_image = any(get_layer_images(layer_source, ondisk_only=True))
 
         if self.any_packed_image or self.any_ondisk_image:
+            if get_user_preferences().skip_property_popups and not event.shift:
+                return self.execute(context)
+
             return context.window_manager.invoke_props_dialog(self, width=200)
 
-        return context.window_manager.invoke_props_dialog(self, width=200)
+        return self.execute(context)
 
     def draw(self, context):
         if self.any_packed_image:

--- a/Mask.py
+++ b/Mask.py
@@ -334,6 +334,10 @@ class YNewLayerMask(bpy.types.Operator):
     def poll(cls, context):
         return True
 
+    @classmethod
+    def description(self, context, properties):
+        return get_operator_description(self)
+
     def get_to_be_cleared_image_atlas(self, context, yp):
         if self.type == 'IMAGE' and self.use_image_atlas:
             return ImageAtlas.check_need_of_erasing_segments(yp, self.color_option, self.width, self.height, self.hdr)
@@ -400,6 +404,9 @@ class YNewLayerMask(bpy.types.Operator):
         elif layer.type == 'IMAGE':
             source = get_layer_source(layer)
             if source and source.image: self.interpolation = source.interpolation
+        
+        if get_user_preferences().skip_property_popups and not event.shift:
+            return self.execute(context)
 
         return context.window_manager.invoke_props_dialog(self)
 
@@ -715,6 +722,10 @@ class YOpenImageAsMask(bpy.types.Operator, ImportHelper):
         node = get_active_ypaint_node()
         return node and len(node.node_tree.yp.layers) > 0
 
+    @classmethod
+    def description(self, context, properties):
+        return get_operator_description(self)
+
     def invoke(self, context, event):
         obj = context.object
         if hasattr(context, 'layer'):
@@ -755,6 +766,8 @@ class YOpenImageAsMask(bpy.types.Operator, ImportHelper):
             if source and source.image: self.interpolation = source.interpolation
 
         if self.file_browser_filepath != '':
+            if get_user_preferences().skip_property_popups and not event.shift:
+                return self.execute(context)
             return context.window_manager.invoke_props_dialog(self)
 
         context.window_manager.fileselect_add(self)
@@ -938,6 +951,10 @@ class YOpenAvailableDataAsMask(bpy.types.Operator):
     def poll(cls, context):
         return True
 
+    @classmethod
+    def description(self, context, properties):
+        return get_operator_description(self)
+
     def invoke(self, context, event):
         obj = context.object
         node = get_active_ypaint_node()
@@ -1027,6 +1044,9 @@ class YOpenAvailableDataAsMask(bpy.types.Operator):
         # The default blend type for mask is multiply
         if len(layer.masks) == 0:
             self.blend_type = 'MULTIPLY'
+    
+        if self.image_name != '' and get_user_preferences().skip_property_popups and not event.shift:
+            return self.execute(context)
 
         return context.window_manager.invoke_props_dialog(self)
 

--- a/Root.py
+++ b/Root.py
@@ -204,6 +204,10 @@ class YSelectMaterialPolygons(bpy.types.Operator):
     def poll(cls, context):
         return context.object
 
+    @classmethod
+    def description(self, context, properties):
+        return get_operator_description(self)
+
     def invoke(self, context, event):
         if not is_greater_than_280():
             self.execute(context)
@@ -225,6 +229,9 @@ class YSelectMaterialPolygons(bpy.types.Operator):
         for uv in get_uv_layers(obj):
             if not uv.name.startswith(TEMP_UV):
                 self.uv_map_coll.add().name = uv.name
+        
+        if get_user_preferences().skip_property_popups and not event.shift:
+            return self.execute(context)
 
         return context.window_manager.invoke_props_dialog(self, width=400)
 
@@ -452,6 +459,10 @@ class YQuickYPaintNodeSetup(bpy.types.Operator):
     def poll(cls, context):
         return context.object
 
+    @classmethod
+    def description(self, context, properties):
+        return get_operator_description(self)
+
     def invoke(self, context, event):
         space = context.space_data
         obj = context.object
@@ -480,6 +491,9 @@ class YQuickYPaintNodeSetup(bpy.types.Operator):
                     break
 
         self.not_on_material_view = space.type == 'VIEW_3D' and ((not is_greater_than_280() and space.viewport_shade not in {'MATERIAL', 'RENDERED'}) or (is_greater_than_280() and space.shading.type not in {'MATERIAL', 'RENDERED'}))
+
+        if get_user_preferences().skip_property_popups and not event.shift:
+            return self.execute(context)
 
         return context.window_manager.invoke_props_dialog(self)
 
@@ -1814,6 +1828,10 @@ class YDuplicateYPNodes(bpy.types.Operator):
 
         return True
 
+    @classmethod
+    def description(self, context, properties):
+        return get_operator_description(self)
+
     def invoke(self, context, event):
         group_node = get_active_ypaint_node()
         yp = group_node.node_tree.yp
@@ -1824,6 +1842,9 @@ class YDuplicateYPNodes(bpy.types.Operator):
             self.any_ondisk_image = any(get_layer_images(layer, ondisk_only=True))
             if self.any_ondisk_image:
                 break
+
+        if get_user_preferences().skip_property_popups and not event.shift:
+            return self.execute(context)
 
         return context.window_manager.invoke_props_dialog(self)
 

--- a/common.py
+++ b/common.py
@@ -840,6 +840,10 @@ def get_user_preferences():
         return bpy.context.preferences.addons[__package__].preferences
     return bpy.context.user_preferences.addons[__package__].preferences
 
+def get_operator_description(operator):
+    description = operator.bl_description or operator.bl_label
+    return description + ". Hold Shift for options" if get_user_preferences().skip_property_popups else ""
+
 def get_all_layer_collections(arr, col):
     if col not in arr:
         arr.append(col)

--- a/preferences.py
+++ b/preferences.py
@@ -49,6 +49,11 @@ class YPaintPreferences(AddonPreferences):
             description = 'Use image preview or thumbnail on the layers list',
             default = False)
 
+    skip_property_popups: BoolProperty(
+            name = 'Skip Property Popups (Hold Shift to Show)',
+            description = 'Don\'t show property popups unless Shift key is pressed. Will use last invokation properties if skipped',
+            default = False)
+
     make_preview_mode_srgb : BoolProperty(
             name = 'Make Preview Mode use sRGB',
             description = 'Make sure preview mode use sRGB color',
@@ -111,6 +116,7 @@ class YPaintPreferences(AddonPreferences):
         self.layout.prop(self, 'unique_image_atlas_per_yp')
         self.layout.prop(self, 'make_preview_mode_srgb')
         self.layout.prop(self, 'use_image_preview')
+        self.layout.prop(self, 'skip_property_popups')
         self.layout.prop(self, 'show_experimental')
         self.layout.prop(self, 'developer_mode')
         #self.layout.prop(self, 'parallax_without_baked')


### PR DESCRIPTION
Adds a setting to disable most popup windows by default and allows holding Shift to show them

Also adds a hint about the Shift key to tooltips of affected operators

**Note:** There are some operators in ucupaint that don't support the redo panel because they rely on code running in `invoke()`. Trying to run them through the redo panel would result in an error or sometimes crash. This is a little beyond the scope of this PR (the redo panel is shown regardless of whether the popup is skipped or not), but since this PR makes it easier to discover those problems I decided to fix that by disabling the redo panel for operators that don't support it. This only hides the redo panel on the bottom left, the undo functionality (<kbd>Ctrl+Z</kbd>) still works as expected for those operators