### PR TITLE
Don't draw colon when channels are collapsed

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -1551,7 +1551,6 @@ def draw_layer_channels(context, layout, layer, layer_tree, image):
             else:
                 label += ' (' + root_ch.name + ')'
                 #label = root_ch.name
-            label += ':'
 
     else:
         label = pgettext_iface('Channels') + ' (' + str(len(enabled_channels)) + ')'


### PR DESCRIPTION
Fixes a small inconsistency to make it behave like masks

<img width="136" alt="image" src="https://github.com/user-attachments/assets/15247402-4eed-4426-b5b0-dd57ed26389e"><br>

<img width="261" alt="image" src="https://github.com/user-attachments/assets/70057e24-413b-4b38-9de7-835c9e3fcaf8">
