### PR TITLE
Clean up icon preferences

### DIFF
--- a/lib.py
+++ b/lib.py
@@ -247,15 +247,9 @@ def load_custom_icons():
     else:
         icons = get_user_preferences().icons 
 
-        bg_color = bpy.context.preferences.themes[0].preferences.space.back
-        is_dark_theme = bg_color[0] + bg_color[1] + bg_color[2] < 1.5
-
         if icons == 'DEFAULT':
-            if is_greater_than_280():
-                icon_set = 'light' if is_dark_theme else 'dark'
-            else:
-                icon_set = 'legacy'
-        elif icons == 'MODERN':
+            bg_color = bpy.context.preferences.themes[0].preferences.space.back
+            is_dark_theme = bg_color[0] + bg_color[1] + bg_color[2] < 1.5
             icon_set = 'light' if is_dark_theme else 'dark'
         else:
             icon_set = 'legacy'

--- a/preferences.py
+++ b/preferences.py
@@ -62,8 +62,7 @@ class YPaintPreferences(AddonPreferences):
     icons : EnumProperty(
             name = 'Icons',
             description = 'Icon set',
-            items=(('DEFAULT', 'Default', 'Choose automatically based on Blender version'),
-                   ('MODERN', 'Modern', 'Icon set from the current Blender version'),
+            items=(('DEFAULT', 'Default', 'Icon set from the current Blender version'),
                    ('LEGACY', 'Legacy', 'Icon set from the old Blender version')),
             default='DEFAULT',
             update=update_icons


### PR DESCRIPTION
Cleanup after the compatibility fixes - removed the redundant version check and also left only 2 options as the old "default" didn't actually do anything anymore. Modern is renamed to default now