### PR TITLE
Fix operator description generator

### DIFF
--- a/common.py
+++ b/common.py
@@ -841,7 +841,12 @@ def get_user_preferences():
     return bpy.context.user_preferences.addons[__package__].preferences
 
 def get_operator_description(operator):
-    description = operator.bl_description or operator.bl_label
+    if hasattr(operator, 'bl_description'):
+        description = operator.bl_description
+    elif hasattr(operator, 'bl_label'):
+        description = operator.bl_label
+    else:
+        return ''
     return description + ". Hold Shift for options" if get_user_preferences().skip_property_popups else ""
 
 def get_all_layer_collections(arr, col):


### PR DESCRIPTION
Was throwing an error on operators with no specified description

<img width="1371" alt="s" src="https://github.com/user-attachments/assets/6da09231-dbab-4592-b1c3-dcb3e180fdfb">
