### PR TITLE
Add features to simplify positioning of existing and new decals

### DIFF
--- a/common.py
+++ b/common.py
@@ -5246,6 +5246,16 @@ def get_layer_images(layer, udim_only=False, ondisk_only=False, packed_only=Fals
 
     return filtered_images
 
+def any_decal_inside_layer(layer):
+    if layer.texcoord_type == 'Decal':
+        return True
+
+    for mask in layer.masks:
+        if mask.texcoord_type == 'Decal':
+            return True
+
+    return False
+
 def any_single_user_ondisk_image_inside_layer(layer):
     for image in get_layer_images(layer, ondisk_only=True):
         if is_image_single_user(image):

--- a/ui.py
+++ b/ui.py
@@ -1461,6 +1461,7 @@ def draw_layer_source(context, layout, layer, layer_tree, source, image, vcol, i
                         if is_bl_newer_than(2, 80):
                             boxcol.operator('node.y_select_decal_object', icon='EMPTY_SINGLE_ARROW')
                         else: boxcol.operator('node.y_select_decal_object', icon='EMPTY_DATA')
+                        boxcol.operator('node.y_set_decal_object_position_to_sursor', text='Set Position to Cursor', icon='CURSOR')
 
                     if layer.texcoord_type != 'Decal':
                         mapping = get_layer_mapping(layer)
@@ -2430,6 +2431,7 @@ def draw_layer_masks(context, layout, layer):
                         if is_bl_newer_than(2, 80):
                             boxcol.operator('node.y_select_decal_object', icon='EMPTY_SINGLE_ARROW')
                         else: boxcol.operator('node.y_select_decal_object', icon='EMPTY_DATA')
+                        boxcol.operator('node.y_set_decal_object_position_to_sursor', text='Set Position to Cursor', icon='CURSOR')
 
                     if mask.texcoord_type != 'Decal':
                         mapping = get_mask_mapping(mask)


### PR DESCRIPTION
Adds 2 things:

- A button to set the position of existing decal object to 3D cursor
- A checkbox to set a new decal position to 3D cursor when duplicating a decal

https://github.com/user-attachments/assets/4b085ad7-9b84-4389-a728-7bd07dfd94c0

Note: Code duplication for getting texcoord is potentially a concern, but I found that it's used in many different places so it's better to refactor it separately in the future