### PR TITLE
Add missing halts to uniform scale enabled functions

### DIFF
--- a/Layer.py
+++ b/Layer.py
@@ -6175,6 +6175,9 @@ def update_layer_blur_vector_factor(self, context):
         blur_vector.inputs[0].default_value = layer.blur_vector_factor
 
 def update_layer_uniform_scale_enabled(self, context):
+    yp = self.id_data.yp
+    if yp.halt_update: return
+
     layer = self
     update_entity_uniform_scale_enabled(layer)
 

--- a/Mask.py
+++ b/Mask.py
@@ -1798,6 +1798,8 @@ class YLayerMaskChannel(bpy.types.PropertyGroup):
 
 def update_mask_uniform_scale_enabled(self, context):
     yp = self.id_data.yp
+    if yp.halt_update: return
+
     match = re.match(r'yp\.layers\[(\d+)\]\.masks\[(\d+)\]', self.path_from_id())
     layer = yp.layers[int(match.group(1))]
     mask = self


### PR DESCRIPTION
Those were called when a layer is first created causing an error:

<img width="1372" alt="s" src="https://github.com/user-attachments/assets/f521478c-c9ca-4f2e-bd4c-fa39113a903b"><br>

This PR fixes this