### PR TITLE
Don't try to convert image paths to relative when the blend file is not saved

### DIFF
--- a/Layer.py
+++ b/Layer.py
@@ -1895,7 +1895,7 @@ class BaseMultipleImagesLayer():
             syname = valid_synonyms[i]
 
             # Set relative
-            if self.relative:
+            if self.relative and bpy.data.filepath != '':
                 try: image.filepath = bpy.path.relpath(image.filepath)
                 except: pass
 
@@ -2476,7 +2476,7 @@ class YOpenImageToLayer(bpy.types.Operator, ImportHelper):
         node.node_tree.yp.halt_update = True
 
         for image in images:
-            if self.relative:
+            if self.relative and bpy.data.filepath != '':
                 try: image.filepath = bpy.path.relpath(image.filepath)
                 except: pass
 

--- a/Mask.py
+++ b/Mask.py
@@ -847,7 +847,7 @@ class YOpenImageAsMask(bpy.types.Operator, ImportHelper):
             bpy.context.area.type = ori_ui_type
 
         for image in images:
-            if self.relative:
+            if self.relative and bpy.data.filepath != '':
                 try: image.filepath = bpy.path.relpath(image.filepath)
                 except: pass
 


### PR DESCRIPTION
Closes #192

The problem was that it didn't actually fail to convert to relative paths with unsaved blend file but the resulting paths were broken (could be a mac or unix specific problem I suppose). Anyway it doesn't make sense to try to convert to relative when the file is not saved because it's relative to the blend file according to docs and this PR actually fixes the issue