### PR TITLE
Cleanup: Use consistent whitespace style

### DIFF
--- a/Bake.py
+++ b/Bake.py
@@ -96,8 +96,10 @@ def transfer_uv(objs, mat, entity, uv_map, is_entity_baked=False):
 
     # Create temp image as bake target
     if len(tilenums) > 1 or (segment and image.source == 'TILED'):
-        temp_image = bpy.data.images.new(name='__TEMP',
-                width=width, height=height, alpha=True, float_buffer=image.is_float, tiled=True)
+        temp_image = bpy.data.images.new(
+            name='__TEMP', width=width, height=height,
+            alpha=True, float_buffer=image.is_float, tiled=True
+        )
 
         # Fill tiles
         for tilenum in tilenums:
@@ -109,8 +111,10 @@ def transfer_uv(objs, mat, entity, uv_map, is_entity_baked=False):
         else: UDIM.initial_pack_udim(temp_image, col, image.name)
 
     else:
-        temp_image = bpy.data.images.new(name='__TEMP',
-                width=width, height=height, alpha=True, float_buffer=image.is_float)
+        temp_image = bpy.data.images.new(
+            name='__TEMP', width=width, height=height,
+            alpha=True, float_buffer=image.is_float
+        )
 
     temp_image.colorspace_settings.name = image.colorspace_settings.name
     temp_image.generated_color = col
@@ -229,10 +233,12 @@ def transfer_uv(objs, mat, entity, uv_map, is_entity_baked=False):
         UDIM.remove_udim_atlas_segment_by_name(image, segment.name, yp)
 
         # Create new segment
-        new_segment = UDIM.get_set_udim_atlas_segment(tilenums, 
-                width=width, height=height, color=col, 
-                colorspace=image.colorspace_settings.name, hdr=image.is_float, yp=yp, 
-                source_image=temp_image, source_tilenums=tilenums)
+        new_segment = UDIM.get_set_udim_atlas_segment(
+            tilenums, 
+            width=width, height=height, color=col, 
+            colorspace=image.colorspace_settings.name, hdr=image.is_float, yp=yp, 
+            source_image=temp_image, source_tilenums=tilenums
+        )
 
         # Set image
         if image != new_segment.id_data:
@@ -384,13 +390,17 @@ class YTransferSomeLayerUV(bpy.types.Operator, BaseBakeOperator):
     uv_map : StringProperty(default='')
     uv_map_coll : CollectionProperty(type=bpy.types.PropertyGroup)
 
-    remove_from_uv : BoolProperty(name='Delete From UV',
-            description = "Remove 'From UV' from objects",
-            default=False)
+    remove_from_uv : BoolProperty(
+        name = 'Delete From UV',
+        description = "Remove 'From UV' from objects",
+        default = False
+    )
 
-    reorder_uv_list : BoolProperty(name='Reorder UV',
-            description = "Reorder 'To UV' so it will have the same index as 'From UV'",
-            default=True)
+    reorder_uv_list : BoolProperty(
+        name = 'Reorder UV',
+        description = "Reorder 'To UV' so it will have the same index as 'From UV'",
+        default = True
+    )
 
     @classmethod
     def poll(cls, context):
@@ -485,9 +495,10 @@ class YTransferSomeLayerUV(bpy.types.Operator, BaseBakeOperator):
 
         # Prepare bake settings
         book = remember_before_bake(yp)
-        prepare_bake_settings(book, objs, yp, samples=self.samples, margin=self.margin, 
-                uv_map=self.uv_map, bake_type='EMIT', bake_device=self.bake_device, margin_type=self.margin_type
-                )
+        prepare_bake_settings(
+            book, objs, yp, samples=self.samples, margin=self.margin, 
+            uv_map=self.uv_map, bake_type='EMIT', bake_device=self.bake_device, margin_type=self.margin_type
+        )
         
         # Get entites to transfer
         entities = get_entities_to_transfer(yp, self.from_uv_map, self.uv_map)
@@ -533,7 +544,11 @@ class YTransferSomeLayerUV(bpy.types.Operator, BaseBakeOperator):
         # Refresh mapping and stuff
         yp.active_layer_index = yp.active_layer_index
 
-        print('INFO: All layers and masks using', self.from_uv_map, 'are transferred to', self.uv_map, 'in', '{:0.2f}'.format(time.time() - T), 'seconds!')
+        print(
+            'INFO: All layers and masks using', self.from_uv_map,
+            'are transferred to', self.uv_map,
+            'in', '{:0.2f}'.format(time.time() - T), 'seconds!'
+        )
 
         return {'FINISHED'}
 
@@ -622,9 +637,10 @@ class YTransferLayerUV(bpy.types.Operator, BaseBakeOperator):
 
         # Prepare bake settings
         book = remember_before_bake(yp)
-        prepare_bake_settings(book, objs, yp, samples=self.samples, margin=self.margin, 
-                uv_map=self.uv_map, bake_type='EMIT', bake_device=self.bake_device, margin_type=self.margin_type
-                )
+        prepare_bake_settings(
+            book, objs, yp, samples=self.samples, margin=self.margin, 
+            uv_map=self.uv_map, bake_type='EMIT', bake_device=self.bake_device, margin_type=self.margin_type
+        )
 
         if self.entity.type == 'IMAGE':
             # Set other entites uv that using the same image or segment
@@ -643,7 +659,12 @@ class YTransferLayerUV(bpy.types.Operator, BaseBakeOperator):
         # Refresh mapping and stuff
         yp.active_layer_index = yp.active_layer_index
 
-        print('INFO:', self.entity.name, 'UV is transferred from', self.entity.uv_name, 'to', self.uv_map, 'at', '{:0.2f}'.format(time.time() - T), 'seconds!')
+        print(
+            'INFO:', self.entity.name,
+            'UV is transferred from', self.entity.uv_name,
+            'to', self.uv_map,
+            'in', '{:0.2f}'.format(time.time() - T), 'seconds!'
+        )
 
         return {'FINISHED'}
 
@@ -678,17 +699,21 @@ class YResizeImage(bpy.types.Operator, BaseBakeOperator):
     layer_name : StringProperty(default='')
     image_name : StringProperty(default='')
 
-    width : IntProperty(name='Width', default = 1024, min=1, max=16384)
-    height : IntProperty(name='Height', default = 1024, min=1, max=16384)
+    width : IntProperty(name='Width', default=1024, min=1, max=16384)
+    height : IntProperty(name='Height', default=1024, min=1, max=16384)
 
-    all_tiles : BoolProperty(name='Resize All Tiles',
-            description='Resize all tiles (when using UDIM atlas, only segment tiles will be resized)',
-            default=False)
+    all_tiles : BoolProperty(
+        name = 'Resize All Tiles',
+        description = 'Resize all tiles (when using UDIM atlas, only segment tiles will be resized)',
+        default = False
+    )
 
-    tile_number : EnumProperty(name='Tile Number',
-            description='Tile number that will be resized',
-            items = UDIM.udim_tilenum_items,
-            update=update_resize_image_tile_number)
+    tile_number : EnumProperty(
+        name = 'Tile Number',
+        description = 'Tile number that will be resized',
+        items = UDIM.udim_tilenum_items,
+        update = update_resize_image_tile_number
+    )
 
     @classmethod
     def poll(cls, context):
@@ -807,7 +832,10 @@ class YResizeImage(bpy.types.Operator, BaseBakeOperator):
             bpy.context.area.ui_type = ori_ui_type
 
         else:
-            scaled_img, new_segment = resize_image(image, self.width, self.height, image.colorspace_settings.name, self.samples, 0, segment, bake_device=self.bake_device, yp=yp)
+            scaled_img, new_segment = resize_image(
+                image, self.width, self.height, image.colorspace_settings.name,
+                self.samples, 0, segment, bake_device=self.bake_device, yp=yp
+            )
 
             if new_segment:
                 entity.segment_name = new_segment.name
@@ -831,39 +859,46 @@ class YBakeChannelToVcol(bpy.types.Operator, BaseBakeOperator):
     bl_options = {'REGISTER', 'UNDO'}
 
     all_materials : BoolProperty(
-            name='Bake All Materials',
-            description='Bake all materials with ucupaint nodes rather than just the active one',
-            default=False)
+        name = 'Bake All Materials',
+        description = 'Bake all materials with ucupaint nodes rather than just the active one',
+        default = False
+    )
 
     vcol_name : StringProperty(
-            name='Target Vertex Color Name', 
-            description="Target vertex color name, it will create one if it doesn't exist",
-            default='')
+        name = 'Target Vertex Color Name', 
+        description = "Target vertex color name, it will create one if it doesn't exist",
+        default = ''
+    )
     
     add_emission : BoolProperty(
-            name='Add Emission', 
-            description='Add the result with Emission Channel', 
-            default=False)
+        name = 'Add Emission', 
+        description = 'Add the result with Emission Channel', 
+        default = False
+    )
 
     emission_multiplier : FloatProperty(
-            name='Emission Multiplier',
-            description='Emission multiplier so the emission can be more visible on the result',
-            default=1.0, min=0.0)
+        name = 'Emission Multiplier',
+        description = 'Emission multiplier so the emission can be more visible on the result',
+        default=1.0, min=0.0
+    )
 
     force_first_index : BoolProperty(
-            name='Force First Index', 
-            description="Force target vertex color to be first on the vertex colors list (useful for exporting)",
-            default=True)
+        name = 'Force First Index', 
+        description = "Force target vertex color to be first on the vertex colors list (useful for exporting)",
+        default = True
+    )
 
     include_alpha : BoolProperty(
-            name='Include Alpha',
-            description="Bake channel alpha to result (need channel enable alpha)",
-            default=False)
+        name = 'Include Alpha',
+        description = "Bake channel alpha to result (need channel enable alpha)",
+        default = False
+    )
 
     bake_to_alpha_only : BoolProperty(
-            name='Bake To Alpha Only',
-            description="Bake value into the alpha",
-            default=False)
+        name = 'Bake To Alpha Only',
+        description = "Bake value into the alpha",
+        default = False
+    )
 
     @classmethod
     def poll(cls, context):
@@ -1024,7 +1059,10 @@ class YBakeChannelToVcol(bpy.types.Operator, BaseBakeOperator):
                             p.material_index = active_mat_id
 
                 # Prepare bake settings
-                prepare_bake_settings(book, objs, yp, disable_problematic_modifiers=True, bake_device=self.bake_device, bake_target='VERTEX_COLORS')
+                prepare_bake_settings(
+                    book, objs, yp, disable_problematic_modifiers=True,
+                    bake_device=self.bake_device, bake_target='VERTEX_COLORS'
+                )
 
                 # Get extra channel
                 extra_channel = None
@@ -1032,7 +1070,10 @@ class YBakeChannelToVcol(bpy.types.Operator, BaseBakeOperator):
                     extra_channel = yp.channels.get('Emission')
 
                 # Bake channel
-                bake_to_vcol(mat, node, channel, objs, extra_channel, self.emission_multiplier, self.include_alpha or self.bake_to_alpha_only, self.vcol_name)
+                bake_to_vcol(
+                    mat, node, channel, objs, extra_channel, self.emission_multiplier,
+                    self.include_alpha or self.bake_to_alpha_only, self.vcol_name
+                )
 
                 for ob in objs:
                     # Recover material index
@@ -1053,8 +1094,9 @@ class YDeleteBakedChannelImages(bpy.types.Operator):
     bl_options = {'UNDO'}
 
     also_del_vcol : BoolProperty(
-        name="Also delete the vertex color",
-        default=False)
+        name = "Also delete the vertex color",
+        default = False
+    )
 
     @classmethod
     def poll(cls, context):
@@ -1167,68 +1209,85 @@ class YBakeChannels(bpy.types.Operator, BaseBakeOperator):
     uv_map_coll : CollectionProperty(type=bpy.types.PropertyGroup)
 
     interpolation : EnumProperty(
-            name = 'Image Interpolation Type',
-            description = 'Image interpolation type',
-            items = interpolation_type_items,
-            default = 'Linear')
+        name = 'Image Interpolation Type',
+        description = 'Image interpolation type',
+        items = interpolation_type_items,
+        default = 'Linear'
+    )
 
     #hdr : BoolProperty(name='32 bit Float', default=False)
 
-    only_active_channel : BoolProperty(name = 'Only Bake Active Channel',
-            description = 'Only bake active channel',
-            default = False)
+    only_active_channel : BoolProperty(
+        name = 'Only Bake Active Channel',
+        description = 'Only bake active channel',
+        default = False
+    )
 
-    fxaa : BoolProperty(name='Use FXAA', 
-            description = "Use FXAA to baked images (doesn't work with float/non clamped images)",
-            default=True)
+    fxaa : BoolProperty(
+        name = 'Use FXAA', 
+        description = "Use FXAA to baked images (doesn't work with float/non clamped images)",
+        default = True
+    )
 
     aa_level : IntProperty(
-        name='Anti Aliasing Level',
-        description='Super Sample Anti Aliasing Level (1=off)',
-        default=1, min=1, max=2)
+        name = 'Anti Aliasing Level',
+        description = 'Super Sample Anti Aliasing Level (1=off)',
+        default=1, min=1, max=2
+    )
 
-    denoise : BoolProperty(name='Use Denoise', 
-            description = "Use Denoise on baked images",
-            default=False)
+    denoise : BoolProperty(
+        name = 'Use Denoise', 
+        description = "Use Denoise on baked images",
+        default = False
+    )
 
     force_bake_all_polygons : BoolProperty(
-            name='Force Bake all Polygons',
-            description='Force bake all polygons, useful if material is not using direct polygon (ex: solidify material)',
-            default=False)
+        name = 'Force Bake all Polygons',
+        description = 'Force bake all polygons, useful if material is not using direct polygon (ex: solidify material)',
+        default = False
+    )
 
-    enable_bake_as_vcol : BoolProperty(name='Enable Bake As VCol',
-            description='Has any channel enabled Bake As Vertex Color',
-            default=False)
+    enable_bake_as_vcol : BoolProperty(
+        name = 'Enable Bake As VCol',
+        description = 'Has any channel enabled Bake As Vertex Color',
+        default = False
+    )
 
     vcol_force_first_ch_idx : EnumProperty(
-                name='Force First Vertex Color Channel',
-                description='Force the first channel after baking the Vertex Color',
-                items=bake_vcol_channel_items)
+        name = 'Force First Vertex Color Channel',
+        description = 'Force the first channel after baking the Vertex Color',
+        items = bake_vcol_channel_items
+    )
 
     vcol_force_first_ch_idx_bool : BoolProperty(
-                name='Force First Vertex Color Channel',
-                description='Force the first channel after baking the Vertex Color',
-                default=False)
+        name = 'Force First Vertex Color Channel',
+        description = 'Force the first channel after baking the Vertex Color',
+        default = False
+    )
 
     use_udim : BoolProperty(
-            name = 'Use UDIM Tiles',
-            description='Use UDIM Tiles',
-            default=False)
+        name = 'Use UDIM Tiles',
+        description = 'Use UDIM Tiles',
+        default = False
+    )
 
     use_float_for_normal : BoolProperty(
-            name = 'Use Float for Normal',
-            description='Use float image for baked normal',
-            default=False)
+        name = 'Use Float for Normal',
+        description = 'Use float image for baked normal',
+        default = False
+    )
 
     use_float_for_displacement : BoolProperty(
-            name = 'Use Float for Displacement',
-            description='Use float image for baked displacement',
-            default=False)
+        name = 'Use Float for Displacement',
+        description = 'Use float image for baked displacement',
+        default = False
+    )
     
     bake_disabled_layers : BoolProperty(
-            name = 'Bake Disabled Layers',  
-            description = 'Take disabled layers into account when baking',
-            default = False)
+        name = 'Bake Disabled Layers',  
+        description = 'Take disabled layers into account when baking',
+        default = False
+    )
 
     @classmethod
     def poll(cls, context):
@@ -1541,8 +1600,10 @@ class YBakeChannels(bpy.types.Operator, BaseBakeOperator):
         height = self.height * self.aa_level
 
         # Prepare bake settings
-        prepare_bake_settings(book, objs, yp, self.samples, margin, self.uv_map, disable_problematic_modifiers=True, 
-                bake_device=self.bake_device, margin_type=self.margin_type)
+        prepare_bake_settings(
+            book, objs, yp, self.samples, margin, self.uv_map, disable_problematic_modifiers=True, 
+            bake_device=self.bake_device, margin_type=self.margin_type
+        )
 
         # Get tilenums
         tilenums = UDIM.get_tile_numbers(objs, self.uv_map) if self.use_udim else [1001]
@@ -1559,10 +1620,12 @@ class YBakeChannels(bpy.types.Operator, BaseBakeOperator):
             ch.no_layer_using = not is_any_layer_using_channel(ch, node)
             if not ch.no_layer_using:
                 use_hdr = not ch.use_clamp
-                bake_channel(self.uv_map, mat, node, ch, width, height, use_hdr=use_hdr, force_use_udim=self.use_udim, 
-                             tilenums=tilenums, interpolation=self.interpolation, 
-                             use_float_for_displacement=self.use_float_for_displacement, 
-                             use_float_for_normal=self.use_float_for_normal)
+                bake_channel(
+                    self.uv_map, mat, node, ch, width, height, use_hdr=use_hdr, force_use_udim=self.use_udim, 
+                    tilenums=tilenums, interpolation=self.interpolation, 
+                    use_float_for_displacement=self.use_float_for_displacement, 
+                    use_float_for_normal=self.use_float_for_normal
+                )
 
         # Process baked images
         baked_images = []
@@ -1577,8 +1640,11 @@ class YBakeChannels(bpy.types.Operator, BaseBakeOperator):
 
                 # AA process
                 if self.aa_level > 1:
-                    resize_image(baked.image, self.width, self.height, 
-                            baked.image.colorspace_settings.name, alpha_aware=ch.enable_alpha, bake_device=self.bake_device)
+                    resize_image(
+                        baked.image, self.width, self.height, 
+                        baked.image.colorspace_settings.name,
+                        alpha_aware=ch.enable_alpha, bake_device=self.bake_device
+                    )
 
                 # FXAA doesn't work with hdr image
                 if self.fxaa and ch.use_clamp:
@@ -1597,8 +1663,11 @@ class YBakeChannels(bpy.types.Operator, BaseBakeOperator):
 
                     # AA process
                     if self.aa_level > 1:
-                        resize_image(baked_disp.image, self.width, self.height, 
-                                baked.image.colorspace_settings.name, alpha_aware=ch.enable_alpha, bake_device=self.bake_device)
+                        resize_image(
+                            baked_disp.image, self.width, self.height, 
+                            baked.image.colorspace_settings.name,
+                            alpha_aware=ch.enable_alpha, bake_device=self.bake_device
+                        )
 
                     # FXAA
                     if self.fxaa and not baked_disp.image.is_float:
@@ -1611,8 +1680,11 @@ class YBakeChannels(bpy.types.Operator, BaseBakeOperator):
 
                     # AA process
                     if self.aa_level > 1:
-                        resize_image(baked_normal_overlay.image, self.width, self.height, 
-                                baked.image.colorspace_settings.name, alpha_aware=ch.enable_alpha, bake_device=self.bake_device)
+                        resize_image(
+                            baked_normal_overlay.image, self.width, self.height, 
+                            baked.image.colorspace_settings.name,
+                            alpha_aware=ch.enable_alpha, bake_device=self.bake_device
+                        )
                     # FXAA
                     if self.fxaa:
                         fxaa_image(baked_normal_overlay.image, ch.enable_alpha, bake_device=self.bake_device)
@@ -1624,8 +1696,11 @@ class YBakeChannels(bpy.types.Operator, BaseBakeOperator):
 
                     # AA process
                     if self.aa_level > 1:
-                        resize_image(baked_vdisp.image, self.width, self.height, 
-                                baked.image.colorspace_settings.name, alpha_aware=ch.enable_alpha, bake_device=self.bake_device)
+                        resize_image(
+                            baked_vdisp.image, self.width, self.height, 
+                            baked.image.colorspace_settings.name,
+                            alpha_aware=ch.enable_alpha, bake_device=self.bake_device
+                        )
 
                     baked_images.append(baked_vdisp.image)
 
@@ -1685,8 +1760,10 @@ class YBakeChannels(bpy.types.Operator, BaseBakeOperator):
                 if not btimg:
                     # Set new bake target image
                     if len(tilenums) > 1:
-                        btimg = bpy.data.images.new(name=bt.name, width=self.width, height=self.height, 
-                                alpha=True, tiled=True, float_buffer=bt.use_float)
+                        btimg = bpy.data.images.new(
+                            name=bt.name, width=self.width, height=self.height, 
+                            alpha=True, tiled=True, float_buffer=bt.use_float
+                        )
                         btimg.colorspace_settings.name = get_noncolor_name()
                         btimg.filepath = filepath
 
@@ -1696,8 +1773,10 @@ class YBakeChannels(bpy.types.Operator, BaseBakeOperator):
 
                         UDIM.initial_pack_udim(btimg, color)
                     else:
-                        btimg = bpy.data.images.new(name=bt.name,
-                            width=self.width, height=self.height, alpha=True, float_buffer=bt.use_float)
+                        btimg = bpy.data.images.new(
+                            name=bt.name, width=self.width, height=self.height,
+                            alpha=True, float_buffer=bt.use_float
+                        )
                         btimg.colorspace_settings.name = get_noncolor_name()
                         btimg.filepath = filepath
                         btimg.generated_color = color
@@ -1746,7 +1825,10 @@ class YBakeChannels(bpy.types.Operator, BaseBakeOperator):
                                     UDIM.swap_tile(baked.image, 1001, tilenum)
 
                                 # Copy pixels
-                                copy_image_channel_pixels(baked.image, btimg, src_idx=subidx, dest_idx=i, invert_value=btc.invert_value)
+                                copy_image_channel_pixels(
+                                    baked.image, btimg, src_idx=subidx,
+                                    dest_idx=i, invert_value=btc.invert_value
+                                )
 
                                 # Swap tile again to recover
                                 if tilenum != 1001:
@@ -1818,7 +1900,10 @@ class YBakeChannels(bpy.types.Operator, BaseBakeOperator):
                     real_force_first_ch_idx = -1
             # used to sort by channel
             current_vcol_order = 0
-            prepare_bake_settings(book, objs, yp, disable_problematic_modifiers=True, bake_device=self.bake_device, bake_target='VERTEX_COLORS')
+            prepare_bake_settings(
+                book, objs, yp, disable_problematic_modifiers=True,
+                bake_device=self.bake_device, bake_target='VERTEX_COLORS'
+            )
             for ch in self.channels:
                 if ch.enable_bake_to_vcol and ch.type != 'NORMAL':
                     # Check vertex color
@@ -2055,26 +2140,31 @@ class YMergeLayer(bpy.types.Operator, BaseBakeOperator):
     bl_options = {'REGISTER', 'UNDO'}
 
     direction : EnumProperty(
-            name = 'Direction',
-            items = (('UP', 'Up', ''),
-                     ('DOWN', 'Down', '')),
-            default = 'UP')
+        name = 'Direction',
+        items = (
+            ('UP', 'Up', ''),
+            ('DOWN', 'Down', '')
+        ),
+        default = 'UP'
+    )
 
     channel_idx : EnumProperty(
-            name = 'Channel',
-            description = 'Channel for merge reference',
-            items = merge_channel_items)
-            #update=update_channel_idx_new_layer)
+        name = 'Channel',
+        description = 'Channel for merge reference',
+        items = merge_channel_items
+    )
 
     apply_modifiers : BoolProperty(
-            name = 'Apply Layer Modifiers',
-            description = 'Apply layer modifiers',
-            default = False)
+        name = 'Apply Layer Modifiers',
+        description = 'Apply layer modifiers',
+        default = False
+    )
 
     apply_neighbor_modifiers : BoolProperty(
-            name = 'Apply Neighbor Modifiers',
-            description = 'Apply neighbor modifiers',
-            default = True)
+        name = 'Apply Neighbor Modifiers',
+        description = 'Apply neighbor modifiers',
+        default = True
+    )
 
     #height_aware : BoolProperty(
     #        name = 'Height Aware',
@@ -2084,8 +2174,11 @@ class YMergeLayer(bpy.types.Operator, BaseBakeOperator):
     @classmethod
     def poll(cls, context):
         group_node = get_active_ypaint_node()
-        return (context.object and group_node and len(group_node.node_tree.yp.layers) > 0 
-                and len(group_node.node_tree.yp.channels) > 0)
+        return (
+            context.object and group_node
+                and len(group_node.node_tree.yp.layers) > 0 
+                and len(group_node.node_tree.yp.channels) > 0
+        )
 
     def invoke(self, context, event):
         self.invoke_operator(context)
@@ -2227,9 +2320,11 @@ class YMergeLayer(bpy.types.Operator, BaseBakeOperator):
 
 
             book = remember_before_bake(yp)
-            prepare_bake_settings(book, objs, yp, samples=1, margin=5, 
-                    uv_map=layer.uv_name, bake_type='EMIT', bake_device=self.bake_device
-                    )
+            prepare_bake_settings(
+                book, objs, yp, samples=1, margin=5, 
+                uv_map=layer.uv_name, bake_type='EMIT',
+                bake_device = self.bake_device
+            )
 
             # Merge objects if necessary
             temp_objs = []
@@ -2353,8 +2448,8 @@ class YMergeLayer(bpy.types.Operator, BaseBakeOperator):
 
                 if upper_vcol and lower_vcol:
 
-                    cols = numpy.zeros(len(obj.data.loops)*4, dtype=numpy.float32)
-                    cols.shape = (cols.shape[0]//4, 4)
+                    cols = numpy.zeros(len(obj.data.loops) * 4, dtype=numpy.float32)
+                    cols.shape = (cols.shape[0] // 4, 4)
 
                     for i, l in enumerate(obj.data.loops):
                         cols[i] = blend_color_mix_byte(lower_vcol.data[i].color, upper_vcol.data[i].color, 
@@ -2409,10 +2504,13 @@ class YMergeMask(bpy.types.Operator, BaseBakeOperator):
     bl_options = {'UNDO'}
 
     direction : EnumProperty(
-            name = 'Direction',
-            items = (('UP', 'Up', ''),
-                     ('DOWN', 'Down', '')),
-            default = 'UP')
+        name = 'Direction',
+        items = (
+            ('UP', 'Up', ''),
+            ('DOWN', 'Down', '')
+        ),
+        default = 'UP'
+    )
 
     @classmethod
     def poll(cls, context):
@@ -2428,10 +2526,10 @@ class YMergeMask(bpy.types.Operator, BaseBakeOperator):
         m = re.match(r'yp\.layers\[(\d+)\]\.masks\[(\d+)\]', mask.path_from_id())
         index = int(m.group(2))
         if self.direction == 'UP':
-            try: neighbor_mask = layer.masks[index-1]
+            try: neighbor_mask = layer.masks[index - 1]
             except: neighbor_mask = None
         else:
-            try: neighbor_mask = layer.masks[index+1]
+            try: neighbor_mask = layer.masks[index + 1]
             except: neighbor_mask = None
 
         # Blender 2.7x has no global undo between modes
@@ -2483,9 +2581,9 @@ class YMergeMask(bpy.types.Operator, BaseBakeOperator):
 
         # Get neighbor index
         if self.direction == 'UP' and index > 0:
-            neighbor_idx = index-1
+            neighbor_idx = index - 1
         elif self.direction == 'DOWN' and index < num_masks-1:
-            neighbor_idx = index+1
+            neighbor_idx = index + 1
         else:
             self.report({'ERROR'}, "No valid neighbor mask!")
             return {'CANCELLED'}
@@ -2507,8 +2605,10 @@ class YMergeMask(bpy.types.Operator, BaseBakeOperator):
             width = segment.width
             height = segment.height
 
-            img = bpy.data.images.new(name='__TEMP',
-                    width=width, height=height, alpha=True, float_buffer=source.image.is_float)
+            img = bpy.data.images.new(
+                name='__TEMP', width=width, height=height,
+                alpha=True, float_buffer=source.image.is_float
+            )
 
             if source.image.yia.color == 'WHITE':
                 img.generated_color = (1.0, 1.0, 1.0, 1.0)
@@ -2552,9 +2652,11 @@ class YMergeMask(bpy.types.Operator, BaseBakeOperator):
         objs = get_all_objects_with_same_materials(mat, True)
 
         book = remember_before_bake(yp)
-        prepare_bake_settings(book, objs, yp, samples=1, margin=5, 
-                uv_map=mask.uv_name, bake_type='EMIT', bake_device=self.bake_device
-                )
+        prepare_bake_settings(
+            book, objs, yp, samples=1, margin=5, 
+            uv_map=mask.uv_name, bake_type='EMIT',
+            bake_device = self.bake_device
+        )
 
         # Combine objects if possible
         temp_objs = []
@@ -2735,7 +2837,11 @@ class YBakeTempImage(bpy.types.Operator, BaseBakeOperator):
             return {'CANCELLED'}
 
         # Bake temp image
-        image = temp_bake(context, entity, self.width, self.height, self.hdr, self.samples , self.margin, self.uv_map, margin_type=self.margin_type, bake_device=self.bake_device)
+        image = temp_bake(
+            context, entity, self.width, self.height, self.hdr, self.samples,
+            self.margin, self.uv_map, margin_type=self.margin_type,
+            bake_device=self.bake_device
+        )
 
         return {'FINISHED'}
 
@@ -2765,7 +2871,7 @@ def copy_default_value(inp_source, inp_target):
     elif isinstance(inp_target.default_value, float) and isinstance(inp_source.default_value, float):
         inp_target.default_value = inp_source.default_value
     elif isinstance(inp_target.default_value, float):
-        avg = sum([inp_source.default_value[i] for i in range(3)])/3
+        avg = sum([inp_source.default_value[i] for i in range(3)]) / 3
         inp_target.default_value = avg
     elif isinstance(inp_source.default_value, float):
         for i in range(3):
@@ -3145,7 +3251,6 @@ def update_enable_baked_outside(self, context):
 
             # Delete nodes inside frames
             if baked_outside_frame:
-                
                 remove_node(mtree, ch, 'baked_outside', parent=baked_outside_frame)
                 remove_node(mtree, ch, 'baked_outside_vcol', parent=baked_outside_frame)
                 remove_node(mtree, ch, 'baked_outside_disp', parent=baked_outside_frame)

--- a/BakeInfo.py
+++ b/BakeInfo.py
@@ -18,134 +18,163 @@ class YBakeInfoSelectedObject(bpy.types.PropertyGroup):
     selected_vertex_indices : CollectionProperty(type=YBakeInfoSelectedVertex)
 
 class YBakeInfoProps(bpy.types.PropertyGroup):
-
     is_baked : BoolProperty(default=False) # Flag to mark if the image is from baking or not
     is_baked_channel : BoolProperty(default=False) # Flag to mark if the image baked from main channel
 
     bake_type : EnumProperty(
-            name = 'Bake Type',
-            description = 'Bake Type',
-            items = bake_type_items,
-            default='AO'
-            )
+        name = 'Bake Type',
+        description = 'Bake Type',
+        items = bake_type_items,
+        default = 'AO'
+    )
 
-    samples : IntProperty(name='Bake Samples', 
-            description='Bake Samples, more means less jagged on generated textures', 
-            default=1, min=1)
+    samples : IntProperty(
+        name = 'Bake Samples', 
+        description = 'Bake Samples, more means less jagged on generated textures', 
+        default=1, min=1
+    )
 
-    margin : IntProperty(name='Bake Margin',
-            description = 'Bake margin in pixels',
-            default=5, min=0, subtype='PIXEL')
+    margin : IntProperty(
+        name = 'Bake Margin',
+        description = 'Bake margin in pixels',
+        subtype = 'PIXEL',
+        default=5, min=0
+    )
 
-    margin_type : EnumProperty(name = 'Margin Type',
-            description = '',
-            items = (('ADJACENT_FACES', 'Adjacent Faces', 'Use pixels from adjacent faces across UV seams.'),
-                     ('EXTEND', 'Extend', 'Extend border pixels outwards')),
-            default = 'ADJACENT_FACES')
+    margin_type : EnumProperty(
+        name = 'Margin Type',
+        description = '',
+        items = (
+            ('ADJACENT_FACES', 'Adjacent Faces', 'Use pixels from adjacent faces across UV seams.'),
+            ('EXTEND', 'Extend', 'Extend border pixels outwards')
+        ),
+        default = 'ADJACENT_FACES'
+    )
 
     flip_normals : BoolProperty(
-            name='Flip Normals',
-            description='Flip normal of mesh',
-            default=False
-            )
+        name = 'Flip Normals',
+        description = 'Flip normal of mesh',
+        default = False
+    )
     
     only_local : BoolProperty(
-            name='Only Local',
-            description='Only bake local ambient occlusion',
-            default=False
-            )
+        name = 'Only Local',
+        description = 'Only bake local ambient occlusion',
+        default = False
+    )
 
     subsurf_influence : BoolProperty(
-            name='Subsurf Influence',
-            description='Take account subsurf when baking cavity',
-            default=False
-            )
+        name = 'Subsurf Influence',
+        description = 'Take account subsurf when baking cavity',
+        default = False
+    )
     
     force_bake_all_polygons : BoolProperty(
-            name='Force Bake all Polygons',
-            description='Force bake all polygons, useful if material is not using direct polygon (ex: solidify material)',
-            default=False)
+        name = 'Force Bake all Polygons',
+        description = 'Force bake all polygons, useful if material is not using direct polygon (ex: solidify material)',
+        default = False
+    )
 
-    fxaa : BoolProperty(name='Use FXAA', 
-            description = "Use FXAA on baked image (doesn't work with float images)",
-            default=False)
+    fxaa : BoolProperty(
+        name='Use FXAA', 
+        description = "Use FXAA on baked image (doesn't work with float images)",
+        default = False
+    )
 
-    ssaa : BoolProperty(name='Use SSAA', 
-            description = "Use Supersample AA on baked image",
-            default=False)
+    ssaa : BoolProperty(
+        name = 'Use SSAA', 
+        description = "Use Supersample AA on baked image",
+        default = False
+    )
 
-    denoise : BoolProperty(name='Use Denoise', 
-            description = "Use Denoise on baked image",
-            default=True)
+    denoise : BoolProperty(
+        name = 'Use Denoise', 
+        description = "Use Denoise on baked image",
+        default = True
+    )
 
-    blur : BoolProperty(name='Use Blur', 
-            description = "Use blur to baked image",
-            default=False)
+    blur : BoolProperty(
+        name = 'Use Blur', 
+        description = "Use blur to baked image",
+        default = False
+    )
 
-    blur_factor : FloatProperty(name='Blur Factor',
-            description = "Blur factor to baked image",
-            default=1.0, min=0.0, max=100.0
-            )
+    blur_factor : FloatProperty(
+        name = 'Blur Factor',
+        description = "Blur factor to baked image",
+        default=1.0, min=0.0, max=100.0
+    )
 
     use_baked_disp : BoolProperty(
-            name='Use Baked Displacement Map',
-            description='Use baked displacement map, this will also apply subdiv setup on object',
-            default=False
-            )
+        name = 'Use Baked Displacement Map',
+        description = 'Use baked displacement map, this will also apply subdiv setup on object',
+        default = False
+    )
 
     bake_device : EnumProperty(
-            name='Bake Device',
-            description='Device to use for baking',
-            items = (('GPU', 'GPU Compute', ''),
-                     ('CPU', 'CPU', '')),
-            default='CPU'
-            )
+        name = 'Bake Device',
+        description = 'Device to use for baking',
+        items = (
+            ('GPU', 'GPU Compute', ''),
+            ('CPU', 'CPU', '')
+        ),
+        default = 'CPU'
+    )
 
     cage_object_name : StringProperty(
-            name = 'Cage Object',
-            description = 'Object to use as cage instead of calculating the cage from the active object with cage extrusion',
-            default='')
+        name = 'Cage Object',
+        description = 'Object to use as cage instead of calculating the cage from the active object with cage extrusion',
+        default = ''
+    )
 
     cage_extrusion : FloatProperty(
-            name = 'Cage Extrusion',
-            description = 'Inflate the active object by the specified distance for baking. This helps matching to points nearer to the outside of the selected object meshes',
-            default=0.2, min=0.0, max=1.0)
+        name = 'Cage Extrusion',
+        description = 'Inflate the active object by the specified distance for baking. This helps matching to points nearer to the outside of the selected object meshes',
+        default=0.2, min=0.0, max=1.0
+    )
 
     max_ray_distance : FloatProperty(
-            name = 'Max Ray Distance',
-            description = 'The maximum ray distance for matching points between the active and selected objects. If zero, there is no limit',
-            default=0.2, min=0.0, max=1.0)
+        name = 'Max Ray Distance',
+        description = 'The maximum ray distance for matching points between the active and selected objects. If zero, there is no limit',
+        default=0.2, min=0.0, max=1.0
+    )
 
     use_udim : BoolProperty(
-            name = 'Use UDIM Tiles',
-            description='Use UDIM Tiles',
-            default=False)
+        name = 'Use UDIM Tiles',
+        description = 'Use UDIM Tiles',
+        default = False
+    )
 
     aa_level : IntProperty(
-        name='Anti Aliasing Level',
-        description='Super Sample Anti Aliasing Level (1=off)',
-        default=1, min=1, max=2)
+        name = 'Anti Aliasing Level',
+        description = 'Super Sample Anti Aliasing Level (1=off)',
+        default=1, min=1, max=2
+    )
 
     interpolation : EnumProperty(
-            name = 'Image Interpolation Type',
-            description = 'Image interpolation type',
-            items = interpolation_type_items,
-            default = 'Linear')
+        name = 'Image Interpolation Type',
+        description = 'Image interpolation type',
+        items = interpolation_type_items,
+        default = 'Linear'
+    )
 
     use_float_for_normal : BoolProperty(
-            name = 'Use Float for Normal',
-            description='Use float image for baked normal',
-            default=False)
+        name = 'Use Float for Normal',
+        description = 'Use float image for baked normal',
+        default = False
+    )
 
     use_float_for_displacement : BoolProperty(
-            name = 'Use Float for Displacement',
-            description='Use float image for baked displacement',
-            default=False)
+        name = 'Use Float for Displacement',
+        description = 'Use float image for baked displacement',
+        default = False
+    )
 
     bake_disabled_layers : BoolProperty(
-            name = 'Bake Disabled Layers',  
-            description = 'Take disabled layers into account when baking',
-            default = False)
+        name = 'Bake Disabled Layers',  
+        description = 'Take disabled layers into account when baking',
+        default = False
+    )
 
     # To store other objects info
     other_objects : CollectionProperty(type=YBakeInfoOtherObject)
@@ -162,14 +191,16 @@ class YBakeInfoProps(bpy.types.PropertyGroup):
     bevel_radius : FloatProperty(default=0.05, min=0.0, max=1000.0)
 
     use_image_atlas : BoolProperty(
-            name = 'Use Image Atlas',
-            description='Use Image Atlas',
-            default=False)
+        name = 'Use Image Atlas',
+        description = 'Use Image Atlas',
+        default = False
+    )
 
     vcol_force_first_ch_idx : StringProperty(
-            name='Force First Vertex Color Channel',
-            description='Force the first channel after baking the Vertex Color',
-            default='Do Nothing')
+        name = 'Force First Vertex Color Channel',
+        description = 'Force the first channel after baking the Vertex Color',
+        default = 'Do Nothing'
+    )
 
     selected_face_mode : BoolProperty(default=False)
     selected_objects : CollectionProperty(type=YBakeInfoSelectedObject)
@@ -177,12 +208,13 @@ class YBakeInfoProps(bpy.types.PropertyGroup):
     image_resolution : EnumProperty(
         name = 'Image Resolution',
         items = image_resolution_items,
-        default = '1024')
+        default = '1024'
+    )
     
     use_custom_resolution : BoolProperty(
-        name= 'Custom Resolution',
-        default=False,
-        description= 'Use custom Resolution to adjust the width and height individually'
+        name = 'Custom Resolution',
+        default = False,
+        description = 'Use custom Resolution to adjust the width and height individually'
     )
 
 def register():

--- a/BakeTarget.py
+++ b/BakeTarget.py
@@ -3,18 +3,18 @@ from .common import *
 from bpy.props import *
 
 rgba_items = (
-        ('0', 'R', ''),
-        ('1', 'G', ''),
-        ('2', 'B', ''),
-        ('3', 'A', ''),
-        )
+    ('0', 'R', ''),
+    ('1', 'G', ''),
+    ('2', 'B', ''),
+    ('3', 'A', ''),
+)
 
 normal_type_items = (
-        ('COMBINED', 'Combined Normal', ''),
-        ('DISPLACEMENT', 'Displacement', ''),
-        ('OVERLAY_ONLY', 'Normal Without Bump', ''),
-        ('VECTOR_DISPLACEMENT', 'Vector Displacement', ''),
-        )
+    ('COMBINED', 'Combined Normal', ''),
+    ('DISPLACEMENT', 'Displacement', ''),
+    ('OVERLAY_ONLY', 'Normal Without Bump', ''),
+    ('VECTOR_DISPLACEMENT', 'Vector Displacement', ''),
+)
 
 def update_active_bake_target_index(self, context):
     yp = self
@@ -31,52 +31,60 @@ def update_active_bake_target_index(self, context):
 class YBakeTargetChannel(bpy.types.PropertyGroup):
 
     channel_name : StringProperty(
-            name = 'Channel Source Name',
-            description = 'Channel source name for bake target',
-            default = '')
+        name = 'Channel Source Name',
+        description = 'Channel source name for bake target',
+        default = ''
+    )
 
     subchannel_index : EnumProperty(
-            name = 'Subchannel',
-            description = 'Channel source RGBA index',
-            items = rgba_items,
-            default= '0')
+        name = 'Subchannel',
+        description = 'Channel source RGBA index',
+        items = rgba_items,
+        default = '0'
+    )
 
     default_value : FloatProperty(
-            name = 'Default Value',
-            description = 'Channel default value',
-            subtype = 'FACTOR',
-            default = 0.0, min=0.0, max=1.0)
+        name = 'Default Value',
+        description = 'Channel default value',
+        subtype = 'FACTOR',
+        default = 0.0, min=0.0, max=1.0
+    )
 
     normal_type : EnumProperty(
-            name = 'Normal Channel Type',
-            description = 'Normal channel source type',
-            items = normal_type_items,
-            default='COMBINED')
+        name = 'Normal Channel Type',
+        description = 'Normal channel source type',
+        items = normal_type_items,
+        default = 'COMBINED'
+    )
 
     invert_value : BoolProperty(
-            name = 'Invert Value',
-            description = 'Invert value',
-            default = False)
+        name = 'Invert Value',
+        description = 'Invert value',
+        default = False
+    )
 
 class YBakeTarget(bpy.types.PropertyGroup):
     name : StringProperty(
-            name='Bake Target Name',
-            description='Name of bake target name',
-            default='')
+        name = 'Bake Target Name',
+        description = 'Name of bake target name',
+        default = ''
+    )
 
     data_type : EnumProperty(
-            name = 'Bake Target Data Type',
-            description = 'Bake target data type',
-            items = (
-                ('IMAGE', 'Image', '', 'IMAGE_DATA', 0),
-                ('VCOL', 'Vertex Color', '', 'GROUP_VCOL', 1),
-                ),
-            default='IMAGE')
+        name = 'Bake Target Data Type',
+        description = 'Bake target data type',
+        items = (
+            ('IMAGE', 'Image', '', 'IMAGE_DATA', 0),
+            ('VCOL', 'Vertex Color', '', 'GROUP_VCOL', 1),
+        ),
+        default = 'IMAGE'
+    )
 
     use_float : BoolProperty(
-            name = '32-bit Image',
-            description = 'Use 32-bit float image',
-            default=False)
+        name = '32-bit Image',
+        description = 'Use 32-bit float image',
+        default = False
+    )
 
     r : PointerProperty(type=YBakeTargetChannel)
     g : PointerProperty(type=YBakeTargetChannel)
@@ -117,24 +125,28 @@ class YNewBakeTarget(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     name : StringProperty(
-            name = 'New Bake Target Name',
-            description = 'New bake target name',
-            default='')
+        name = 'New Bake Target Name',
+        description = 'New bake target name',
+        default = ''
+    )
 
     preset : EnumProperty(
-            name = 'Bake Target Preset',
-            description = 'Customm bake target preset',
-            items = (
-                ('BLANK', 'Blank', ''),
-                ('ORM', 'GLTF ORM', ''),
-                ('DX_NORMAL', 'DirectX Normal', ''),
-                ),
-            default='BLANK', update=update_new_bake_target_preset)
+        name = 'Bake Target Preset',
+        description = 'Customm bake target preset',
+        items = (
+            ('BLANK', 'Blank', ''),
+            ('ORM', 'GLTF ORM', ''),
+            ('DX_NORMAL', 'DirectX Normal', ''),
+        ),
+        default = 'BLANK',
+        update = update_new_bake_target_preset
+    )
 
     use_float : BoolProperty(
-            name = '32-bit Float',
-            description = 'Use 32-bit float image',
-            default=False)
+        name = '32-bit Float',
+        description = 'Use 32-bit float image',
+        default = False
+    )
 
     @classmethod
     def poll(cls, context):

--- a/BakeToLayer.py
+++ b/BakeToLayer.py
@@ -154,17 +154,18 @@ class YBakeToLayer(bpy.types.Operator, BaseBakeOperator):
     uv_map_1 : StringProperty(default='')
 
     interpolation : EnumProperty(
-            name = 'Image Interpolation Type',
-            description = 'Image interpolation type',
-            items = interpolation_type_items,
-            default = 'Linear')
+        name = 'Image Interpolation Type',
+        description = 'Image interpolation type',
+        items = interpolation_type_items,
+        default = 'Linear'
+    )
 
     # For choosing overwrite entity from list
     overwrite_choice : BoolProperty(
-            name='Overwrite available layer',
-            description='Overwrite available layer',
-            default=False
-            )
+        name = 'Overwrite available layer',
+        description = 'Overwrite available layer',
+        default = False
+    )
 
     # For rebake button
     overwrite_current : BoolProperty(default=False)
@@ -176,29 +177,32 @@ class YBakeToLayer(bpy.types.Operator, BaseBakeOperator):
     overwrite_segment_name : StringProperty(default='')
 
     type : EnumProperty(
-            name = 'Bake Type',
-            description = 'Bake Type',
-            items = bake_type_items,
-            default='AO'
-            )
+        name = 'Bake Type',
+        description = 'Bake Type',
+        items = bake_type_items,
+        default = 'AO'
+    )
 
     # Other objects props
     cage_object_name : StringProperty(
-            name = 'Cage Object',
-            description = 'Object to use as cage instead of calculating the cage from the active object with cage extrusion',
-            default=''
-            )
+        name = 'Cage Object',
+        description = 'Object to use as cage instead of calculating the cage from the active object with cage extrusion',
+        default = ''
+    )
+
     cage_object_coll : CollectionProperty(type=bpy.types.PropertyGroup)
 
     cage_extrusion : FloatProperty(
-            name = 'Cage Extrusion',
-            description = 'Inflate the active object by the specified distance for baking. This helps matching to points nearer to the outside of the selected object meshes',
-            default=0.2, min=0.0, max=1.0)
+        name = 'Cage Extrusion',
+        description = 'Inflate the active object by the specified distance for baking. This helps matching to points nearer to the outside of the selected object meshes',
+        default=0.2, min=0.0, max=1.0
+    )
 
     max_ray_distance : FloatProperty(
-            name = 'Max Ray Distance',
-            description = 'The maximum ray distance for matching points between the active and selected objects. If zero, there is no limit',
-            default=0.2, min=0.0, max=1.0)
+        name = 'Max Ray Distance',
+        description = 'The maximum ray distance for matching points between the active and selected objects. If zero, there is no limit',
+        default=0.2, min=0.0, max=1.0
+    )
     
     # AO Props
     ao_distance : FloatProperty(default=1.0)
@@ -210,87 +214,100 @@ class YBakeToLayer(bpy.types.Operator, BaseBakeOperator):
     multires_base : IntProperty(default=1, min=0, max=16)
 
     target_type : EnumProperty(
-            name = 'Target Bake Type',
-            description = 'Target Bake Type',
-            items = (('LAYER', 'Layer', ''),
-                     ('MASK', 'Mask', '')),
-            default='LAYER'
-            )
+        name = 'Target Bake Type',
+        description = 'Target Bake Type',
+        items = (
+            ('LAYER', 'Layer', ''),
+            ('MASK', 'Mask', '')
+        ),
+        default='LAYER'
+    )
 
-    fxaa : BoolProperty(name='Use FXAA', 
-            description = "Use FXAA on baked image (doesn't work with float images)",
-            default=True)
+    fxaa : BoolProperty(
+        name = 'Use FXAA', 
+        description = "Use FXAA on baked image (doesn't work with float images)",
+        default = True
+    )
 
-    ssaa : BoolProperty(name='Use SSAA', 
-            description = "Use Supersample AA on baked image",
-            default=False)
+    ssaa : BoolProperty(
+        name = 'Use SSAA', 
+        description = "Use Supersample AA on baked image",
+        default = False
+    )
 
-    denoise : BoolProperty(name='Use Denoise', 
-            description = "Use Denoise on baked image",
-            default=True)
+    denoise : BoolProperty(
+        name = 'Use Denoise', 
+        description = "Use Denoise on baked image",
+        default = True
+    )
 
     channel_idx : EnumProperty(
-            name = 'Channel',
-            description = 'Channel of new layer, can be changed later',
-            items = Layer.channel_items)
-            #update=Layer.update_channel_idx_new_layer)
+        name = 'Channel',
+        description = 'Channel of new layer, can be changed later',
+        items = Layer.channel_items
+    )
 
     blend_type : EnumProperty(
         name = 'Blend',
         items = blend_type_items,
-        default = 'MIX')
+        default = 'MIX'
+    )
 
     normal_blend_type : EnumProperty(
-            name = 'Normal Blend Type',
-            items = normal_blend_items,
-            default = 'MIX')
+        name = 'Normal Blend Type',
+        items = normal_blend_items,
+        default = 'MIX'
+    )
 
     normal_map_type : EnumProperty(
-            name = 'Normal Map Type',
-            description = 'Normal map type of this layer',
-            items = Layer.get_normal_map_type_items)
-            #default = 'NORMAL_MAP')
+        name = 'Normal Map Type',
+        description = 'Normal map type of this layer',
+        items = Layer.get_normal_map_type_items
+    )
 
     hdr : BoolProperty(name='32 bit Float', default=True)
 
     use_baked_disp : BoolProperty(
-            name='Use Displacement Setup',
-            description='Use displacement setup, this will also apply subdiv setup on object',
-            default=False
-            )
+        name = 'Use Displacement Setup',
+        description = 'Use displacement setup, this will also apply subdiv setup on object',
+        default = False
+    )
 
     flip_normals : BoolProperty(
-            name='Flip Normals',
-            description='Flip normal of mesh',
-            default=False
-            )
+        name = 'Flip Normals',
+        description = 'Flip normal of mesh',
+        default = False
+    )
 
     only_local : BoolProperty(
-            name='Only Local',
-            description='Only bake local ambient occlusion',
-            default=False
-            )
+        name = 'Only Local',
+        description = 'Only bake local ambient occlusion',
+        default = False
+    )
 
     subsurf_influence : BoolProperty(
-            name='Subsurf / Multires Influence',
-            description='Take account subsurf or multires when baking cavity',
-            default=True
-            )
+        name = 'Subsurf / Multires Influence',
+        description = 'Take account subsurf or multires when baking cavity',
+        default = True
+    )
 
     force_bake_all_polygons : BoolProperty(
-            name='Force Bake all Polygons',
-            description='Force bake all polygons, useful if material is not using direct polygon (ex: solidify material)',
-            default=False)
+        name = 'Force Bake all Polygons',
+        description = 'Force bake all polygons, useful if material is not using direct polygon (ex: solidify material)',
+        default = False
+    )
 
     use_image_atlas : BoolProperty(
-            name = 'Use Image Atlas',
-            description='Use Image Atlas',
-            default=False)
+        name = 'Use Image Atlas',
+        description = 'Use Image Atlas',
+        default = False
+    )
 
     use_udim : BoolProperty(
-            name = 'Use UDIM Tiles',
-            description='Use UDIM Tiles',
-            default=False)
+        name = 'Use UDIM Tiles',
+        description = 'Use UDIM Tiles',
+        default = False
+    )
     
     @classmethod
     def poll(cls, context):
@@ -1079,15 +1096,16 @@ class YBakeToLayer(bpy.types.Operator, BaseBakeOperator):
         # Cage object only used for other object baking
         cage_object_name = self.cage_object_name if self.type.startswith('OTHER_OBJECT_') else ''
 
-        prepare_bake_settings(book, objs, yp, samples=self.samples, margin=self.margin, 
-                uv_map=self.uv_map, bake_type=bake_type, #disable_problematic_modifiers=True, 
-                bake_device=self.bake_device, hide_other_objs=hide_other_objs, 
-                bake_from_multires=self.type.startswith('MULTIRES_'), tile_x = tile_x, tile_y = tile_y, 
-                use_selected_to_active=self.type.startswith('OTHER_OBJECT_'),
-                max_ray_distance=self.max_ray_distance, cage_extrusion=self.cage_extrusion,
-                source_objs=other_objs, use_denoising=False, margin_type=self.margin_type,
-                cage_object_name=cage_object_name
-                )
+        prepare_bake_settings(
+            book, objs, yp, samples=self.samples, margin=self.margin, 
+            uv_map=self.uv_map, bake_type=bake_type, #disable_problematic_modifiers=True, 
+            bake_device=self.bake_device, hide_other_objs=hide_other_objs, 
+            bake_from_multires=self.type.startswith('MULTIRES_'), tile_x = tile_x, tile_y = tile_y, 
+            use_selected_to_active=self.type.startswith('OTHER_OBJECT_'),
+            max_ray_distance=self.max_ray_distance, cage_extrusion=self.cage_extrusion,
+            source_objs=other_objs, use_denoising=False, margin_type=self.margin_type,
+            cage_object_name = cage_object_name
+        )
 
         # Set multires level
         #ori_multires_levels = {}
@@ -1145,7 +1163,7 @@ class YBakeToLayer(bpy.types.Operator, BaseBakeOperator):
                     set_active_vertex_color(obj, vcol)
                 except: pass
 
-                bpy.ops.paint.vertex_color_dirt(dirt_angle=math.pi/2)
+                bpy.ops.paint.vertex_color_dirt(dirt_angle=math.pi / 2)
 
             print('BAKE TO LAYER: Applying subsurf/multires is done in', '{:0.2f}'.format(time.time() - tt), 'seconds!')
 
@@ -1167,11 +1185,11 @@ class YBakeToLayer(bpy.types.Operator, BaseBakeOperator):
                 # Deselect other objects first
                 for o in other_objs:
                     o.select_set(False)
-                bpy.ops.object.mode_set(mode = 'EDIT')
+                bpy.ops.object.mode_set(mode='EDIT')
                 bpy.ops.mesh.reveal()
                 bpy.ops.mesh.select_all(action='SELECT')
                 bpy.ops.mesh.flip_normals()
-                bpy.ops.object.mode_set(mode = 'OBJECT')
+                bpy.ops.object.mode_set(mode='OBJECT')
                 # Reselect other objects
                 for o in other_objs:
                     o.select_set(True)
@@ -1179,11 +1197,11 @@ class YBakeToLayer(bpy.types.Operator, BaseBakeOperator):
                 for obj in objs:
                     if obj in other_objs: continue
                     context.scene.objects.active = obj
-                    bpy.ops.object.mode_set(mode = 'EDIT')
+                    bpy.ops.object.mode_set(mode='EDIT')
                     bpy.ops.mesh.reveal()
                     bpy.ops.mesh.select_all(action='SELECT')
                     bpy.ops.mesh.flip_normals()
-                    bpy.ops.object.mode_set(mode = 'OBJECT')
+                    bpy.ops.object.mode_set(mode='OBJECT')
 
         # More setup
         ori_mods = {}
@@ -1496,8 +1514,10 @@ class YBakeToLayer(bpy.types.Operator, BaseBakeOperator):
 
             # New target image
             if self.use_udim:
-                image = bpy.data.images.new(name=image_name, width=width, height=height, 
-                        alpha=True, float_buffer=self.hdr, tiled=True)
+                image = bpy.data.images.new(
+                    name=image_name, width=width, height=height, 
+                    alpha=True, float_buffer=self.hdr, tiled=True
+                )
 
                 # Fill tiles
                 for tilenum in tilenums:
@@ -1507,8 +1527,10 @@ class YBakeToLayer(bpy.types.Operator, BaseBakeOperator):
                 # Remember base color
                 image.yui.base_color = color
             else:
-                image = bpy.data.images.new(name=image_name,
-                        width=width, height=height, alpha=True, float_buffer=self.hdr)
+                image = bpy.data.images.new(
+                    name=image_name, width=width, height=height,
+                    alpha=True, float_buffer=self.hdr
+                )
 
             image.generated_color = color
             image.colorspace_settings.name = colorspace
@@ -1607,7 +1629,10 @@ class YBakeToLayer(bpy.types.Operator, BaseBakeOperator):
 
             # Back to original size if using SSA
             if use_ssaa:
-                image, temp_segment = resize_image(image, self.width, self.height, image.colorspace_settings.name, alpha_aware=True, bake_device=self.bake_device)
+                image, temp_segment = resize_image(
+                    image, self.width, self.height, image.colorspace_settings.name,
+                    alpha_aware=True, bake_device=self.bake_device
+                )
 
             # Denoise AO image
             if use_denoise:
@@ -1632,15 +1657,17 @@ class YBakeToLayer(bpy.types.Operator, BaseBakeOperator):
                 if not segment or need_to_create_new_segment:
 
                     if self.use_udim:
-                        segment = UDIM.get_set_udim_atlas_segment(tilenums, color=(0,0,0,0), 
-                                colorspace=get_srgb_name(), hdr=self.hdr, yp=yp)
+                        segment = UDIM.get_set_udim_atlas_segment(
+                            tilenums, color=(0, 0, 0, 0), colorspace=get_srgb_name(), hdr=self.hdr, yp=yp
+                        )
                     else:
                         # Clearing unused image atlas segments
                         img_atlas = ImageAtlas.check_need_of_erasing_segments(yp, 'TRANSPARENT', self.width, self.height, self.hdr)
                         if img_atlas: ImageAtlas.clear_unused_segments(img_atlas.yia)
 
                         segment = ImageAtlas.get_set_image_atlas_segment(
-                                self.width, self.height, 'TRANSPARENT', self.hdr, yp=yp) #, ypup.image_atlas_size)
+                            self.width, self.height, 'TRANSPARENT', self.hdr, yp=yp
+                        )
 
                     new_segment_created = True
 
@@ -1717,10 +1744,11 @@ class YBakeToLayer(bpy.types.Operator, BaseBakeOperator):
                         layer_name = get_unique_name(layer_name, yp.layers)
 
                     yp.halt_update = True
-                    layer = Layer.add_new_layer(node.node_tree, layer_name, 'IMAGE', channel_idx, self.blend_type, 
-                            self.normal_blend_type, self.normal_map_type, 'UV', self.uv_map, image, None, segment,
-                            interpolation=self.interpolation
-                            )
+                    layer = Layer.add_new_layer(
+                        node.node_tree, layer_name, 'IMAGE', channel_idx, self.blend_type, 
+                        self.normal_blend_type, self.normal_map_type, 'UV', self.uv_map, image, None, segment,
+                        interpolation = self.interpolation
+                    )
                     yp.halt_update = False
                     active_id = yp.active_layer_index
 
@@ -1740,7 +1768,10 @@ class YBakeToLayer(bpy.types.Operator, BaseBakeOperator):
                     if self.use_image_atlas:
                         mask_name = get_unique_name(mask_name, active_layer.masks)
 
-                    mask = Mask.add_new_mask(active_layer, mask_name, 'IMAGE', 'UV', self.uv_map, image, None, segment)
+                    mask = Mask.add_new_mask(
+                        active_layer, mask_name, 'IMAGE', 'UV', self.uv_map,
+                        image, None, segment
+                    )
                     mask.active_edit = True
 
                     reconnect_layer_nodes(active_layer)
@@ -1935,11 +1966,11 @@ class YBakeToLayer(bpy.types.Operator, BaseBakeOperator):
                 # Deselect other objects first
                 for o in other_objs:
                     o.select_set(False)
-                bpy.ops.object.mode_set(mode = 'EDIT')
+                bpy.ops.object.mode_set(mode='EDIT')
                 bpy.ops.mesh.reveal()
                 bpy.ops.mesh.select_all(action='SELECT')
                 bpy.ops.mesh.flip_normals()
-                bpy.ops.object.mode_set(mode = 'OBJECT')
+                bpy.ops.object.mode_set(mode='OBJECT')
                 # Reselect other objects
                 for o in other_objs:
                     o.select_set(True)
@@ -1947,11 +1978,11 @@ class YBakeToLayer(bpy.types.Operator, BaseBakeOperator):
                 for obj in objs:
                     if obj in other_objs: continue
                     context.scene.objects.active = obj
-                    bpy.ops.object.mode_set(mode = 'EDIT')
+                    bpy.ops.object.mode_set(mode='EDIT')
                     bpy.ops.mesh.reveal()
                     bpy.ops.mesh.select_all(action='SELECT')
                     bpy.ops.mesh.flip_normals()
-                    bpy.ops.object.mode_set(mode = 'OBJECT')
+                    bpy.ops.object.mode_set(mode='OBJECT')
 
         # Recover subdiv setup
         if height_root_ch and subdiv_setup_changes:
@@ -2006,8 +2037,12 @@ class YBakeToLayer(bpy.types.Operator, BaseBakeOperator):
 
         return {'FINISHED'}
 
-def bake_as_image(objs, mat, entity, name, width=1024, height=1024, hdr=False, samples=1, margin=5, uv_name='', bake_device='CPU', 
-        use_udim=False, tilenums=[1001], fxaa=True, blur=False, blur_factor=0.5, denoise=False, disable_modifiers=True, margin_type='ADJACENT_FACES'):
+def bake_as_image(
+        objs, mat, entity, name, width=1024, height=1024, hdr=False,
+        samples=1, margin=5, uv_name='', bake_device='CPU', 
+        use_udim=False, tilenums=[1001], fxaa=True, blur=False, blur_factor=0.5,
+        denoise=False, disable_modifiers=True, margin_type='ADJACENT_FACES'
+    ):
 
     yp = entity.id_data.yp
 
@@ -2087,27 +2122,30 @@ def bake_as_image(objs, mat, entity, name, width=1024, height=1024, hdr=False, s
         for m in get_problematic_modifiers(obj):
             m.show_render = False
 
-    prepare_bake_settings(book, objs, yp, samples=samples, margin=margin, 
-            uv_map=uv_name, bake_type='EMIT', bake_device=bake_device, 
-            margin_type=margin_type
-            )
+    prepare_bake_settings(
+        book, objs, yp, samples=samples, margin=margin, 
+        uv_map=uv_name, bake_type='EMIT', bake_device=bake_device, 
+        margin_type = margin_type
+    )
 
     # Create bake nodes
     tex = mat.node_tree.nodes.new('ShaderNodeTexImage')
 
     if mask:
-        color = (0,0,0,1)
+        color = (0, 0, 0, 1)
         color_str = 'BLACK'
         colorspace = get_noncolor_name()
     else: 
-        color = (0,0,0,0)
+        color = (0, 0, 0, 0)
         color_str = 'TRANSPARENT'
         colorspace = get_srgb_name()
 
     # Create image
     if use_udim:
-        image = bpy.data.images.new(name=name,
-                width=width, height=height, alpha=True, float_buffer=hdr, tiled=True)
+        image = bpy.data.images.new(
+            name=name, width=width, height=height,
+            alpha=True, float_buffer=hdr, tiled=True
+        )
 
         # Fill tiles
         for tilenum in tilenums:
@@ -2117,8 +2155,10 @@ def bake_as_image(objs, mat, entity, name, width=1024, height=1024, hdr=False, s
         # Remember base color
         image.yia.color = color_str
     else:
-        image = bpy.data.images.new(name=name,
-                width=width, height=height, alpha=True, float_buffer=hdr)
+        image = bpy.data.images.new(
+            name=name, width=width, height=height,
+            alpha=True, float_buffer=hdr
+        )
 
     image.generated_color = color
     image.colorspace_settings.name = colorspace
@@ -2189,42 +2229,53 @@ class YBakeEntityToImage(bpy.types.Operator, BaseBakeOperator):
 
     hdr : BoolProperty(name='32 bit Float', default=False)
 
-    fxaa : BoolProperty(name='Use FXAA', 
-            description = "Use FXAA to baked image (doesn't work with float images)",
-            default=True)
+    fxaa : BoolProperty(
+        name = 'Use FXAA', 
+        description = "Use FXAA to baked image (doesn't work with float images)",
+        default = True
+    )
 
-    denoise : BoolProperty(name='Use Denoise', 
-            description = "Use Denoise on baked images",
-            default=False)
+    denoise : BoolProperty(
+        name = 'Use Denoise', 
+        description = 'Use Denoise on baked images',
+        default = False
+    )
 
     use_image_atlas : BoolProperty(
-            name = 'Use Image Atlas',
-            description='Use Image Atlas',
-            default=False)
+        name = 'Use Image Atlas',
+        description = 'Use Image Atlas',
+        default = False
+    )
 
-    blur : BoolProperty(name='Use Blur', 
-            description = "Use blur to baked image",
-            default=False)
+    blur : BoolProperty(
+        name = 'Use Blur', 
+        description = 'Use blur to baked image',
+        default = False
+    )
 
-    blur_factor : FloatProperty(name='Blur Factor',
-            description = "Blur factor to baked image",
-            default=1.0, min=0.0, max=100.0
-            )
+    blur_factor : FloatProperty(
+        name = 'Blur Factor',
+        description = 'Blur factor to baked image',
+        default=1.0, min=0.0, max=100.0
+    )
 
     duplicate_entity : BoolProperty(
-            name = 'Duplicate Entity',
-            description='Duplicate entity',
-            default=False)
+        name = 'Duplicate Entity',
+        description = 'Duplicate entity',
+        default = False
+    )
 
     disable_current : BoolProperty(
-            name = 'Disable current layer/mask',
-            description='Disable current layer/mask',
-            default=True)
+        name = 'Disable current layer/mask',
+        description = 'Disable current layer/mask',
+        default = True
+    )
 
     use_udim : BoolProperty(
-            name = 'Use UDIM Tiles',
-            description='Use UDIM Tiles',
-            default=False)
+        name = 'Use UDIM Tiles',
+        description = 'Use UDIM Tiles',
+        default = False
+    )
 
     @classmethod
     def poll(cls, context):
@@ -2448,15 +2499,17 @@ class YBakeEntityToImage(bpy.types.Operator, BaseBakeOperator):
         if self.use_image_atlas:
 
             if self.use_udim:
-                segment = UDIM.get_set_udim_atlas_segment(self.tilenums, color=(0,0,0,1), 
-                        colorspace=get_noncolor_name(), hdr=self.hdr, yp=yp)
+                segment = UDIM.get_set_udim_atlas_segment(
+                    self.tilenums, color=(0, 0, 0, 1), colorspace=get_noncolor_name(), hdr=self.hdr, yp=yp
+                )
             else:
                 # Clearing unused image atlas segments
                 img_atlas = ImageAtlas.check_need_of_erasing_segments(yp, 'BLACK', self.width, self.height, self.hdr)
                 if img_atlas: ImageAtlas.clear_unused_segments(img_atlas.yia)
 
                 segment = ImageAtlas.get_set_image_atlas_segment(
-                        self.width, self.height, 'BLACK', self.hdr, yp=yp) #, ypup.image_atlas_size)
+                    self.width, self.height, 'BLACK', self.hdr, yp=yp
+                )
 
             ia_image = segment.id_data
 
@@ -2530,11 +2583,13 @@ class YBakeEntityToImage(bpy.types.Operator, BaseBakeOperator):
         if self.use_udim:
             self.tilenums = UDIM.get_tile_numbers(objs, self.uv_map)
 
-        self.image = bake_as_image(objs, mat, entity, self.name, width=self.width, height=self.height, hdr=self.hdr, 
-                samples=self.samples, margin=self.margin, uv_name=self.uv_map, bake_device=self.bake_device, 
-                use_udim=self.use_udim, tilenums=self.tilenums, fxaa=self.fxaa, blur=self.blur, blur_factor=self.blur_factor, denoise=self.denoise,
-                disable_modifiers = not self.duplicate_entity, margin_type=self.margin_type
-                )
+        self.image = bake_as_image(
+            objs, mat, entity, self.name, width=self.width, height=self.height, hdr=self.hdr, 
+            samples=self.samples, margin=self.margin, uv_name=self.uv_map, bake_device=self.bake_device, 
+            use_udim=self.use_udim, tilenums=self.tilenums, fxaa=self.fxaa,
+            blur=self.blur, blur_factor=self.blur_factor, denoise=self.denoise,
+            disable_modifiers=not self.duplicate_entity, margin_type=self.margin_type
+        )
 
         # Get segment
         segment = self.get_image_atlas_segment(context)

--- a/ImageAtlas.py
+++ b/ImageAtlas.py
@@ -55,16 +55,18 @@ def create_image_atlas(color='BLACK', size=8192, hdr=False, name=''):
 
     name = get_unique_name(name, bpy.data.images)
 
-    img = bpy.data.images.new(name=name, 
-            width=size, height=size, alpha=True, float_buffer=hdr)
+    img = bpy.data.images.new(
+        name=name, width=size, height=size,
+        alpha=True, float_buffer=hdr
+    )
 
     if color == 'BLACK':
-        img.generated_color = (0,0,0,1)
+        img.generated_color = (0, 0, 0, 1)
         img.colorspace_settings.name = get_noncolor_name()
     elif color == 'WHITE':
-        img.generated_color = (1,1,1,1)
+        img.generated_color = (1, 1, 1, 1)
         img.colorspace_settings.name = get_noncolor_name()
-    else: img.generated_color = (0,0,0,0)
+    else: img.generated_color = (0, 0, 0, 0)
 
     img.yia.is_image_atlas = True
     img.yia.color = color
@@ -246,8 +248,8 @@ def replace_segment_with_image(yp, segment, image, uv_name=''):
 
 def get_segment_mapping(segment, image):
 
-    scale_x = segment.width/image.size[0]
-    scale_y = segment.height/image.size[1]
+    scale_x = segment.width / image.size[0]
+    scale_y = segment.height / image.size[1]
 
     offset_x = scale_x * segment.tile_x
     offset_y = scale_y * segment.tile_y
@@ -295,14 +297,17 @@ class YNewImageAtlasSegmentTest(bpy.types.Operator):
 
     #image_atlas_coll : CollectionProperty(type=bpy.types.PropertyGroup)
     color : EnumProperty(
-            name = 'Altas Base Color',
-            items = (('WHITE', 'White', ''),
-                     ('BLACK', 'Black', ''),
-                     ('TRANSPARENT', 'Transparent', '')),
-            default = 'BLACK')
+        name = 'Altas Base Color',
+        items = (
+            ('WHITE', 'White', ''),
+            ('BLACK', 'Black', ''),
+            ('TRANSPARENT', 'Transparent', '')
+        ),
+        default = 'BLACK'
+    )
 
-    width : IntProperty(name='Width', default = 128, min=1, max=4096)
-    height : IntProperty(name='Height', default = 128, min=1, max=4096)
+    width : IntProperty(name='Width', default=128, min=1, max=4096)
+    height : IntProperty(name='Height', default=128, min=1, max=4096)
 
     @classmethod
     def poll(cls, context):
@@ -339,8 +344,8 @@ class YNewImageAtlasSegmentTest(bpy.types.Operator):
         #    atlas_img = create_image_atlas(color='BLACK', size=1024)
         #else: atlas_img = bpy.data.images.get(self.image_atlas_name)
         segment = get_set_image_atlas_segment(
-                self.width, self.height, self.color, 
-                hdr=False)
+            self.width, self.height, self.color, hdr=False
+        )
 
         atlas_img = segment.id_data
         atlas = atlas_img.yia
@@ -371,8 +376,8 @@ class YNewImageAtlasSegmentTest(bpy.types.Operator):
 
                 for x in range(start_x, end_x):
                     for i in range(3):
-                        pxs[offset_y + (x*4) + i] = col[i]
-                        pxs[offset_y + (x*4) + 3] = 1.0
+                        pxs[offset_y + (x * 4) + i] = col[i]
+                        pxs[offset_y + (x * 4) + 3] = 1.0
 
             atlas_img.pixels = pxs
 
@@ -486,9 +491,10 @@ class YConvertToImageAtlas(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     all_images : BoolProperty(
-            name = 'All Images',
-            description = 'Convert all images instead of only the active one',
-            default=False)
+        name = 'All Images',
+        description = 'Convert all images instead of only the active one',
+        default = False
+    )
 
     @classmethod
     def poll(cls, context):
@@ -593,9 +599,10 @@ class YConvertToStandardImage(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     all_images : BoolProperty(
-            name = 'All Images',
-            description = 'Convert all images instead of only the active one',
-            default=False)
+        name = 'All Images',
+        description = 'Convert all images instead of only the active one',
+        default = False
+    )
 
     @classmethod
     def poll(cls, context):
@@ -634,11 +641,15 @@ class YConvertToStandardImage(bpy.types.Operator):
 
             # Create new image based on image atlas
             if image.yia.is_image_atlas:
-                new_image = bpy.data.images.new(name=entities[i][0].name,
-                        width=segment.width, height=segment.height, alpha=True, float_buffer=image.is_float)
+                new_image = bpy.data.images.new(
+                    name=entities[i][0].name, width=segment.width, height=segment.height,
+                    alpha=True, float_buffer=image.is_float
+                )
             else:
-                new_image = bpy.data.images.new(name=entities[i][0].name,
-                        width=image.size[0], height=image.size[1], alpha=True, float_buffer=image.is_float, tiled=True)
+                new_image = bpy.data.images.new(
+                    name=entities[i][0].name, width=image.size[0], height=image.size[1],
+                    alpha=True, float_buffer=image.is_float, tiled=True
+                )
 
                 atlas_tilenums = UDIM.get_udim_segment_tilenums(segment)
                 index = UDIM.get_udim_segment_index(image, segment)
@@ -721,9 +732,10 @@ class YConvertToStandardImage(bpy.types.Operator):
 class YImageAtlasSegments(bpy.types.PropertyGroup):
 
     name : StringProperty(
-            name='Name',
-            description='Name of Image Atlas Segments',
-            default='')
+        name = 'Name',
+        description = 'Name of Image Atlas Segments',
+        default = ''
+    )
 
     tile_x : IntProperty(default=0)
     tile_y : IntProperty(default=0)
@@ -737,18 +749,22 @@ class YImageAtlasSegments(bpy.types.PropertyGroup):
 
 class YImageAtlas(bpy.types.PropertyGroup):
     name : StringProperty(
-            name='Name',
-            description='Name of Image Atlas',
-            default='')
+        name = 'Name',
+        description = 'Name of Image Atlas',
+        default = ''
+    )
 
     is_image_atlas : BoolProperty(default=False)
 
     color : EnumProperty(
-            name = 'Atlas Base Color',
-            items = (('WHITE', 'White', ''),
-                     ('BLACK', 'Black', ''),
-                     ('TRANSPARENT', 'Transparent', '')),
-            default = 'BLACK')
+        name = 'Atlas Base Color',
+        items = (
+            ('WHITE', 'White', ''),
+            ('BLACK', 'Black', ''),
+            ('TRANSPARENT', 'Transparent', '')
+        ),
+        default = 'BLACK'
+    )
 
     #float_buffer : BoolProperty(default=False)
 

--- a/Layer.py
+++ b/Layer.py
@@ -57,18 +57,19 @@ def load_hemi_props(layer, source):
     trans = source.node_tree.nodes.get('Vector Transform')
     if trans: trans.convert_from = layer.hemi_space
 
-def add_new_layer(group_tree, layer_name, layer_type, channel_idx, 
+def add_new_layer(
+        group_tree, layer_name, layer_type, channel_idx, 
         blend_type, normal_blend_type, normal_map_type, 
         texcoord_type, uv_name='', image=None, vcol=None, segment=None,
-        solid_color = (1,1,1),
+        solid_color=(1, 1, 1),
         add_mask=False, mask_type='IMAGE', mask_image_filepath='', mask_relative=True,
         mask_texcoord_type='UV', mask_color='BLACK', mask_use_hdr=False, 
-        mask_uv_name = '', mask_width=1024, mask_height=1024, use_image_atlas_for_mask=False,
-        hemi_space = 'WORLD', hemi_use_prev_normal = True,
-        mask_color_id=(1,0,1), mask_vcol_data_type='BYTE_COLOR', mask_vcol_domain='CORNER',
-        use_divider_alpha = False, use_udim_for_mask=False,
-        interpolation = 'Linear', mask_interpolation = 'Linear', mask_edge_detect_radius=0.05
-        ):
+        mask_uv_name='', mask_width=1024, mask_height=1024, use_image_atlas_for_mask=False,
+        hemi_space='WORLD', hemi_use_prev_normal=True,
+        mask_color_id=(1, 0, 1), mask_vcol_data_type='BYTE_COLOR', mask_vcol_domain='CORNER',
+        use_divider_alpha=False, use_udim_for_mask=False,
+        interpolation='Linear', mask_interpolation='Linear', mask_edge_detect_radius=0.05
+    ):
 
     yp = group_tree.yp
     ypup = get_user_preferences()
@@ -217,11 +218,11 @@ def add_new_layer(group_tree, layer_name, layer_type, channel_idx,
 
         if mask_type == 'IMAGE':
             if not mask_image_filepath:
-                color = (0,0,0,0)
+                color = (0, 0, 0, 0)
                 if mask_color == 'WHITE':
-                    color = (1,1,1,1)
+                    color = (1, 1, 1, 1)
                 elif mask_color == 'BLACK':
-                    color = (0,0,0,1)
+                    color = (0, 0, 0, 1)
 
                 if use_udim_for_mask:
                     objs = get_all_objects_with_same_materials(mat)
@@ -229,16 +230,21 @@ def add_new_layer(group_tree, layer_name, layer_type, channel_idx,
 
                 if use_image_atlas_for_mask:
                     if use_udim_for_mask:
-                        mask_segment = UDIM.get_set_udim_atlas_segment(tilenums,
-                                mask_width, mask_height, color, colorspace=get_noncolor_name(), hdr=mask_use_hdr, yp=yp)
+                        mask_segment = UDIM.get_set_udim_atlas_segment(
+                            tilenums, mask_width, mask_height, color,
+                            colorspace=get_noncolor_name(), hdr=mask_use_hdr, yp=yp
+                        )
                     else:
                         mask_segment = ImageAtlas.get_set_image_atlas_segment(
-                                mask_width, mask_height, mask_color, mask_use_hdr, yp=yp)
+                            mask_width, mask_height, mask_color, mask_use_hdr, yp=yp
+                        )
                     mask_image = mask_segment.id_data
                 else:
                     if use_udim_for_mask:
-                        mask_image = bpy.data.images.new(mask_name, 
-                                width=mask_width, height=mask_height, alpha=False, float_buffer=mask_use_hdr, tiled=True)
+                        mask_image = bpy.data.images.new(
+                            mask_name, width=mask_width, height=mask_height,
+                            alpha=False, float_buffer=mask_use_hdr, tiled=True
+                        )
 
                         # Fill tiles
                         for tilenum in tilenums:
@@ -246,8 +252,10 @@ def add_new_layer(group_tree, layer_name, layer_type, channel_idx,
                         UDIM.initial_pack_udim(mask_image, color)
 
                     else:
-                        mask_image = bpy.data.images.new(mask_name, 
-                                width=mask_width, height=mask_height, alpha=False, float_buffer=mask_use_hdr)
+                        mask_image = bpy.data.images.new(
+                            mask_name, width=mask_width, height=mask_height,
+                            alpha=False, float_buffer=mask_use_hdr
+                        )
 
                     mask_image.generated_color = color
                     if hasattr(mask_image, 'use_alpha'):
@@ -293,9 +301,12 @@ def add_new_layer(group_tree, layer_name, layer_type, channel_idx,
             elif mask_type == 'COLOR_ID':
                 check_colorid_vcol(objs)
 
-        mask = Mask.add_new_mask(layer, mask_name, mask_type, mask_texcoord_type,
-                mask_uv_name, mask_image, mask_vcol, mask_segment, interpolation=mask_interpolation, color_id=mask_color_id,
-                edge_detect_radius=mask_edge_detect_radius)
+        mask = Mask.add_new_mask(
+            layer, mask_name, mask_type, mask_texcoord_type,
+            mask_uv_name, mask_image, mask_vcol, mask_segment,
+            interpolation=mask_interpolation, color_id=mask_color_id,
+            edge_detect_radius=mask_edge_detect_radius
+        )
         mask.active_edit = True
 
     # Fill channel layer props
@@ -389,16 +400,18 @@ class YNewVcolToOverrideChannel(bpy.types.Operator):
     name : StringProperty(default='')
 
     data_type : EnumProperty(
-            name = 'Vertex Color Data Type',
-            description = 'Vertex color data type',
-            items = vcol_data_type_items,
-            default='BYTE_COLOR')
+        name = 'Vertex Color Data Type',
+        description = 'Vertex color data type',
+        items = vcol_data_type_items,
+        default = 'BYTE_COLOR'
+    )
 
     domain : EnumProperty(
-            name = 'Vertex Color Domain',
-            description = 'Vertex color domain',
-            items = vcol_domain_items,
-            default='CORNER')
+        name = 'Vertex Color Domain',
+        description = 'Vertex color domain',
+        items = vcol_domain_items,
+        default = 'CORNER'
+    )
 
     @classmethod
     def poll(cls, context):
@@ -548,35 +561,38 @@ class YNewVDMLayer(bpy.types.Operator):
 
     name : StringProperty(default='')
 
-    width : IntProperty(name='Width', default = 1024, min=1, max=16384)
-    height : IntProperty(name='Height', default = 1024, min=1, max=16384)
+    width : IntProperty(name='Width', default=1024, min=1, max=16384)
+    height : IntProperty(name='Height', default=1024, min=1, max=16384)
 
     image_resolution : EnumProperty(
         name = 'Image Resolution',
         items = image_resolution_items,
         default = '1024'
-        )
+    )
 
     use_custom_resolution : BoolProperty(
-        name= 'Custom Resolution',
-        default=False,
-        description= 'Use custom Resolution to adjust the width and height individually'
+        name = 'Custom Resolution',
+        description = 'Use custom Resolution to adjust the width and height individually',
+        default = False
     )
 
     blend_type : EnumProperty(
-            name = 'Blend Type',
-            items = normal_blend_items,
-            default = 'OVERLAY')
+        name = 'Blend Type',
+        items = normal_blend_items,
+        default = 'OVERLAY'
+    )
 
     use_udim : BoolProperty(
-            name = 'Use UDIM Tiles',
-            description='Use UDIM Tiles',
-            default=False)
+        name = 'Use UDIM Tiles',
+        description = 'Use UDIM Tiles',
+        default = False
+    )
 
     enable_subdiv_setup : BoolProperty(
-            name = 'Enable Displacement Setup',
-            description='Enable Displacement Setup on Normal channel',
-            default=True)
+        name = 'Enable Displacement Setup',
+        description = 'Enable Displacement Setup on Normal channel',
+        default = True
+    )
 
     # NOTE: UDIM is not supported yet, so no UDIM checking
     uv_map : StringProperty(default='') #, update=update_new_layer_uv_map)
@@ -693,13 +709,15 @@ class YNewVDMLayer(bpy.types.Operator):
         channel_idx = get_channel_index(height_root_ch)
 
         alpha = True
-        color = (0,0,0,0)
+        color = (0, 0, 0, 0)
 
         if self.use_udim:
             tilenums = UDIM.get_tile_numbers(objs, self.uv_map)
 
-            img = bpy.data.images.new(name=self.name, width=self.width, height=self.height, 
-                    alpha=alpha, float_buffer=True, tiled=True)
+            img = bpy.data.images.new(
+                name=self.name, width=self.width, height=self.height, 
+                alpha=alpha, float_buffer=True, tiled=True
+            )
 
             # Fill tiles
             for tilenum in tilenums:
@@ -707,8 +725,10 @@ class YNewVDMLayer(bpy.types.Operator):
             UDIM.initial_pack_udim(img, color)
 
         else:
-            img = bpy.data.images.new(name=self.name, width=self.width, height=self.height, 
-                    alpha=alpha, float_buffer=True)
+            img = bpy.data.images.new(
+                name=self.name, width=self.width, height=self.height, 
+                alpha=alpha, float_buffer=True
+            )
 
         #img.generated_type = self.generated_type
         img.generated_type = 'BLANK'
@@ -720,11 +740,12 @@ class YNewVDMLayer(bpy.types.Operator):
 
         yp.halt_update = True
 
-        layer = add_new_layer(node.node_tree, self.name, 'IMAGE', 
-                channel_idx, 'MIX', self.blend_type, 
-                'VECTOR_DISPLACEMENT_MAP', 'UV', self.uv_map, img,
-                interpolation = 'Cubic'
-                )
+        layer = add_new_layer(
+            node.node_tree, self.name, 'IMAGE', 
+            channel_idx, 'MIX', self.blend_type, 
+            'VECTOR_DISPLACEMENT_MAP', 'UV', self.uv_map, img,
+            interpolation = 'Cubic'
+        )
 
         yp.halt_update = False
 
@@ -765,191 +786,221 @@ class YNewLayer(bpy.types.Operator):
     name : StringProperty(default='')
 
     type : EnumProperty(
-            name = 'Layer Type',
-            items = layer_type_items,
-            default = 'IMAGE')
+        name = 'Layer Type',
+        items = layer_type_items,
+        default = 'IMAGE'
+    )
 
     # For image layer
-    width : IntProperty(name='Width', default = 1024, min=1, max=16384)
-    height : IntProperty(name='Height', default = 1024, min=1, max=16384)
+    width : IntProperty(name='Width', default=1024, min=1, max=16384)
+    height : IntProperty(name='Height', default=1024, min=1, max=16384)
     #color : FloatVectorProperty(name='Color', size=4, subtype='COLOR', default=(0.0,0.0,0.0,0.0), min=0.0, max=1.0)
     #alpha : BoolProperty(name='Alpha', default=True)
     hdr : BoolProperty(name='32 bit Float', default=False)
 
     interpolation : EnumProperty(
-            name = 'Image Interpolation Type',
-            description = 'Image interpolation type',
-            items = interpolation_type_items,
-            default = 'Linear')
+        name = 'Image Interpolation Type',
+        description = 'Image interpolation type',
+        items = interpolation_type_items,
+        default = 'Linear'
+    )
 
     texcoord_type : EnumProperty(
-            name = 'Layer Coordinate Type',
-            description = 'Layer Coordinate Type',
-            items = texcoord_type_items,
-            default = 'UV')
+        name = 'Layer Coordinate Type',
+        description = 'Layer Coordinate Type',
+        items = texcoord_type_items,
+        default = 'UV'
+    )
 
     channel_idx : EnumProperty(
-            name = 'Channel',
-            description = 'Channel of new layer, can be changed later',
-            items = channel_items,
-            update=update_channel_idx_new_layer)
+        name = 'Channel',
+        description = 'Channel of new layer, can be changed later',
+        items = channel_items,
+        update = update_channel_idx_new_layer
+    )
 
     blend_type : EnumProperty(
         name = 'Blend',
         description = 'Blend type',
         items = blend_type_items,
-        default = 'MIX')
+        default = 'MIX'
+    )
 
     normal_blend_type : EnumProperty(
-            name = 'Normal Blend Type',
-            items = normal_blend_items,
-            default = 'MIX')
+        name = 'Normal Blend Type',
+        items = normal_blend_items,
+        default = 'MIX'
+    )
 
     solid_color : FloatVectorProperty(
-            name='Solid Color', size=3, subtype='COLOR', default=(1.0,1.0,1.0), min=0.0, max=1.0)
+        name = 'Solid Color',
+        size = 3,
+        subtype = 'COLOR',
+        default=(1.0, 1.0, 1.0), min=0.0, max=1.0
+    )
 
     add_mask : BoolProperty(
-            name = 'Add Mask',
-            description = 'Add mask to new layer',
-            default = False)
+        name = 'Add Mask',
+        description = 'Add mask to new layer',
+        default = False
+    )
 
     mask_type : EnumProperty(
-            name = 'Mask Type',
-            description = 'Mask type',
-            items = (
-                ('IMAGE', 'Image', '', 'IMAGE_DATA', 0),
-                ('VCOL', 'Vertex Color', '', 'GROUP_VCOL', 1),
-                ('COLOR_ID', 'Color ID', '', 'COLOR', 2),
-                ('EDGE_DETECT', 'Edge Detect', '', 'MESH_CUBE', 3)
-                ),
-            default = 'IMAGE')
+        name = 'Mask Type',
+        description = 'Mask type',
+        items = (
+            ('IMAGE', 'Image', '', 'IMAGE_DATA', 0),
+            ('VCOL', 'Vertex Color', '', 'GROUP_VCOL', 1),
+            ('COLOR_ID', 'Color ID', '', 'COLOR', 2),
+            ('EDGE_DETECT', 'Edge Detect', '', 'MESH_CUBE', 3)
+        ),
+        default = 'IMAGE'
+    )
 
     mask_color : EnumProperty(
-            name = 'Mask Color',
-            description = 'Mask Color',
-            items = (
-                ('WHITE', 'White (Full Opacity)', ''),
-                ('BLACK', 'Black (Full Transparency)', ''),
-                ),
-            default='BLACK')
+        name = 'Mask Color',
+        description = 'Mask Color',
+        items = (
+            ('WHITE', 'White (Full Opacity)', ''),
+            ('BLACK', 'Black (Full Transparency)', ''),
+        ),
+        default = 'BLACK'
+    )
 
-    mask_width : IntProperty(name='Mask Width', default = 1024, min=1, max=4096)
-    mask_height : IntProperty(name='Mask Height', default = 1024, min=1, max=4096)
+    mask_width : IntProperty(name='Mask Width', default=1024, min=1, max=4096)
+    mask_height : IntProperty(name='Mask Height', default=1024, min=1, max=4096)
 
     mask_image_resolution : EnumProperty(
         name = 'Image Resolution',
         items = image_resolution_items,
-        default = '1024')
+        default = '1024'
+    )
     
     mask_use_custom_resolution : BoolProperty(
-        name= 'Custom Resolution',
-        default=False,
-        description= 'Use custom Resolution to adjust the width and height individually'
+        name = 'Custom Resolution',
+        description= 'Use custom Resolution to adjust the width and height individually',
+        default = False
     )
 
     mask_interpolation : EnumProperty(
-            name = 'Mask Image Interpolation Type',
-            description = 'Mask image interpolation type',
-            items = interpolation_type_items,
-            default = 'Linear')
+        name = 'Mask Image Interpolation Type',
+        description = 'Mask image interpolation type',
+        items = interpolation_type_items,
+        default = 'Linear'
+    )
 
     mask_texcoord_type : EnumProperty(
-            name = 'Mask Coordinate Type',
-            description = 'Mask Coordinate Type',
-            items = texcoord_type_items,
-            default = 'UV')
+        name = 'Mask Coordinate Type',
+        description = 'Mask Coordinate Type',
+        items = texcoord_type_items,
+        default = 'UV'
+    )
 
     mask_uv_name : StringProperty(default='', update=update_new_layer_mask_uv_map)
     mask_use_hdr : BoolProperty(name='32 bit Float', default=False)
 
     mask_color_id : FloatVectorProperty(
-            name='Color ID', size=3,
-            subtype='COLOR',
-            default=(1.0, 0.0, 1.0),
-            min=0.0, max=1.0)
+        name = 'Color ID',
+        size = 3,
+        subtype = 'COLOR',
+        default=(1.0, 0.0, 1.0), min=0.0, max=1.0
+    )
     
     mask_image_filepath : StringProperty(
-            name = 'Mask Image Path',
-            description = 'Path to mask image',
-            default = '',
-            subtype = 'FILE_PATH',
-            options = {'SKIP_SAVE'})
+        name = 'Mask Image Path',
+        description = 'Path to mask image',
+        default = '',
+        subtype = 'FILE_PATH',
+        options = {'SKIP_SAVE'}
+    )
 
     mask_relative : BoolProperty(name="Relative Mask Path", default=True, description="Apply relative paths")
 
     uv_map : StringProperty(default='', update=update_new_layer_uv_map)
 
     normal_map_type : EnumProperty(
-            name = 'Normal Map Type',
-            description = 'Normal map type of this layer',
-            items = get_normal_map_type_items)
-            #default = 'BUMP_MAP')
+        name = 'Normal Map Type',
+        description = 'Normal map type of this layer',
+        items = get_normal_map_type_items
+    )
 
     use_udim : BoolProperty(
-            name = 'Use UDIM Tiles',
-            description='Use UDIM Tiles',
-            default=False)
+        name = 'Use UDIM Tiles',
+        description = 'Use UDIM Tiles',
+        default = False
+    )
 
     use_udim_for_mask : BoolProperty(
-            name = 'Use UDIM Tiles for Mask',
-            description='Use UDIM Tiles for Mask',
-            default=False)
+        name = 'Use UDIM Tiles for Mask',
+        description='Use UDIM Tiles for Mask',
+        default = False
+    )
 
     use_image_atlas : BoolProperty(
-            name = 'Use Image Atlas',
-            description='Use Image Atlas',
-            default=False)
+        name = 'Use Image Atlas',
+        description='Use Image Atlas',
+        default = False
+    )
 
     use_image_atlas_for_mask : BoolProperty(
-            name = 'Use Image Atlas for Mask',
-            description='Use Image Atlas for Mask',
-            default=False)
+        name = 'Use Image Atlas for Mask',
+        description='Use Image Atlas for Mask',
+        default = False
+    )
 
     hemi_space : EnumProperty(
-            name = 'Fake Lighting Space',
-            description = 'Fake lighting space',
-            items = hemi_space_items,
-            default='WORLD')
+        name = 'Fake Lighting Space',
+        description = 'Fake lighting space',
+        items = hemi_space_items,
+        default = 'WORLD'
+    )
 
     hemi_use_prev_normal : BoolProperty(
-            name = 'Use previous Normal',
-            description = 'Take account previous Normal',
-            default = True)
+        name = 'Use previous Normal',
+        description = 'Take account previous Normal',
+        default = True
+    )
 
     vcol_data_type : EnumProperty(
-            name = 'Vertex Color Data Type',
-            description = 'Vertex color data type',
-            items = vcol_data_type_items,
-            default='BYTE_COLOR')
+        name = 'Vertex Color Data Type',
+        description = 'Vertex color data type',
+        items = vcol_data_type_items,
+        default = 'BYTE_COLOR'
+    )
 
     vcol_domain : EnumProperty(
-            name = 'Vertex Color Domain',
-            description = 'Vertex color domain',
-            items = vcol_domain_items,
-            default='CORNER')
+        name = 'Vertex Color Domain',
+        description = 'Vertex color domain',
+        items = vcol_domain_items,
+        default = 'CORNER'
+    )
 
     mask_vcol_data_type : EnumProperty(
-            name = 'Mask Vertex Color Data Type',
-            description = 'Mask Vertex color data type',
-            items = vcol_data_type_items,
-            default='BYTE_COLOR')
+        name = 'Mask Vertex Color Data Type',
+        description = 'Mask Vertex color data type',
+        items = vcol_data_type_items,
+        default = 'BYTE_COLOR'
+    )
 
     mask_vcol_domain : EnumProperty(
-            name = 'Mask Vertex Color Domain',
-            description = 'Mask Vertex color domain',
-            items = vcol_domain_items,
-            default='CORNER')
+        name = 'Mask Vertex Color Domain',
+        description = 'Mask Vertex color domain',
+        items = vcol_domain_items,
+        default = 'CORNER'
+    )
 
     use_divider_alpha : BoolProperty(
-            name = 'Spread Fix',
-            description='Use spread fix (very recommended for vertex color or image layer)',
-            default=False)
+        name = 'Spread Fix',
+        description='Use spread fix (very recommended for vertex color or image layer)',
+        default = False
+    )
 
     # For edge detection
     mask_edge_detect_radius : FloatProperty(
-            name = 'Edge Detect Mask Radius',
-            description = 'Edge detect mask radius',
-            default=0.05, min=0.0, max=10.0)
+        name = 'Edge Detect Mask Radius',
+        description = 'Edge detect mask radius',
+        default=0.05, min=0.0, max=10.0
+    )
 
     uv_map_coll : CollectionProperty(type=bpy.types.PropertyGroup)
 
@@ -957,12 +1008,12 @@ class YNewLayer(bpy.types.Operator):
         name = 'Image Resolution',
         items = image_resolution_items,
         default = '1024'
-        )
+    )
 
     use_custom_resolution : BoolProperty(
         name= 'Custom Resolution',
-        default=False,
-        description= 'Use custom Resolution to adjust the width and height individually'
+        description = 'Use custom Resolution to adjust the width and height individually',
+        default = False
     )
 
     @classmethod
@@ -1369,7 +1420,7 @@ class YNewLayer(bpy.types.Operator):
         if self.type == 'IMAGE':
 
             alpha = True
-            color = (0,0,0,0)
+            color = (0, 0, 0, 0)
 
             if self.use_udim:
                 objs = get_all_objects_with_same_materials(mat)
@@ -1379,14 +1430,15 @@ class YNewLayer(bpy.types.Operator):
                 if self.use_udim:
                     segment = UDIM.get_set_udim_atlas_segment(tilenums, self.width, self.height, color, get_srgb_name(), self.hdr, yp)
                 else:
-                    segment = ImageAtlas.get_set_image_atlas_segment(
-                            self.width, self.height, 'TRANSPARENT', self.hdr, yp=yp) #, ypup.image_atlas_size)
+                    segment = ImageAtlas.get_set_image_atlas_segment(self.width, self.height, 'TRANSPARENT', self.hdr, yp=yp)
                 img = segment.id_data
             else:
 
                 if self.use_udim:
-                    img = bpy.data.images.new(name=self.name, width=self.width, height=self.height, 
-                            alpha=alpha, float_buffer=self.hdr, tiled=True)
+                    img = bpy.data.images.new(
+                        name=self.name, width=self.width, height=self.height, 
+                        alpha=alpha, float_buffer=self.hdr, tiled=True
+                    )
 
                     # Fill tiles
                     for tilenum in tilenums:
@@ -1394,8 +1446,10 @@ class YNewLayer(bpy.types.Operator):
                     UDIM.initial_pack_udim(img, color)
 
                 else:
-                    img = bpy.data.images.new(name=self.name, width=self.width, height=self.height, 
-                            alpha=alpha, float_buffer=self.hdr)
+                    img = bpy.data.images.new(
+                        name=self.name, width=self.width, height=self.height, 
+                        alpha=alpha, float_buffer=self.hdr
+                    )
 
                     #img.generated_type = self.generated_type
                     img.generated_type = 'BLANK'
@@ -1434,19 +1488,20 @@ class YNewLayer(bpy.types.Operator):
         try: channel_idx = int(self.channel_idx)
         except: channel_idx = 0
 
-        layer = add_new_layer(node.node_tree, self.name, self.type, 
-                channel_idx, self.blend_type, self.normal_blend_type, 
-                self.normal_map_type, self.texcoord_type, self.uv_map, img, vcol, segment,
-                self.solid_color,
-                self.add_mask, self.mask_type, self.mask_image_filepath, self.mask_relative,
-                self.mask_texcoord_type, self.mask_color, self.mask_use_hdr, self.mask_uv_name,
-                self.mask_width, self.mask_height, self.use_image_atlas_for_mask, 
-                self.hemi_space, self.hemi_use_prev_normal, self.mask_color_id,
-                self.mask_vcol_data_type, self.mask_vcol_domain, self.use_divider_alpha,
-                self.use_udim_for_mask,
-                self.interpolation, self.mask_interpolation,
-                self.mask_edge_detect_radius
-                )
+        layer = add_new_layer(
+            node.node_tree, self.name, self.type, 
+            channel_idx, self.blend_type, self.normal_blend_type, 
+            self.normal_map_type, self.texcoord_type, self.uv_map, img, vcol, segment,
+            self.solid_color,
+            self.add_mask, self.mask_type, self.mask_image_filepath, self.mask_relative,
+            self.mask_texcoord_type, self.mask_color, self.mask_use_hdr, self.mask_uv_name,
+            self.mask_width, self.mask_height, self.use_image_atlas_for_mask, 
+            self.hemi_space, self.hemi_use_prev_normal, self.mask_color_id,
+            self.mask_vcol_data_type, self.mask_vcol_domain, self.use_divider_alpha,
+            self.use_udim_for_mask,
+            self.interpolation, self.mask_interpolation,
+            self.mask_edge_detect_radius
+        )
 
         if segment:
             ImageAtlas.set_segment_mapping(layer, segment, img)
@@ -1508,13 +1563,17 @@ class YOpenImageToOverrideChannel(bpy.types.Operator, ImportHelper):
     # File browser filter
     filter_folder : BoolProperty(default=True, options={'HIDDEN', 'SKIP_SAVE'})
     filter_image : BoolProperty(default=True, options={'HIDDEN', 'SKIP_SAVE'})
+
     display_type : EnumProperty(
-            items = (('FILE_DEFAULTDISPLAY', 'Default', ''),
-                     ('FILE_SHORTDISLPAY', 'Short List', ''),
-                     ('FILE_LONGDISPLAY', 'Long List', ''),
-                     ('FILE_IMGDISPLAY', 'Thumbnails', '')),
-            default = 'FILE_IMGDISPLAY',
-            options={'HIDDEN', 'SKIP_SAVE'})
+        items = (
+            ('FILE_DEFAULTDISPLAY', 'Default', ''),
+            ('FILE_SHORTDISLPAY', 'Short List', ''),
+            ('FILE_LONGDISPLAY', 'Long List', ''),
+            ('FILE_IMGDISPLAY', 'Thumbnails', '')
+        ),
+        default = 'FILE_IMGDISPLAY',
+        options = {'HIDDEN', 'SKIP_SAVE'}
+    )
 
     relative : BoolProperty(name="Relative Path", default=True, description="Apply relative paths")
 
@@ -1661,13 +1720,17 @@ class YOpenImageToOverride1Channel(bpy.types.Operator, ImportHelper):
     # File browser filter
     filter_folder : BoolProperty(default=True, options={'HIDDEN', 'SKIP_SAVE'})
     filter_image : BoolProperty(default=True, options={'HIDDEN', 'SKIP_SAVE'})
+
     display_type : EnumProperty(
-            items = (('FILE_DEFAULTDISPLAY', 'Default', ''),
-                     ('FILE_SHORTDISLPAY', 'Short List', ''),
-                     ('FILE_LONGDISPLAY', 'Long List', ''),
-                     ('FILE_IMGDISPLAY', 'Thumbnails', '')),
-            default = 'FILE_IMGDISPLAY',
-            options={'HIDDEN', 'SKIP_SAVE'})
+        items = (
+            ('FILE_DEFAULTDISPLAY', 'Default', ''),
+            ('FILE_SHORTDISLPAY', 'Short List', ''),
+            ('FILE_LONGDISPLAY', 'Long List', ''),
+            ('FILE_IMGDISPLAY', 'Thumbnails', '')
+        ),
+        default = 'FILE_IMGDISPLAY',
+        options = {'HIDDEN', 'SKIP_SAVE'}
+    )
 
     relative : BoolProperty(name="Relative Path", default=True, description="Apply relative paths")
 
@@ -1807,82 +1870,98 @@ class BaseMultipleImagesLayer():
     # File browser filter
     filter_folder : BoolProperty(default=True, options={'HIDDEN', 'SKIP_SAVE'})
     filter_image : BoolProperty(default=True, options={'HIDDEN', 'SKIP_SAVE'})
+
     display_type : EnumProperty(
-            items = (('FILE_DEFAULTDISPLAY', 'Default', ''),
-                     ('FILE_SHORTDISLPAY', 'Short List', ''),
-                     ('FILE_LONGDISPLAY', 'Long List', ''),
-                     ('FILE_IMGDISPLAY', 'Thumbnails', '')),
-            default = 'FILE_IMGDISPLAY',
-            options={'HIDDEN', 'SKIP_SAVE'})
+        items = (
+            ('FILE_DEFAULTDISPLAY', 'Default', ''),
+            ('FILE_SHORTDISLPAY', 'Short List', ''),
+            ('FILE_LONGDISPLAY', 'Long List', ''),
+            ('FILE_IMGDISPLAY', 'Thumbnails', '')
+        ),
+        default = 'FILE_IMGDISPLAY',
+        options = {'HIDDEN', 'SKIP_SAVE'}
+    )
 
     relative : BoolProperty(name="Relative Path", default=True, description="Apply relative paths")
 
     texcoord_type : EnumProperty(
-            name = 'Layer Coordinate Type',
-            description = 'Layer Coordinate Type',
-            items = texcoord_type_items,
-            default = 'UV')
+        name = 'Layer Coordinate Type',
+        description = 'Layer Coordinate Type',
+        items = texcoord_type_items,
+        default = 'UV'
+    )
 
     uv_map : StringProperty(default='')
     uv_map_coll : CollectionProperty(type=bpy.types.PropertyGroup)
 
     add_mask : BoolProperty(
-            name = 'Add Mask',
-            description = 'Add mask to new layer',
-            default = False)
+        name = 'Add Mask',
+        description = 'Add mask to new layer',
+        default = False
+    )
 
     mask_type : EnumProperty(
-            name = 'Mask Type',
-            description = 'Mask type',
-            items = (('IMAGE', 'Image', '', 'IMAGE_DATA', 0),
-                ('VCOL', 'Vertex Color', '', 'GROUP_VCOL', 1)),
-            default = 'IMAGE')
+        name = 'Mask Type',
+        description = 'Mask type',
+        items = (
+            ('IMAGE', 'Image', '', 'IMAGE_DATA', 0),
+            ('VCOL', 'Vertex Color', '', 'GROUP_VCOL', 1)
+        ),
+        default = 'IMAGE'
+    )
 
     mask_color : EnumProperty(
-            name = 'Mask Color',
-            description = 'Mask Color',
-            items = (
-                ('WHITE', 'White (Full Opacity)', ''),
-                ('BLACK', 'Black (Full Transparency)', ''),
-                ),
-            default='BLACK')
+        name = 'Mask Color',
+        description = 'Mask Color',
+        items = (
+            ('WHITE', 'White (Full Opacity)', ''),
+            ('BLACK', 'Black (Full Transparency)', ''),
+        ),
+        default = 'BLACK'
+    )
 
-    mask_width : IntProperty(name='Mask Width', default = 1024, min=1, max=4096)
-    mask_height : IntProperty(name='Mask Height', default = 1024, min=1, max=4096)
+    mask_width : IntProperty(name='Mask Width', default=1024, min=1, max=4096)
+    mask_height : IntProperty(name='Mask Height', default=1024, min=1, max=4096)
 
     mask_image_resolution : EnumProperty(
         name = 'Image Resolution',
         items = image_resolution_items,
-        default = '1024')
+        default = '1024'
+    )
     
     mask_use_custom_resolution : BoolProperty(
-        name= 'Custom Resolution',
-        default=False,
-        description= 'Use custom Resolution to adjust the width and height individually'
+        name = 'Custom Resolution',
+        description = 'Use custom Resolution to adjust the width and height individually',
+        default = False
     )
 
     mask_uv_name : StringProperty(default='', update=update_new_layer_mask_uv_map)
     mask_use_hdr : BoolProperty(name='32 bit Float', default=False)
 
     use_udim_for_mask : BoolProperty(
-            name = 'Use UDIM Tiles for Mask',
-            description='Use UDIM Tiles for Mask',
-            default=False)
+        name = 'Use UDIM Tiles for Mask',
+        description = 'Use UDIM Tiles for Mask',
+        default = False
+    )
 
     use_image_atlas_for_mask : BoolProperty(
-            name = 'Use Image Atlas for Mask',
-            description='Use Image Atlas for Mask',
-            default=False)
+        name = 'Use Image Atlas for Mask',
+        description = 'Use Image Atlas for Mask',
+        default = False
+    )
 
     # NOTE: Most PBR textures are optimized to use 'displacement only without bump' in conjunction with normal map
     # Since this addon already produce normal map with the displacement, it's better to use only bump map by default
     normal_map_priority : EnumProperty(
-            name = 'Normal Map Priority',
-            description = 'Normal map mode when bump and normal map are both found',
-            items = (('BUMP_MAP', 'Prioritize Bump Map', ''),
-                ('NORMAL_MAP', 'Prioritize Normal Map', ''),
-                ('BUMP_NORMAL_MAP', 'Use both Bump and Normal Map', '')),
-            default = 'BUMP_MAP')
+        name = 'Normal Map Priority',
+        description = 'Normal map mode when bump and normal map are both found',
+        items = (
+            ('BUMP_MAP', 'Prioritize Bump Map', ''),
+            ('NORMAL_MAP', 'Prioritize Normal Map', ''),
+            ('BUMP_NORMAL_MAP', 'Use both Bump and Normal Map', '')
+        ),
+        default = 'BUMP_MAP'
+    )
 
     def generate_paths(self):
         return (fn.name for fn in self.files), self.directory
@@ -1970,13 +2049,13 @@ class BaseMultipleImagesLayer():
                 gl_image = image
 
         synonym_libs = {
-                'color' : ['albedo', 'diffuse', 'base color', 'd'], 
-                'alpha' : ['opacity', 'a'], 
-                'ambient occlusion' : ['ao'], 
-                'metallic' : ['metalness', 'm'],
-                'roughness' : ['glossiness', 'r'],
-                'normal' : ['displacement', 'height', 'bump', 'n'], # Prioritize displacement/bump before actual normal map
-                }
+            'color' : ['albedo', 'diffuse', 'base color', 'd'], 
+            'alpha' : ['opacity', 'a'], 
+            'ambient occlusion' : ['ao'], 
+            'metallic' : ['metalness', 'm'],
+            'roughness' : ['glossiness', 'r'],
+            'normal' : ['displacement', 'height', 'bump', 'n'], # Prioritize displacement/bump before actual normal map
+        }
 
         bump_synonyms = ['displacement', 'height', 'bump']
 
@@ -2078,12 +2157,14 @@ class BaseMultipleImagesLayer():
             if i == 0:
                 yp.halt_update = True
                                                  
-                layer = add_new_layer(node.node_tree, image.name, 'IMAGE', 
-                        int(ch_idx), 'MIX', 'MIX', 
-                        normal_map_type, self.texcoord_type, self.uv_map, image, None, None,
-                        (1,1,1), self.add_mask, self.mask_type, None, None, None, self.mask_color, self.mask_use_hdr, 
-                        self.mask_uv_name, self.mask_width, self.mask_height, self.use_image_atlas_for_mask, 
-                        use_udim_for_mask=self.use_udim_for_mask)
+                layer = add_new_layer(
+                    node.node_tree, image.name, 'IMAGE', 
+                    int(ch_idx), 'MIX', 'MIX', 
+                    normal_map_type, self.texcoord_type, self.uv_map, image, None, None,
+                    (1, 1, 1), self.add_mask, self.mask_type, None, None, None, self.mask_color, self.mask_use_hdr, 
+                    self.mask_uv_name, self.mask_width, self.mask_height, self.use_image_atlas_for_mask, 
+                    use_udim_for_mask=self.use_udim_for_mask
+                )
 
                 yp.halt_update = False
                 tree = get_tree(layer)
@@ -2345,7 +2426,7 @@ class YOpenImagesFromMaterialToLayer(bpy.types.Operator, BaseMultipleImagesLayer
 
         obj = context.object
         if not obj.data or not hasattr(obj.data, 'materials'):
-            self.report({'ERROR'}, "Cannot use "+get_addon_title()+" with object '"+obj.name+"'!")
+            self.report({'ERROR'}, "Cannot use " + get_addon_title() + " with object '" + obj.name + "'!")
             return {'CANCELLED'}
 
         # Get material from local first
@@ -2493,56 +2574,66 @@ class YOpenImageToLayer(bpy.types.Operator, ImportHelper):
     # File browser filter
     filter_folder : BoolProperty(default=True, options={'HIDDEN', 'SKIP_SAVE'})
     filter_image : BoolProperty(default=True, options={'HIDDEN', 'SKIP_SAVE'})
+
     display_type : EnumProperty(
-            items = (('FILE_DEFAULTDISPLAY', 'Default', ''),
-                     ('FILE_SHORTDISLPAY', 'Short List', ''),
-                     ('FILE_LONGDISPLAY', 'Long List', ''),
-                     ('FILE_IMGDISPLAY', 'Thumbnails', '')),
-            default = 'FILE_IMGDISPLAY',
-            options={'HIDDEN', 'SKIP_SAVE'})
+        items = (
+            ('FILE_DEFAULTDISPLAY', 'Default', ''),
+            ('FILE_SHORTDISLPAY', 'Short List', ''),
+            ('FILE_LONGDISPLAY', 'Long List', ''),
+            ('FILE_IMGDISPLAY', 'Thumbnails', '')
+        ),
+        default = 'FILE_IMGDISPLAY',
+        options = {'HIDDEN', 'SKIP_SAVE'}
+    )
 
     relative : BoolProperty(name="Relative Path", default=True, description="Apply relative paths")
 
     interpolation : EnumProperty(
-            name = 'Image Interpolation Type',
-            description = 'Image interpolation type',
-            items = interpolation_type_items,
-            default = 'Linear')
+        name = 'Image Interpolation Type',
+        description = 'Image interpolation type',
+        items = interpolation_type_items,
+        default = 'Linear'
+    )
 
     texcoord_type : EnumProperty(
-            name = 'Layer Coordinate Type',
-            description = 'Layer Coordinate Type',
-            items = texcoord_type_items,
-            default = 'UV')
+        name = 'Layer Coordinate Type',
+        description = 'Layer Coordinate Type',
+        items = texcoord_type_items,
+        default = 'UV'
+    )
 
     uv_map : StringProperty(default='')
 
     channel_idx : EnumProperty(
-            name = 'Channel',
-            description = 'Channel of new layer, can be changed later',
-            items = channel_items,
-            update=update_channel_idx_new_layer)
+        name = 'Channel',
+        description = 'Channel of new layer, can be changed later',
+        items = channel_items,
+        update = update_channel_idx_new_layer
+    )
 
     blend_type : EnumProperty(
         name = 'Blend',
         items = blend_type_items,
-        default = 'MIX')
+        default = 'MIX'
+    )
 
     normal_blend_type : EnumProperty(
-            name = 'Normal Blend Type',
-            items = normal_blend_items,
-            default = 'MIX')
+        name = 'Normal Blend Type',
+        items = normal_blend_items,
+        default = 'MIX'
+    )
 
     normal_map_type : EnumProperty(
-            name = 'Normal Map Type',
-            description = 'Normal map type of this layer',
-            items = get_normal_map_type_items)
-            #default = 'NORMAL_MAP')
+        name = 'Normal Map Type',
+        description = 'Normal map type of this layer',
+        items = get_normal_map_type_items
+    )
 
     use_udim_detecting : BoolProperty(
-            name = 'Detect UDIMs',
-            description = 'Detect selected UDIM files and load all matching tiles.',
-            default = True)
+        name = 'Detect UDIMs',
+        description = 'Detect selected UDIM files and load all matching tiles.',
+        default = True
+    )
 
     uv_map_coll : CollectionProperty(type=bpy.types.PropertyGroup)
 
@@ -2657,8 +2748,10 @@ class YOpenImageToLayer(bpy.types.Operator, ImportHelper):
             bpy.context.area.type = 'IMAGE_EDITOR'
             images = []
             for path in import_list:
-                bpy.ops.image.open(filepath=directory+os.sep+path, directory=directory, 
-                        relative_path=self.relative, use_udim_detecting=self.use_udim_detecting)
+                bpy.ops.image.open(
+                    filepath=directory + os.sep + path, directory=directory, 
+                    relative_path=self.relative, use_udim_detecting=self.use_udim_detecting
+                )
                 image = bpy.context.space_data.image
                 if image not in images:
                     images.append(image)
@@ -2671,11 +2764,11 @@ class YOpenImageToLayer(bpy.types.Operator, ImportHelper):
                 try: image.filepath = bpy.path.relpath(image.filepath)
                 except: pass
 
-            add_new_layer(node.node_tree, image.name, 'IMAGE', int(self.channel_idx), self.blend_type, 
-                    self.normal_blend_type, self.normal_map_type, self.texcoord_type, self.uv_map,
-                    image, None, None,
-                    interpolation=self.interpolation
-                    )
+            add_new_layer(
+                node.node_tree, image.name, 'IMAGE', int(self.channel_idx), self.blend_type, 
+                self.normal_blend_type, self.normal_map_type, self.texcoord_type, self.uv_map,
+                image, None, None, interpolation=self.interpolation
+            )
 
         node.node_tree.yp.halt_update = False
 
@@ -2815,10 +2908,13 @@ class YOpenAvailableDataToOverrideChannel(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     type : EnumProperty(
-            name = 'Layer Type',
-            items = (('IMAGE', 'Image', ''),
-                ('VCOL', 'Vertex Color', '')),
-            default = 'IMAGE')
+        name = 'Layer Type',
+        items = (
+            ('IMAGE', 'Image', ''),
+            ('VCOL', 'Vertex Color', '')
+        ),
+        default = 'IMAGE'
+    )
 
     image_name : StringProperty(name="Image")
     image_coll : CollectionProperty(type=bpy.types.PropertyGroup)
@@ -2992,46 +3088,54 @@ class YOpenAvailableDataToLayer(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     type : EnumProperty(
-            name = 'Layer Type',
-            items = (('IMAGE', 'Image', ''),
-                ('VCOL', 'Vertex Color', '')),
-            default = 'IMAGE')
+        name = 'Layer Type',
+        items = (
+            ('IMAGE', 'Image', ''),
+            ('VCOL', 'Vertex Color', '')
+        ),
+        default = 'IMAGE'
+    )
 
     interpolation : EnumProperty(
-            name = 'Image Interpolation Type',
-            description = 'Image interpolation type',
-            items = interpolation_type_items,
-            default = 'Linear')
+        name = 'Image Interpolation Type',
+        description = 'Image interpolation type',
+        items = interpolation_type_items,
+        default = 'Linear'
+    )
 
     texcoord_type : EnumProperty(
-            name = 'Layer Coordinate Type',
-            description = 'Layer Coordinate Type',
-            items = texcoord_type_items,
-            default = 'UV')
+        name = 'Layer Coordinate Type',
+        description = 'Layer Coordinate Type',
+        items = texcoord_type_items,
+        default = 'UV'
+    )
 
     uv_map : StringProperty(default='')
 
     channel_idx : EnumProperty(
-            name = 'Channel',
-            description = 'Channel of new layer, can be changed later',
-            items = channel_items,
-            update=update_channel_idx_new_layer)
+        name = 'Channel',
+        description = 'Channel of new layer, can be changed later',
+        items = channel_items,
+        update = update_channel_idx_new_layer
+    )
 
     blend_type : EnumProperty(
         name = 'Blend',
         items = blend_type_items,
-        default = 'MIX')
+        default = 'MIX'
+    )
 
     normal_blend_type : EnumProperty(
-            name = 'Normal Blend Type',
-            items = normal_blend_items,
-            default = 'MIX')
+        name = 'Normal Blend Type',
+        items = normal_blend_items,
+        default = 'MIX'
+    )
 
     normal_map_type : EnumProperty(
-            name = 'Normal Map Type',
-            description = 'Normal map type of this layer',
-            items = get_normal_map_type_items)
-            #default = 'BUMP_MAP')
+        name = 'Normal Map Type',
+        description = 'Normal map type of this layer',
+        items = get_normal_map_type_items
+    )
 
     image_name : StringProperty(name="Image")
     image_coll : CollectionProperty(type=bpy.types.PropertyGroup)
@@ -3169,11 +3273,11 @@ class YOpenAvailableDataToLayer(bpy.types.Operator):
                     else: set_obj_vertex_colors(o, other_v.name, (0.0, 0.0, 0.0, 1.0))
                     set_active_vertex_color(o, other_v)
 
-        add_new_layer(node.node_tree, name, self.type, int(self.channel_idx), self.blend_type, 
-                self.normal_blend_type, self.normal_map_type, self.texcoord_type, self.uv_map, 
-                image, vcol, None, 
-                interpolation = self.interpolation
-                )
+        add_new_layer(
+            node.node_tree, name, self.type, int(self.channel_idx), self.blend_type, 
+            self.normal_blend_type, self.normal_map_type, self.texcoord_type, self.uv_map, 
+            image, vcol, None, interpolation=self.interpolation
+        )
 
         node.node_tree.yp.halt_update = False
 
@@ -3199,10 +3303,13 @@ class YMoveInOutLayerGroup(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     direction : EnumProperty(
-            name = 'Direction',
-            items = (('UP', 'Up', ''),
-                     ('DOWN', 'Down', '')),
-            default = 'UP')
+        name = 'Direction',
+        items = (
+            ('UP', 'Up', ''),
+            ('DOWN', 'Down', '')
+        ),
+        default = 'UP'
+    )
 
     @classmethod
     def poll(cls, context):
@@ -3321,10 +3428,13 @@ class YMoveLayer(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     direction : EnumProperty(
-            name = 'Direction',
-            items = (('UP', 'Up', ''),
-                     ('DOWN', 'Down', '')),
-            default = 'UP')
+        name = 'Direction',
+        items = (
+            ('UP', 'Up', ''),
+            ('DOWN', 'Down', '')
+        ),
+        default = 'UP'
+    )
 
     @classmethod
     def poll(cls, context):
@@ -3378,7 +3488,7 @@ class YMoveLayer(bpy.types.Operator):
 
                 # Swap layer
                 yp.layers.move(neighbor_idx, layer_idx)
-                yp.active_layer_index = layer_idx+1
+                yp.active_layer_index = layer_idx + 1
 
         elif layer.type == 'GROUP' and neighbor_layer.type == 'GROUP':
 
@@ -3387,8 +3497,8 @@ class YMoveLayer(bpy.types.Operator):
                 #print('Case C')
 
                 # Swap all related layers
-                for i in range(last_member_idx+1 - layer_idx):
-                    yp.layers.move(layer_idx+i, neighbor_idx+i)
+                for i in range(last_member_idx + 1 - layer_idx):
+                    yp.layers.move(layer_idx + i, neighbor_idx + i)
 
                 yp.active_layer_index = neighbor_idx
 
@@ -3397,13 +3507,13 @@ class YMoveLayer(bpy.types.Operator):
                 #print('Case D')
 
                 last_neighbor_member_idx = get_last_child_idx(neighbor_layer)
-                num_members = last_neighbor_member_idx+1 - neighbor_idx
+                num_members = last_neighbor_member_idx + 1 - neighbor_idx
 
                 # Swap all related layers
                 for i in range(num_members):
-                    yp.layers.move(neighbor_idx+i, layer_idx+i)
+                    yp.layers.move(neighbor_idx + i, layer_idx + i)
 
-                yp.active_layer_index = layer_idx+num_members
+                yp.active_layer_index = layer_idx + num_members
 
         elif layer.type != 'GROUP' and neighbor_layer.type == 'GROUP':
 
@@ -3490,10 +3600,13 @@ class YMoveInOutLayerGroupMenu(bpy.types.Operator):
     #bl_options = {'REGISTER', 'UNDO'}
 
     direction : EnumProperty(
-            name = 'Direction',
-            items = (('UP', 'Up', ''),
-                     ('DOWN', 'Down', '')),
-            default = 'UP')
+        name = 'Direction',
+        items = (
+            ('UP', 'Up', ''),
+            ('DOWN', 'Down', '')
+        ),
+        default = 'UP'
+    )
 
     move_out : BoolProperty(default=False)
 
@@ -4111,9 +4224,10 @@ class YReplaceLayerChannelOverride(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     type : EnumProperty(
-            name = 'Layer Type',
-            items = channel_override_type_items,
-            default = 'IMAGE')
+        name = 'Layer Type',
+        items = channel_override_type_items,
+        default = 'IMAGE'
+    )
 
     @classmethod
     def poll(cls, context):
@@ -4134,9 +4248,10 @@ class YReplaceLayerChannelOverride1(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     type : EnumProperty(
-            name = 'Layer Type',
-            items = channel_override_1_type_items,
-            default = 'IMAGE')
+        name = 'Layer Type',
+        items = channel_override_1_type_items,
+        default = 'IMAGE'
+    )
 
     @classmethod
     def poll(cls, context):
@@ -4197,9 +4312,10 @@ class YReplaceLayerType(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     type : EnumProperty(
-            name = 'Layer Type',
-            items = layer_type_items,
-            default = 'IMAGE')
+        name = 'Layer Type',
+        items = layer_type_items,
+        default = 'IMAGE'
+    )
 
     item_name : StringProperty(name="Item")
     item_coll : CollectionProperty(type=bpy.types.PropertyGroup)
@@ -4506,8 +4622,11 @@ def duplicate_layer_nodes_and_images(tree, specific_layer=None, packed_duplicate
 
             # create new segment based on previous one
             if duplicate_blank:
-                new_segment = UDIM.get_set_udim_atlas_segment(tilenums, color=img.yui.base_color, 
-                        colorspace=img.colorspace_settings.name, hdr=img.is_float, yp=yp) #, source_image=img)
+                new_segment = UDIM.get_set_udim_atlas_segment(
+                    tilenums, color=img.yui.base_color,
+                    colorspace = img.colorspace_settings.name,
+                    hdr=img.is_float, yp=yp
+                )
 
             # If using different image atlas per yp, just copy the image (unless specific layer is on)
             elif not specific_layer:
@@ -4516,9 +4635,12 @@ def duplicate_layer_nodes_and_images(tree, specific_layer=None, packed_duplicate
                 img_nodes[i].image = copied_image_atlas[img.name]
 
             else:
-                new_segment = UDIM.get_set_udim_atlas_segment(tilenums, color=img.yui.base_color, 
-                        colorspace=img.colorspace_settings.name, hdr=img.is_float, yp=yp, 
-                        source_image=img, source_tilenums=segment_tilenums)
+                new_segment = UDIM.get_set_udim_atlas_segment(
+                    tilenums, color=img.yui.base_color, 
+                    colorspace = img.colorspace_settings.name,
+                    hdr=img.is_float, yp=yp, 
+                    source_image=img, source_tilenums=segment_tilenums
+                )
 
             if new_segment:
 
@@ -4545,18 +4667,18 @@ def duplicate_layer_nodes_and_images(tree, specific_layer=None, packed_duplicate
                     mask_idx = int(m.group(2))
                     mask = img_users[i]
 
-                    color = (0,0,0,1)
+                    color = (0, 0, 0, 1)
                     if is_bl_newer_than(2, 83):
                         # Check average value of the image using numpy
-                        pxs = numpy.empty(shape=img.size[0]*img.size[1]*4, dtype=numpy.float32)
+                        pxs = numpy.empty(shape=img.size[0] * img.size[1] * 4, dtype=numpy.float32)
                         img.pixels.foreach_get(pxs)
                         if numpy.average(pxs) > 0.5:
-                            color = (1,1,1,1)
+                            color = (1, 1, 1, 1)
                     else:
                         # Set Mask color based on the index and blend type
                         if mask_idx > 0 and mask.blend_type not in {'ADD'}:
-                            color = (1,1,1,1)
-                else: color = (0,0,0,0)
+                            color = (1, 1, 1, 1)
+                else: color = (0, 0, 0, 0)
 
                 img_name = get_unique_name(img.name, bpy.data.images)
 
@@ -4566,8 +4688,10 @@ def duplicate_layer_nodes_and_images(tree, specific_layer=None, packed_duplicate
                     UDIM.fill_tiles(img_nodes[i].image, color)
                     UDIM.initial_pack_udim(img_nodes[i].image, color)
                 else:
-                    img_nodes[i].image = bpy.data.images.new(img_name,
-                            width=img.size[0], height=img.size[1], alpha=alpha, float_buffer=img.is_float)
+                    img_nodes[i].image = bpy.data.images.new(
+                        img_name, width=img.size[0], height=img.size[1],
+                        alpha=alpha, float_buffer=img.is_float
+                    )
                     img_nodes[i].image.generated_color = color
 
                 img_nodes[i].image.colorspace_settings.name = img.colorspace_settings.name
@@ -4588,28 +4712,28 @@ class YDuplicateLayer(bpy.types.Operator):
     bl_options = {'UNDO'}
 
     packed_duplicate : BoolProperty(
-            name = 'Duplicate Packed Images',
-            description = 'Duplicate packed images',
-            default = True
-            )
+        name = 'Duplicate Packed Images',
+        description = 'Duplicate packed images',
+        default = True
+    )
 
     duplicate_blank : BoolProperty(
-            name = 'Make Duplicated Images blank',
-            description = 'Make duplicated images blank',
-            default = False
-            )
+        name = 'Make Duplicated Images blank',
+        description = 'Make duplicated images blank',
+        default = False
+    )
 
     ondisk_duplicate : BoolProperty(
-            name = 'Duplicate Images on disk',
-            description = 'Duplicate images on disk, this will create copies of images sourced from external files',
-            default = False
-            )
+        name = 'Duplicate Images on disk',
+        description = 'Duplicate images on disk, this will create copies of images sourced from external files',
+        default = False
+    )
     
     set_new_decal_position : BoolProperty(
-            name = 'Set New Decal Position to Cursor',
-            description = 'Position decals at 3D Cursor when duplicating',
-            default = False
-            )
+        name = 'Set New Decal Position to Cursor',
+        description = 'Position decals at 3D Cursor when duplicating',
+        default = False
+    )
 
     @classmethod
     def poll(cls, context):
@@ -4710,11 +4834,13 @@ class YDuplicateLayer(bpy.types.Operator):
                 source_inp = source_node.inputs.get(inp.name)
                 if source_inp: inp.default_value = source_inp.default_value
 
-            duplicate_layer_nodes_and_images(tree, new_layer, 
-                                             packed_duplicate = self.packed_duplicate or self.duplicate_blank,
-                                             duplicate_blank = self.duplicate_blank,
-                                             ondisk_duplicate=self.ondisk_duplicate or self.duplicate_blank,
-                                             set_new_decal_position=self.set_new_decal_position)
+            duplicate_layer_nodes_and_images(
+                tree, new_layer, 
+                packed_duplicate = self.packed_duplicate or self.duplicate_blank,
+                duplicate_blank = self.duplicate_blank,
+                ondisk_duplicate = self.ondisk_duplicate or self.duplicate_blank,
+                set_new_decal_position = self.set_new_decal_position
+            )
 
             # Rename masks
             mask_names = [m.name for m in l.masks]
@@ -4770,9 +4896,10 @@ class YCopyLayer(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     all_layers : BoolProperty(
-            name='Copy All Layers',
-            description='Copy all layers instead of only the active one',
-            default = False)
+        name = 'Copy All Layers',
+        description = 'Copy all layers instead of only the active one',
+        default = False
+    )
 
     @classmethod
     def poll(cls, context):
@@ -4798,22 +4925,22 @@ class YPasteLayer(bpy.types.Operator):
     bl_options = {'UNDO'}
 
     packed_duplicate : BoolProperty(
-            name = 'Duplicate Packed Images',
-            description = 'Duplicate packed images',
-            default = True
-            )
+        name = 'Duplicate Packed Images',
+        description = 'Duplicate packed images',
+        default = True
+    )
 
     ondisk_duplicate : BoolProperty(
-            name = 'Duplicate Images on disk',
-            description = 'Duplicate images on disk, this will create copies of images sourced from external files',
-            default = False
-            )
+        name = 'Duplicate Images on disk',
+        description = 'Duplicate images on disk, this will create copies of images sourced from external files',
+        default = False
+    )
     
     set_new_decal_position : BoolProperty(
-            name = 'Set New Decal Position to Cursor',
-            description = 'Position decals at 3D Cursor when duplicating',
-            default = False
-            )
+        name = 'Set New Decal Position to Cursor',
+        description = 'Position decals at 3D Cursor when duplicating',
+        default = False
+    )
 
     @classmethod
     def poll(cls, context):
@@ -4966,10 +5093,12 @@ class YPasteLayer(bpy.types.Operator):
                 if source_inp: inp.default_value = source_inp.default_value
 
             # Duplicate images and some nodes inside
-            duplicate_layer_nodes_and_images(tree, new_layer, 
-                                            packed_duplicate = self.packed_duplicate,
-                                            ondisk_duplicate=self.ondisk_duplicate,
-                                            set_new_decal_position=self.set_new_decal_position)
+            duplicate_layer_nodes_and_images(
+                tree, new_layer, 
+                packed_duplicate = self.packed_duplicate,
+                ondisk_duplicate = self.ondisk_duplicate,
+                set_new_decal_position = self.set_new_decal_position
+            )
 
             pasted_layer_names.append(new_layer.name)
 
@@ -5367,14 +5496,18 @@ def update_uv_name(self, context):
     # Update uv neighbor
     smooth_bump_ch = get_smooth_bump_channel(layer)
     if smooth_bump_ch and smooth_bump_ch.enable and (smooth_bump_ch.normal_map_type in {'BUMP_MAP', 'BUMP_NORMAL_MAP'} or smooth_bump_ch.enable_transition_bump):
-        uv_neighbor = replace_new_node(tree, layer, 'uv_neighbor', 'ShaderNodeGroup', 'Neighbor UV', 
-                lib.get_neighbor_uv_tree_name(layer.texcoord_type, entity=layer), 
-                return_status=False, hard_replace=True)
+        uv_neighbor = replace_new_node(
+            tree, layer, 'uv_neighbor', 'ShaderNodeGroup', 'Neighbor UV', 
+            lib.get_neighbor_uv_tree_name(layer.texcoord_type, entity=layer), 
+            return_status=False, hard_replace=True
+        )
         set_uv_neighbor_resolution(layer, uv_neighbor)
         if smooth_bump_ch.override and smooth_bump_ch.override_type != 'DEFAULT':
-            uv_neighbor = replace_new_node(tree, smooth_bump_ch, 'uv_neighbor', 'ShaderNodeGroup', 'Neighbor UV', 
-                    lib.get_neighbor_uv_tree_name(layer.texcoord_type, entity=layer), 
-                    return_status=False, hard_replace=True)
+            uv_neighbor = replace_new_node(
+                tree, smooth_bump_ch, 'uv_neighbor', 'ShaderNodeGroup', 'Neighbor UV', 
+                lib.get_neighbor_uv_tree_name(layer.texcoord_type, entity=layer), 
+                return_status=False, hard_replace=True
+            )
             set_uv_neighbor_resolution(smooth_bump_ch, uv_neighbor)
 
         # Update neighbor uv if mask bump is active
@@ -5416,12 +5549,16 @@ def update_texcoord_type(self, context):
     # Update uv neighbor
     smooth_bump_ch = get_smooth_bump_channel(layer)
     if smooth_bump_ch and smooth_bump_ch.enable and (smooth_bump_ch.normal_map_type in {'BUMP_MAP', 'BUMP_NORMAL_MAP'} or smooth_bump_ch.enable_transition_bump):
-        uv_neighbor = replace_new_node(tree, layer, 'uv_neighbor', 'ShaderNodeGroup', 'Neighbor UV', 
-                lib.get_neighbor_uv_tree_name(layer.texcoord_type, entity=layer), hard_replace=True)
+        uv_neighbor = replace_new_node(
+            tree, layer, 'uv_neighbor', 'ShaderNodeGroup', 'Neighbor UV', 
+            lib.get_neighbor_uv_tree_name(layer.texcoord_type, entity=layer), hard_replace=True
+        )
         set_uv_neighbor_resolution(layer, uv_neighbor)
         if smooth_bump_ch.override and smooth_bump_ch.override_type != 'DEFAULT':
-            uv_neighbor = replace_new_node(tree, smooth_bump_ch, 'uv_neighbor', 'ShaderNodeGroup', 'Neighbor UV', 
-                    lib.get_neighbor_uv_tree_name(layer.texcoord_type, entity=layer), hard_replace=True)
+            uv_neighbor = replace_new_node(
+                tree, smooth_bump_ch, 'uv_neighbor', 'ShaderNodeGroup', 'Neighbor UV', 
+                lib.get_neighbor_uv_tree_name(layer.texcoord_type, entity=layer), hard_replace=True
+            )
             set_uv_neighbor_resolution(smooth_bump_ch, uv_neighbor)
 
     # Update layer tree inputs
@@ -5458,8 +5595,10 @@ def update_hemi_camera_ray_mask(self, context):
 
         # Check if source has the inputs, if not reload the node
         if 'Camera Ray Mask' not in source.inputs:
-            source = replace_new_node(tree, self, 'source', 'ShaderNodeGroup', 'Source', 
-                    lib.HEMI, force_replace=True)
+            source = replace_new_node(
+                tree, self, 'source', 'ShaderNodeGroup', 'Source', 
+                lib.HEMI, force_replace=True
+            )
             duplicate_lib_node_tree(source)
             trans = source.node_tree.nodes.get('Vector Transform')
             if trans: trans.convert_from = self.hemi_space
@@ -5694,58 +5833,68 @@ def update_channel_active_edit(self, context):
 
 class YLayerChannel(bpy.types.PropertyGroup):
     enable : BoolProperty(
-            name = 'Enable Layer Channel',
-            description = 'Enable layer channel',
-            default=True, update=update_channel_enable)
+        name = 'Enable Layer Channel',
+        description = 'Enable layer channel',
+        default = True,
+        update = update_channel_enable
+    )
 
     layer_input : EnumProperty(
-            name = 'Layer Input',
-            description = 'Input for layer channel',
-            items = entity_input_items,
-            update = update_layer_input)
+        name = 'Layer Input',
+        description = 'Input for layer channel',
+        items = entity_input_items,
+        update = update_layer_input
+    )
 
     gamma_space : BoolProperty(
-            name='Gamma Space',
-            description='Make sure layer input is in linear space',
-            default = False,
-            update = update_layer_input)
+        name = 'Gamma Space',
+        description = 'Make sure layer input is in linear space',
+        default = False,
+        update = update_layer_input
+    )
 
     use_clamp : BoolProperty(
-            name = 'Use Clamp',
-            description = 'Clamp result to 0..1 range',
-            default = False,
-            update=update_layer_channel_use_clamp)
+        name = 'Use Clamp',
+        description = 'Clamp result to 0..1 range',
+        default = False,
+        update = update_layer_channel_use_clamp
+    )
 
     normal_map_type : EnumProperty(
-            name = 'Normal Map Type',
-            items = get_normal_map_type_items,
-            #default = 'BUMP_MAP',
-            update = update_normal_map_type)
+        name = 'Normal Map Type',
+        items = get_normal_map_type_items,
+        #default = 'BUMP_MAP',
+        update = update_normal_map_type
+    )
 
     blend_type : EnumProperty(
-            name = 'Blend',
-            description = 'Blend type of layer channel',
-            items = blend_type_items,
-            default = 'MIX',
-            update = update_blend_type)
+        name = 'Blend',
+        description = 'Blend type of layer channel',
+        items = blend_type_items,
+        default = 'MIX',
+        update = update_blend_type
+    )
 
     normal_blend_type : EnumProperty(
-            name = 'Normal Blend Type',
-            description = 'Blend type of layer normal channel',
-            items = normal_blend_items,
-            default = 'MIX',
-            update = update_blend_type)
+        name = 'Normal Blend Type',
+        description = 'Blend type of layer normal channel',
+        items = normal_blend_items,
+        default = 'MIX',
+        update = update_blend_type
+    )
 
     height_blend_type : EnumProperty(
-            name = 'Height Blend Type',
-            items = normal_blend_items,
-            default = 'MIX',
-            update = update_blend_type)
+        name = 'Height Blend Type',
+        items = normal_blend_items,
+        default = 'MIX',
+        update = update_blend_type
+    )
 
     intensity_value : FloatProperty(
-            name = 'Layer Channel Opacity', 
-            description = 'Layer channel opacity',
-            default=1.0, min=0.0, max=1.0, subtype='FACTOR', precision=3)
+        name = 'Layer Channel Opacity', 
+        description = 'Layer channel opacity',
+        default=1.0, min=0.0, max=1.0, subtype='FACTOR', precision=3
+    )
 
     # Modifiers
     modifiers : CollectionProperty(type=Modifier.YPaintModifier)
@@ -5753,39 +5902,67 @@ class YLayerChannel(bpy.types.PropertyGroup):
 
     # Override source
     override : BoolProperty(
-            name = 'Enable Override',
-            description = 'Use override value rather than layer value for this channel',
-            default=False, update=update_layer_channel_override)
-    override_type : EnumProperty(items=channel_override_type_items, default='DEFAULT', update=update_layer_channel_override)
+        name = 'Enable Override',
+        description = 'Use override value rather than layer value for this channel',
+        default = False,
+        update = update_layer_channel_override
+    )
+
+    override_type : EnumProperty(
+        items = channel_override_type_items,
+        default = 'DEFAULT',
+        update = update_layer_channel_override
+    )
+
     override_color : FloatVectorProperty(
-            name = 'Override Color',
-            description = 'Override color value for this channel',
-            subtype='COLOR', size=3, min=0.0, max=1.0, default=(0.5, 0.5, 0.5))
+        name = 'Override Color',
+        description = 'Override color value for this channel',
+        subtype='COLOR', size=3, min=0.0, max=1.0, default=(0.5, 0.5, 0.5)
+    )
+
     override_value : FloatProperty(
-            name = 'Override Value',
-            description = 'Override value for this channel',
-            min=0.0, max=1.0, default=1.0)
-    override_vcol_name : StringProperty(name='Vertex Color Name', description='Channel override vertex color name', default='', update=update_layer_channel_override_vcol_name)
+        name = 'Override Value',
+        description = 'Override value for this channel',
+        min=0.0, max=1.0, default=1.0
+    )
+
+    override_vcol_name : StringProperty(
+        name = 'Vertex Color Name',
+        description = 'Channel override vertex color name',
+        default = '',
+        update = update_layer_channel_override_vcol_name
+    )
 
     # Specific for voronoi
     voronoi_feature : EnumProperty(
-            name = 'Voronoi Feature',
-            description = 'The voronoi feature that will be used for compute',
-            items = voronoi_feature_items,
-            default = 'F1',
-            update = update_layer_channel_voronoi_feature
-            )
+        name = 'Voronoi Feature',
+        description = 'The voronoi feature that will be used for compute',
+        items = voronoi_feature_items,
+        default = 'F1',
+        update = update_layer_channel_voronoi_feature
+    )
 
     # Extra override needed when bump and normal are used at the same time
     override_1 : BoolProperty(
-            name = 'Enable Override (Normal Map Channel)',
-            description = 'Use override value rather than layer value for normal map of this channel',
-            default=False, update=update_layer_channel_override_1)
-    override_1_type : EnumProperty(items=channel_override_1_type_items, default='DEFAULT', update=update_layer_channel_override_1)
+        name = 'Enable Override (Normal Map Channel)',
+        description = 'Use override value rather than layer value for normal map of this channel',
+        default = False,
+        update = update_layer_channel_override_1
+    )
+
+    override_1_type : EnumProperty(
+        items = channel_override_1_type_items,
+        default = 'DEFAULT',
+        update = update_layer_channel_override_1
+    )
+
     override_1_color : FloatVectorProperty(
-            name = 'Override Color',
-            description = 'Override color value for normal map of this channel',
-            subtype='COLOR', size=3, min=0.0, max=1.0, default=(0.5, 0.5, 1.0))
+        name = 'Override Color',
+        description = 'Override color value for normal map of this channel',
+        subtype = 'COLOR',
+        size = 3,
+        default=(0.5, 0.5, 1.0), min=0.0, max=1.0
+    )
 
     # Sources
     source : StringProperty(default='')
@@ -5844,57 +6021,68 @@ class YLayerChannel(bpy.types.PropertyGroup):
     normal_flip : StringProperty(default='')
 
     bump_distance : FloatProperty(
-            name='Bump Height Range', 
-            description= 'Bump height range.\n(White equals this value, black equals negative of this value)', 
-            default=0.05, min=-1.0, max=1.0, precision=3) #, # step=1,
+        name = 'Bump Height Range', 
+        description = 'Bump height range.\n(White equals this value, black equals negative of this value)', 
+        default=0.05, min=-1.0, max=1.0, precision=3
+    )
 
     bump_midlevel : FloatProperty(
-            name='Bump Midlevel', 
-            description= 'Neutral bump value that causes no bump',
-            default=0.5, min=0.0, max=1.0, precision=3) 
+        name = 'Bump Midlevel', 
+        description = 'Neutral bump value that causes no bump',
+        default=0.5, min=0.0, max=1.0, precision=3
+    )
 
     bump_smooth_multiplier : FloatProperty(
         name = 'Smooth Bump Step Multiplier',
         description = 'Multiply the smooth bump step.\n(The default step is based on image resolution or 1000 for generated blender texture)',
-        default=1.0, min=0.1, max=10.0, precision=3)
+        default=1.0, min=0.1, max=10.0, precision=3
+    )
 
     normal_bump_distance : FloatProperty(
-            name='Bump Height Range for normal', 
-            description= 'Bump height range for normal channel.\n(White equals this value, black equals negative of this value)', 
-            default=0.00, min=-1.0, max=1.0, precision=3) #, # step=1,
+        name = 'Bump Height Range for normal', 
+        description = 'Bump height range for normal channel.\n(White equals this value, black equals negative of this value)', 
+        default=0.00, min=-1.0, max=1.0, precision=3
+    )
 
     write_height : BoolProperty(
-            name = 'Write Height',
-            description = 'Write height for this layer channel',
-            default = True,
-            update=update_write_height)
+        name = 'Write Height',
+        description = 'Write height for this layer channel',
+        default = True,
+        update = update_write_height
+    )
 
     normal_write_height : BoolProperty(
-            name = 'Write Normal Height',
-            description = 'Write height for this normal layer channel',
-            default = False,
-            update=update_write_height)
+        name = 'Write Normal Height',
+        description = 'Write height for this normal layer channel',
+        default = False,
+        update = update_write_height
+    )
 
     normal_strength : FloatProperty(
         name = 'Normal Strength',
         description = 'Normal strength',
-        default=1.0, min=0.0, max=100.0, precision=3)
+        default=1.0, min=0.0, max=100.0, precision=3
+    )
 
     vdisp_strength : FloatProperty(
         name = 'Vector Displacement Strength',
         description = 'Normal strength',
-        default=1.0, min=-10.0, max=10.0, precision=3)
+        default=1.0, min=-10.0, max=10.0, precision=3
+    )
 
     vdisp_enable_flip_yz : BoolProperty(
         name = 'Vector Displacement Flip YZ Channel',
         description = 'Flip YZ channel value (Compatibility for blender vector displacement standard)',
-        default=True, update=update_layer_channel_vdisp_flip_yz)
+        default = True,
+        update = update_layer_channel_vdisp_flip_yz
+    )
 
     image_flip_y : BoolProperty(
-            name = 'Image Flip Y',
-            description = "Image Flip Y (Use this if you're using normal map created for DirectX application) ",
-            default = False,
-            update=update_image_flip_y)
+        name = 'Image Flip Y',
+        description = "Image Flip Y (Use this if you're using normal map created for DirectX application)",
+        default = False,
+        update = update_image_flip_y
+    )
 
     # For some occasion, modifiers are stored in a tree
     mod_group : StringProperty(default='')
@@ -5910,91 +6098,112 @@ class YLayerChannel(bpy.types.PropertyGroup):
     intensity_multiplier : StringProperty(default='')
 
     # Transition bump related
-    enable_transition_bump : BoolProperty(name='Enable Transition Bump', description='Enable transition bump',
-            default=False, update=transition.update_enable_transition_bump)
+    enable_transition_bump : BoolProperty(
+        name = 'Enable Transition Bump',
+        description = 'Enable transition bump',
+        default = False,
+        update = transition.update_enable_transition_bump
+    )
 
-    show_transition_bump : BoolProperty(name='Toggle Transition Bump',
-            description = "Toggle transition Bump (This will affect other channels)", 
-            default=False) #, update=transition.update_show_transition_bump)
+    show_transition_bump : BoolProperty(
+        name = 'Toggle Transition Bump',
+        description = "Toggle transition Bump (This will affect other channels)", 
+        default = False
+    )
 
     transition_bump_value : FloatProperty(
         name = 'Transition Bump Value',
         description = 'Transition bump value',
-        default=3.0, min=1.0, max=100.0, precision=3)
+        default=3.0, min=1.0, max=100.0, precision=3
+    )
 
     transition_bump_second_edge_value : FloatProperty(
-            name = 'Second Edge Intensity', 
-            description = 'Second Edge intensity value',
-            default=1.2, min=1.0, max=100.0, precision=3)
+        name = 'Second Edge Intensity', 
+        description = 'Second Edge intensity value',
+        default=1.2, min=1.0, max=100.0, precision=3
+    )
 
     transition_bump_distance : FloatProperty(
-            #name='Transition Bump Distance', 
-            #description= 'Distance of mask bump', 
-            name='Transition Bump Height Range', 
-            description= 'Transition bump height range.\n(White equals this value, black equals negative of this value)', 
-            default=0.05, min=0.0, max=1.0, precision=3) # step=1,
+        #name='Transition Bump Distance', 
+        #description= 'Distance of mask bump', 
+        name = 'Transition Bump Height Range', 
+        description = 'Transition bump height range.\n(White equals this value, black equals negative of this value)', 
+        default=0.05, min=0.0, max=1.0, precision=3
+    )
 
     transition_bump_chain : IntProperty(
-            name = 'Transition bump chain',
-            description = 'Number of mask affected by transition bump',
-            default=10, min=0, max=10,
-            update=transition.update_transition_bump_chain)
+        name = 'Transition bump chain',
+        description = 'Number of mask affected by transition bump',
+        default=10, min=0, max=10,
+        update = transition.update_transition_bump_chain
+    )
 
     transition_bump_flip : BoolProperty(
-            name = 'Transition Bump Flip',
-            description = 'Transition bump flip',
-            default=False,
-            update=transition.update_enable_transition_bump)
+        name = 'Transition Bump Flip',
+        description = 'Transition bump flip',
+        default = False,
+        update = transition.update_enable_transition_bump
+    )
 
     transition_bump_curved_offset : FloatProperty(
-            name = 'Transition Bump Curved Offst',
-            description = 'Transition bump curved offset',
-            default=0.02, min=0.0, max=0.1,
-            update=transition.update_transition_bump_curved_offset)
+        name = 'Transition Bump Curved Offst',
+        description = 'Transition bump curved offset',
+        default=0.02, min=0.0, max=0.1,
+        update = transition.update_transition_bump_curved_offset
+    )
 
     transition_bump_crease : BoolProperty(
-            name = 'Transition Bump Crease',
-            description = 'Transition bump crease (only works if flip is inactive)',
-            default=False,
-            update=transition.update_enable_transition_bump)
+        name = 'Transition Bump Crease',
+        description = 'Transition bump crease (only works if flip is inactive)',
+        default = False,
+        update = transition.update_enable_transition_bump
+    )
 
     transition_bump_crease_factor : FloatProperty(
-            name = 'Transition Bump Crease Factor',
-            description = 'Transition bump crease factor',
-            default=0.33, min=0.0, max=1.0, subtype='FACTOR', precision=3)
+        name = 'Transition Bump Crease Factor',
+        description = 'Transition bump crease factor',
+        default=0.33, min=0.0, max=1.0, subtype='FACTOR', precision=3
+    )
 
     transition_bump_crease_power : FloatProperty(
-            name = 'Transition Bump Crease Power',
-            description = 'Transition Bump Crease Power',
-            default=5.0, min=1.0, max=100.0, precision=3)
+        name = 'Transition Bump Crease Power',
+        description = 'Transition Bump Crease Power',
+        default=5.0, min=1.0, max=100.0, precision=3
+    )
 
     transition_bump_fac : FloatProperty(
-            name='Transition Bump Factor',
-            description = 'Transition bump factor',
-            default=1.0, min=0.0, max=1.0, subtype='FACTOR', precision=3)
+        name = 'Transition Bump Factor',
+        description = 'Transition bump factor',
+        default=1.0, min=0.0, max=1.0, subtype='FACTOR', precision=3
+    )
 
     transition_bump_second_fac : FloatProperty(
-            name='Transition Bump Second Factor',
-            description = 'Transition bump second factor',
-            default=1.0, min=0.0, max=1.0, subtype='FACTOR', precision=3)
+        name = 'Transition Bump Second Factor',
+        description = 'Transition bump second factor',
+        default=1.0, min=0.0, max=1.0, subtype='FACTOR', precision=3
+    )
 
     transition_bump_falloff : BoolProperty(
-            name = 'Transition Bump Falloff',
-            default = False, update=transition.update_enable_transition_bump)
+        name = 'Transition Bump Falloff',
+        default = False,
+        update = transition.update_enable_transition_bump
+    )
 
     transition_bump_falloff_type : EnumProperty(
-            name = 'Transition Bump Falloff Type',
-            items = (
-                ('EMULATED_CURVE', 'Emulated Curve', ''),
-                ('CURVE', 'Curve', ''),
-                ),
-            default = 'EMULATED_CURVE',
-            update=transition.update_enable_transition_bump)
+        name = 'Transition Bump Falloff Type',
+        items = (
+            ('EMULATED_CURVE', 'Emulated Curve', ''),
+            ('CURVE', 'Curve', ''),
+        ),
+        default = 'EMULATED_CURVE',
+        update = transition.update_enable_transition_bump
+    )
 
     transition_bump_falloff_emulated_curve_fac : FloatProperty(
-            name='Transition Bump Falloff Emulated Curve Factor',
-            description = 'Transition bump curve emulated curve factor',
-            default=1.0, min=-1.0, max=1.0, subtype='FACTOR', precision=3)
+        name = 'Transition Bump Falloff Emulated Curve Factor',
+        description = 'Transition bump curve emulated curve factor',
+        default=1.0, min=-1.0, max=1.0, subtype='FACTOR', precision=3
+    )
 
     tb_bump : StringProperty(default='')
     tb_bump_flip : StringProperty(default='')
@@ -6011,29 +6220,38 @@ class YLayerChannel(bpy.types.PropertyGroup):
     #tb_falloff_w : StringProperty(default='')
 
     # Transition ramp related
-    enable_transition_ramp : BoolProperty(name='Enable Transition Ramp', description='Enable alpha transition ramp', 
-            default=False, update=transition.update_enable_transition_ramp)
+    enable_transition_ramp : BoolProperty(
+        name = 'Enable Transition Ramp',
+        description = 'Enable alpha transition ramp', 
+        default = False,
+        update = transition.update_enable_transition_ramp
+    )
 
-    show_transition_ramp : BoolProperty(name='Toggle Transition Ramp',
-            description = "Toggle transition Ramp (Works best if there's transition bump enabled on other channel)", 
-            default=False) #, update=transition.update_show_transition_ramp)
+    show_transition_ramp : BoolProperty(
+        name = 'Toggle Transition Ramp',
+        description = "Toggle transition Ramp (Works best if there's transition bump enabled on other channel)", 
+        default = False
+    )
 
     transition_ramp_intensity_value : FloatProperty(
-            name = 'Channel Intensity Factor', 
-            description = 'Channel Intensity Factor',
-            default=1.0, min=0.0, max=1.0, subtype='FACTOR', precision=3)
+        name = 'Channel Intensity Factor', 
+        description = 'Channel Intensity Factor',
+        default=1.0, min=0.0, max=1.0, subtype='FACTOR', precision=3
+    )
 
     transition_ramp_blend_type : EnumProperty(
         name = 'Transition Ramp Blend Type',
         items = blend_type_items,
         default = 'MIX', 
-        update=transition.update_enable_transition_ramp)
+        update = transition.update_enable_transition_ramp
+    )
 
     transition_ramp_intensity_unlink : BoolProperty(
-            name='Unlink Transition Ramp with Channel Intensity', 
-            description='Unlink Transition Ramp with Channel Intensity', 
-            default=False,
-            update=transition.update_enable_transition_ramp)
+        name = 'Unlink Transition Ramp with Channel Intensity', 
+        description = 'Unlink Transition Ramp with Channel Intensity', 
+        default = False,
+        update = transition.update_enable_transition_ramp
+    )
 
     # Transition ramp nodes
     tr_ramp : StringProperty(default='')
@@ -6060,57 +6278,82 @@ class YLayerChannel(bpy.types.PropertyGroup):
     cache_hemi : StringProperty(default='')
 
     # Transition AO related
-    enable_transition_ao : BoolProperty(name='Enable Transition AO', 
-            description='Enable alpha transition Ambient Occlusion (Need active transition bump)', default=False,
-            update=transition.update_enable_transition_ao)
+    enable_transition_ao : BoolProperty(
+        name = 'Enable Transition AO', 
+        description = 'Enable alpha transition Ambient Occlusion (Need active transition bump)',
+        default = False,
+        update = transition.update_enable_transition_ao
+    )
 
-    show_transition_ao : BoolProperty(name='Toggle Transition AO',
-            description = "Toggle transition AO (Only works if there's transition bump enabled on other channel)", 
-            default=False) #, update=transition.update_show_transition_ao)
+    show_transition_ao : BoolProperty(
+        name = 'Toggle Transition AO',
+        description = "Toggle transition AO (Only works if there's transition bump enabled on other channel)", 
+        default = False
+    )
 
-    transition_ao_power : FloatProperty(name='Transition AO Power',
-            #description='Transition AO edge power (higher value means less AO)', min=1.0, max=100.0, default=4.0,
-            description='Transition AO power', min=1.0, max=100.0, default=4.0, precision=3)
+    transition_ao_power : FloatProperty(
+        name = 'Transition AO Power',
+        description = 'Transition AO power',
+        min=1.0, max=100.0, default=4.0, precision=3
+    )
 
-    transition_ao_intensity : FloatProperty(name='Transition AO Intensity',
-            description='Transition AO intensity', subtype='FACTOR', min=0.0, max=1.0, default=0.5, precision=3)
+    transition_ao_intensity : FloatProperty(
+        name = 'Transition AO Intensity',
+        description = 'Transition AO intensity',
+        subtype = 'FACTOR',
+        min=0.0, max=1.0, default=0.5, precision=3
+    )
 
-    transition_ao_color : FloatVectorProperty(name='Transition AO Color', description='Transition AO Color', 
-            subtype='COLOR', size=3, min=0.0, max=1.0, default=(0.0, 0.0, 0.0))
+    transition_ao_color : FloatVectorProperty(
+        name = 'Transition AO Color',
+        description = 'Transition AO Color', 
+        subtype = 'COLOR',
+        size = 3,
+        min=0.0, max=1.0, default=(0.0, 0.0, 0.0)
+    )
 
-    transition_ao_inside_intensity : FloatProperty(name='Transition AO Inside Intensity', 
-            description='Transition AO Inside Intensity', subtype='FACTOR', min=0.0, max=1.0, default=0.0, precision=3)
+    transition_ao_inside_intensity : FloatProperty(
+        name = 'Transition AO Inside Intensity', 
+        description = 'Transition AO Inside Intensity',
+        subtype = 'FACTOR',
+        min=0.0, max=1.0, default=0.0, precision=3
+    )
 
     transition_ao_blend_type : EnumProperty(
         name = 'Transition AO Blend Type',
         items = blend_type_items,
         default = 'MIX', 
-        update=transition.update_enable_transition_ao)
+        update = transition.update_enable_transition_ao
+    )
 
     transition_ao_intensity_unlink : BoolProperty(
-            name='Unlink Transition AO with Channel Intensity', 
-            description='Unlink Transition AO with Channel Intensity', 
-            default=False,
-            update=transition.update_transition_ao_intensity_link)
+        name = 'Unlink Transition AO with Channel Intensity', 
+        description = 'Unlink Transition AO with Channel Intensity', 
+        default = False,
+        update = transition.update_transition_ao_intensity_link
+    )
 
     tao : StringProperty(default='')
 
     active_edit : BoolProperty(
-            name='Active override channel for editing or preview', 
-            description='Active override channel for editing or preview', 
-            default=False,
-            update=update_channel_active_edit)
+        name = 'Active override channel for editing or preview', 
+        description = 'Active override channel for editing or preview', 
+        default = False,
+        update = update_channel_active_edit
+    )
 
     active_edit_1 : BoolProperty(
-            name='Active override channel for editing or preview', 
-            description='Active override channel for editing or preview', 
-            default=False,
-            update=update_channel_active_edit)
+        name = 'Active override channel for editing or preview', 
+        description = 'Active override channel for editing or preview', 
+        default = False,
+        update = update_channel_active_edit
+    )
 
     prev_active_edit_idx : IntProperty(
-            name='Previous Active Edit Index',
-            description='To store previous active edit index',
-            default=0)
+        name = 'Previous Active Edit Index',
+        description = 'To store previous active edit index',
+        default = 0
+    )
 
     # For UI
     expand_bump_settings : BoolProperty(default=False)
@@ -6187,13 +6430,18 @@ def update_layer_uniform_scale_enabled(self, context):
 
 class YLayer(bpy.types.PropertyGroup):
     name : StringProperty(
-            name = 'Layer Name',
-            description = 'Layer name',
-            default='', update=update_layer_name)
+        name = 'Layer Name',
+        description = 'Layer name',
+        default = '',
+        update = update_layer_name
+    )
 
     enable : BoolProperty(
-            name = 'Enable Layer', description = 'Enable layer',
-            default=True, update=update_layer_enable)
+        name = 'Enable Layer',
+        description = 'Enable layer',
+        default = True,
+        update = update_layer_enable
+    )
 
     channels : CollectionProperty(type=YLayerChannel)
 
@@ -6202,101 +6450,118 @@ class YLayer(bpy.types.PropertyGroup):
     depth_group_node : StringProperty(default='')
 
     type : EnumProperty(
-            name = 'Layer Type',
-            items = layer_type_items,
-            default = 'IMAGE')
+        name = 'Layer Type',
+        items = layer_type_items,
+        default = 'IMAGE'
+    )
 
     intensity_value : FloatProperty(
-            name = 'Layer Opacity', 
-            description = 'Layer opacity',
-            default=1.0, min=0.0, max=1.0, subtype='FACTOR', precision=3)
+        name = 'Layer Opacity', 
+        description = 'Layer opacity',
+        default=1.0, min=0.0, max=1.0, subtype='FACTOR', precision=3
+    )
 
     color_shortcut : BoolProperty(
-            name = 'Color Shortcut on the list',
-            description = 'Display color shortcut on the list',
-            default=True,
-            update=update_layer_color_chortcut)
+        name = 'Color Shortcut on the list',
+        description = 'Display color shortcut on the list',
+        default = True,
+        update = update_layer_color_chortcut
+    )
 
     texcoord_type : EnumProperty(
-            name = 'Layer Coordinate Type',
-            description = 'Layer Coordinate Type',
-            items = texcoord_type_items,
-            default = 'UV',
-            update=update_texcoord_type)
+        name = 'Layer Coordinate Type',
+        description = 'Layer Coordinate Type',
+        items = texcoord_type_items,
+        default = 'UV',
+        update = update_texcoord_type
+    )
 
     original_texcoord : EnumProperty(
-            name = 'Original Layer Coordinate Type',
-            items = texcoord_type_items,
-            default = 'UV'
-            )
+        name = 'Original Layer Coordinate Type',
+        items = texcoord_type_items,
+        default = 'UV'
+    )
 
     original_image_extension : StringProperty(
-            name = 'Original Image Extension Type',
-            default = ''
-            )
+        name = 'Original Image Extension Type',
+        default = ''
+    )
 
     projection_blend : FloatProperty(
-            name = 'Box Projection Blend',
-            description = 'Amount of blend to use between sides',
-            default=0.0, min=0.0, max=1.0, subtype='FACTOR',
-            update=update_projection_blend)
+        name = 'Box Projection Blend',
+        description = 'Amount of blend to use between sides',
+        default=0.0, min=0.0, max=1.0,
+        subtype = 'FACTOR',
+        update = update_projection_blend
+    )
 
     # Specific for voronoi
     voronoi_feature : EnumProperty(
-            name = 'Voronoi Feature',
-            description = 'The voronoi feature that will be used for compute',
-            items = voronoi_feature_items,
-            default = 'F1',
-            update = update_voronoi_feature
-            )
+        name = 'Voronoi Feature',
+        description = 'The voronoi feature that will be used for compute',
+        items = voronoi_feature_items,
+        default = 'F1',
+        update = update_voronoi_feature
+    )
 
     # For temporary bake
     use_temp_bake : BoolProperty(
-            name = 'Use Temporary Bake',
-            description = 'Use temporary bake, it can be useful for prevent glitching with cycles',
-            default = False,
-            #update=update_layer_temp_bake
-            )
+        name = 'Use Temporary Bake',
+        description = 'Use temporary bake, it can be useful for prevent glitching with cycles',
+        default = False,
+        #update=update_layer_temp_bake
+    )
 
     original_type : EnumProperty(
-            name = 'Original Layer Type',
-            items = layer_type_items,
-            default = 'IMAGE')
+        name = 'Original Layer Type',
+        items = layer_type_items,
+        default = 'IMAGE'
+    )
 
     image_flip_y : BoolProperty(
-            name = 'Image Flip Y',
-            description = "Image Flip Y (Use this if you're using normal map created for DirectX application) ",
-            default = False,
-            update=update_image_flip_y)
+        name = 'Image Flip Y',
+        description = "Image Flip Y (Use this if you're using normal map created for DirectX application) ",
+        default = False,
+        update = update_image_flip_y
+    )
 
     divide_rgb_by_alpha : BoolProperty(
-            name = 'Spread Fix',
-            description = "Spread fix will divide RGB value by its alpha\nThis can be useful remove dark outline on painted image/vertex color\nWARNING: This is a hack solution so the result might not looks right",
-            default = False,
-            update=update_divide_rgb_by_alpha)
+        name = 'Spread Fix',
+        description = "Spread fix will divide RGB value by its alpha\nThis can be useful remove dark outline on painted image/vertex color\nWARNING: This is a hack solution so the result might not looks right",
+        default = False,
+        update = update_divide_rgb_by_alpha
+    )
 
     # Fake lighting related
 
     hemi_space : EnumProperty(
-            name = 'Fake Lighting Space',
-            description = 'Fake lighting space',
-            items = hemi_space_items,
-            default = 'OBJECT',
-            update=update_hemi_space)
+        name = 'Fake Lighting Space',
+        description = 'Fake lighting space',
+        items = hemi_space_items,
+        default = 'OBJECT',
+        update = update_hemi_space
+    )
 
     hemi_vector : FloatVectorProperty(
-            name='Cache Hemi vector', size=3, precision=3,
-            default=(0.0, 0.0, 1.0))
+        name = 'Cache Hemi vector',
+        size = 3,
+        precision = 3,
+        default = (0.0, 0.0, 1.0)
+    )
 
     hemi_camera_ray_mask : BoolProperty(
-            name = 'Camera Ray Mask',
-            description = "Use Camera Ray value so the back of the mesh won't be affected by fake lighting",
-            default = False, update=update_hemi_camera_ray_mask)
+        name = 'Camera Ray Mask',
+        description = "Use Camera Ray value so the back of the mesh won't be affected by fake lighting",
+        default = False,
+        update = update_hemi_camera_ray_mask
+    )
 
     hemi_use_prev_normal : BoolProperty(
-            name = 'Use previous Normal',
-            description = 'Take account previous Normal',
-            default = False, update=update_hemi_use_prev_normal)
+        name = 'Use previous Normal',
+        description = 'Take account previous Normal',
+        default = False,
+        update = update_hemi_use_prev_normal
+    )
 
     bump_process : StringProperty(default='')
 
@@ -6308,58 +6573,73 @@ class YLayer(bpy.types.PropertyGroup):
     baked_segment_name : StringProperty(default='')
 
     uv_name : StringProperty(
-            name = 'UV Name',
-            description = 'UV Name to use for layer coordinate',
-            default='', update=update_uv_name)
+        name = 'UV Name',
+        description = 'UV Name to use for layer coordinate',
+        default = '',
+        update = update_uv_name
+    )
 
     baked_uv_name : StringProperty(
-            name = 'Baked UV Name',
-            description = 'UV Name to use for layer coordinate',
-            default='')
+        name = 'Baked UV Name',
+        description = 'UV Name to use for layer coordinate',
+        default = ''
+    )
 
     # Parent index
     parent_idx : IntProperty(default=-1)
 
     # Transform
     translation : FloatVectorProperty(
-            name='Translation', size=3, precision=3, 
-            default=(0.0, 0.0, 0.0),
-            update=update_layer_transform
-            ) #, step=1)
+        name = 'Translation',
+        size = 3,
+        precision = 3, 
+        default = (0.0, 0.0, 0.0),
+        update = update_layer_transform
+    )
 
     rotation : FloatVectorProperty(
-            name='Rotation', subtype='AXISANGLE', size=3, precision=3, unit='ROTATION', 
-            default=(0.0, 0.0, 0.0),
-            update=update_layer_transform
-            ) #, step=3)
+        name = 'Rotation',
+        subtype = 'AXISANGLE',
+        size = 3,
+        precision = 3,
+        unit = 'ROTATION', 
+        default = (0.0, 0.0, 0.0),
+        update = update_layer_transform
+    )
 
     scale : FloatVectorProperty(
-            name='Scale', size=3, precision=3, 
-            default=(1.0, 1.0, 1.0),
-            update=update_layer_transform,
-            ) #, step=3)
+        name = 'Scale',
+        size = 3,
+        precision = 3, 
+        default = (1.0, 1.0, 1.0),
+        update = update_layer_transform,
+    )
 
     enable_blur_vector : BoolProperty(
-            name = 'Enable Blur Vector',
-            description = "Enable blur vector",
-            default = False, update=update_layer_blur_vector)
+        name = 'Enable Blur Vector',
+        description = "Enable blur vector",
+        default = False,
+        update = update_layer_blur_vector
+    )
 
     blur_vector_factor : FloatProperty(
-            name = 'Blur Vector Factor', 
-            description = 'Blur vector factor',
-            default=1.0, min=0.0, max=100.0,
-            update=update_layer_blur_vector_factor)
+        name = 'Blur Vector Factor', 
+        description = 'Blur vector factor',
+        default=1.0, min=0.0, max=100.0,
+        update = update_layer_blur_vector_factor
+    )
 
     decal_distance_value : FloatProperty(
-            name = 'Decal Distance',
-            description = 'Distance between surface and the decal object',
-            min=0.0, max=100.0, default=0.5, precision=3)
+        name = 'Decal Distance',
+        description = 'Distance between surface and the decal object',
+        min=0.0, max=100.0, default=0.5, precision=3
+    )
 
     use_baked : BoolProperty(
-            name = 'Use Baked',
-            description = 'Use baked layer image',
-            default = False,
-            )
+        name = 'Use Baked',
+        description = 'Use baked layer image',
+        default = False
+    )
 
     # Sources
     source : StringProperty(default='')
@@ -6405,7 +6685,7 @@ class YLayer(bpy.types.PropertyGroup):
         description = 'Use the same value for all scale components',
         default = False,
         update = update_layer_uniform_scale_enabled
-        )
+    )
 
     uniform_scale_value : FloatProperty(default=1)
 
@@ -6425,8 +6705,13 @@ class YLayer(bpy.types.PropertyGroup):
     mod_group_1 : StringProperty(default='')
 
     # Mask
-    enable_masks : BoolProperty(name='Enable Layer Masks', description='Enable layer masks',
-            default=True, update=Mask.update_enable_layer_masks)
+    enable_masks : BoolProperty(
+        name = 'Enable Layer Masks',
+        description = 'Enable layer masks',
+        default = True,
+        update = Mask.update_enable_layer_masks
+    )
+
     masks : CollectionProperty(type=Mask.YLayerMask)
 
     # UI related

--- a/Mask.py
+++ b/Mask.py
@@ -11,7 +11,12 @@ from .input_outputs import *
 #def check_object_index_props(entity, source=None):
 #    source.inputs[0].default_value = entity.object_index
 
-def add_new_mask(layer, name, mask_type, texcoord_type, uv_name, image = None, vcol = None, segment=None, object_index=0, blend_type='MULTIPLY', hemi_space='WORLD', hemi_use_prev_normal=False, color_id=(1,0,1), source_input='RGB', edge_detect_radius=0.05, modifier_type='INVERT', interpolation='Linear'):
+def add_new_mask(
+        layer, name, mask_type, texcoord_type, uv_name, image=None, vcol=None, segment=None,
+        object_index=0, blend_type='MULTIPLY', hemi_space='WORLD', hemi_use_prev_normal=False,
+        color_id=(1, 0, 1), source_input='RGB', edge_detect_radius=0.05,
+        modifier_type='INVERT', interpolation='Linear'
+    ):
     yp = layer.id_data.yp
     yp.halt_update = True
     ypup = get_user_preferences()
@@ -243,110 +248,122 @@ class YNewLayerMask(bpy.types.Operator):
     name : StringProperty(default='')
 
     type : EnumProperty(
-            name = 'Mask Type',
-            items = mask_type_items,
-            default = 'IMAGE')
+        name = 'Mask Type',
+        items = mask_type_items,
+        default = 'IMAGE'
+    )
 
     modifier_type : EnumProperty(
-            name = 'Mask Modifier Type',
-            items = MaskModifier.mask_modifier_type_items,
-            default = 'INVERT')
+        name = 'Mask Modifier Type',
+        items = MaskModifier.mask_modifier_type_items,
+        default = 'INVERT'
+    )
 
-    width : IntProperty(name='Width', default = 1024, min=1, max=16384)
-    height : IntProperty(name='Height', default = 1024, min=1, max=16384)
+    width : IntProperty(name='Width', default=1024, min=1, max=16384)
+    height : IntProperty(name='Height', default=1024, min=1, max=16384)
     
     interpolation : EnumProperty(
-            name = 'Image Interpolation Type',
-            description = 'image interpolation type',
-            items = interpolation_type_items,
-            default = 'Linear')
+        name = 'Image Interpolation Type',
+        description = 'image interpolation type',
+        items = interpolation_type_items,
+        default = 'Linear'
+    )
 
     blend_type : EnumProperty(
         name = 'Blend',
         description = 'Blend type',
         items = mask_blend_type_items,
-        default = 'MULTIPLY')
+        default = 'MULTIPLY'
+    )
 
     color_option : EnumProperty(
-            name = 'Color Option',
-            description = 'Color Option',
-            items = (
-                ('WHITE', 'White (Full Opacity)', ''),
-                ('BLACK', 'Black (Full Transparency)', ''),
-                ),
-            default='WHITE')
+        name = 'Color Option',
+        description = 'Color Option',
+        items = (
+            ('WHITE', 'White (Full Opacity)', ''),
+            ('BLACK', 'Black (Full Transparency)', ''),
+        ),
+        default='WHITE'
+    )
 
     color_id : FloatVectorProperty(
-            name='Color ID', size=3,
-            subtype='COLOR',
-            default=(1.0, 0.0, 1.0),
-            min=0.0, max=1.0,
-            )
+        name = 'Color ID',
+        size = 3,
+        subtype = 'COLOR',
+        default=(1.0, 0.0, 1.0), min=0.0, max=1.0,
+    )
 
     hdr : BoolProperty(name='32 bit Float', default=False)
 
     texcoord_type : EnumProperty(
-            name = 'Mask Coordinate Type',
-            description = 'Mask Coordinate Type',
-            items = mask_texcoord_type_items,
-            default = 'UV')
+        name = 'Mask Coordinate Type',
+        description = 'Mask Coordinate Type',
+        items = mask_texcoord_type_items,
+        default = 'UV'
+    )
 
     uv_name : StringProperty(default='', update=update_new_mask_uv_map)
     uv_map_coll : CollectionProperty(type=bpy.types.PropertyGroup)
 
     use_udim : BoolProperty(
-            name = 'Use UDIM Tiles',
-            description='Use UDIM Tiles',
-            default=False)
+        name = 'Use UDIM Tiles',
+        description = 'Use UDIM Tiles',
+        default = False
+    )
 
     use_image_atlas : BoolProperty(
-            name = 'Use Image Atlas',
-            description='Use Image Atlas',
-            default=False)
+        name = 'Use Image Atlas',
+        description = 'Use Image Atlas',
+        default = False
+    )
 
     # For fake lighting
     hemi_space : EnumProperty(
-            name = 'Fake Lighting Space',
-            description = 'Fake lighting space',
-            items = hemi_space_items,
-            default='WORLD')
+        name = 'Fake Lighting Space',
+        description = 'Fake lighting space',
+        items = hemi_space_items,
+        default = 'WORLD'
+    )
 
     hemi_use_prev_normal : BoolProperty(
-            name = 'Use previous Normal',
-            description = 'Take previous Normal into the account',
-            default = True)
+        name = 'Use previous Normal',
+        description = 'Take previous Normal into the account',
+        default = True
+    )
 
     # For object index
     object_index : IntProperty(
-            name = 'Object Index',
-            description = 'Object Pass Index',
-            default = 0,
-            min=0)
+        name = 'Object Index',
+        description = 'Object Pass Index',
+        default=0, min=0
+    )
 
-    edge_detect_radius : FloatProperty(
-            default=0.05, min=0.0, max=10.0)
+    edge_detect_radius : FloatProperty(default=0.05, min=0.0, max=10.0)
 
     vcol_data_type : EnumProperty(
-            name = 'Vertex Color Data Type',
-            description = 'Vertex color data type',
-            items = vcol_data_type_items,
-            default='BYTE_COLOR')
+        name = 'Vertex Color Data Type',
+        description = 'Vertex color data type',
+        items = vcol_data_type_items,
+        default = 'BYTE_COLOR'
+    )
 
     vcol_domain : EnumProperty(
-            name = 'Vertex Color Domain',
-            description = 'Vertex color domain',
-            items = vcol_domain_items,
-            default='CORNER')
+        name = 'Vertex Color Domain',
+        description = 'Vertex color domain',
+        items = vcol_domain_items,
+        default = 'CORNER'
+    )
     
     image_resolution : EnumProperty(
         name = 'Image Resolution',
         items = image_resolution_items,
-        default = '1024')
+        default = '1024'
+    )
     
     use_custom_resolution : BoolProperty(
-        name= 'Custom Resolution',
-        default=False,
-        description= 'Use custom Resolution to adjust the width and height individually'
+        name = 'Custom Resolution',
+        default = False,
+        description = 'Use custom Resolution to adjust the width and height individually'
     )
 
     @classmethod
@@ -607,9 +624,9 @@ class YNewLayerMask(bpy.types.Operator):
         if self.type == 'IMAGE':
 
             if self.color_option == 'WHITE':
-                color = (1,1,1,1)
+                color = (1, 1, 1, 1)
             elif self.color_option == 'BLACK':
-                color = (0,0,0,1)
+                color = (0, 0, 0, 1)
 
             if self.use_udim:
                 objs = get_all_objects_with_same_materials(mat)
@@ -620,13 +637,16 @@ class YNewLayerMask(bpy.types.Operator):
                     segment = UDIM.get_set_udim_atlas_segment(tilenums, self.width, self.height, color, get_noncolor_name(), self.hdr, yp)
                 else:
                     segment = ImageAtlas.get_set_image_atlas_segment(
-                            self.width, self.height, self.color_option, self.hdr, yp=yp) #, ypup.image_atlas_size)
+                        self.width, self.height, self.color_option, self.hdr, yp=yp
+                    )
                 img = segment.id_data
             else:
 
                 if self.use_udim:
-                    img = bpy.data.images.new(name=self.name, width=self.width, height=self.height, 
-                            alpha=alpha, float_buffer=self.hdr, tiled=True)
+                    img = bpy.data.images.new(
+                        name=self.name, width=self.width, height=self.height, 
+                        alpha=alpha, float_buffer=self.hdr, tiled=True
+                    )
 
                     # Fill tiles
                     for tilenum in tilenums:
@@ -634,8 +654,10 @@ class YNewLayerMask(bpy.types.Operator):
                     UDIM.initial_pack_udim(img, color)
 
                 else:
-                    img = bpy.data.images.new(name=self.name, 
-                            width=self.width, height=self.height, alpha=alpha, float_buffer=self.hdr)
+                    img = bpy.data.images.new(
+                        name=self.name, width=self.width, height=self.height,
+                        alpha=alpha, float_buffer=self.hdr
+                    )
 
                 img.generated_color = color
                 if hasattr(img, 'use_alpha'):
@@ -673,9 +695,11 @@ class YNewLayerMask(bpy.types.Operator):
         source_input = 'RGB' if self.type not in {'VORONOI', 'NOISE'} else 'ALPHA'
 
         # Add new mask
-        mask = add_new_mask(layer, self.name, self.type, self.texcoord_type, self.uv_name, img, vcol, segment, self.object_index, self.blend_type, 
-                self.hemi_space, self.hemi_use_prev_normal, self.color_id, source_input=source_input, edge_detect_radius=self.edge_detect_radius,
-                modifier_type=self.modifier_type, interpolation=self.interpolation)
+        mask = add_new_mask(
+            layer, self.name, self.type, self.texcoord_type, self.uv_name, img, vcol, segment, self.object_index, self.blend_type, 
+            self.hemi_space, self.hemi_use_prev_normal, self.color_id, source_input=source_input, edge_detect_radius=self.edge_detect_radius,
+            modifier_type=self.modifier_type, interpolation=self.interpolation
+        )
 
         # Enable edit mask
         if self.type in {'IMAGE', 'VCOL', 'COLOR_ID'}:
@@ -709,27 +733,33 @@ class YOpenImageAsMask(bpy.types.Operator, ImportHelper):
     # File browser filter
     filter_folder : BoolProperty(default=True, options={'HIDDEN', 'SKIP_SAVE'})
     filter_image : BoolProperty(default=True, options={'HIDDEN', 'SKIP_SAVE'})
+
     display_type : EnumProperty(
-            items = (('FILE_DEFAULTDISPLAY', 'Default', ''),
-                     ('FILE_SHORTDISLPAY', 'Short List', ''),
-                     ('FILE_LONGDISPLAY', 'Long List', ''),
-                     ('FILE_IMGDISPLAY', 'Thumbnails', '')),
-            default = 'FILE_IMGDISPLAY',
-            options={'HIDDEN', 'SKIP_SAVE'})
+        items = (
+            ('FILE_DEFAULTDISPLAY', 'Default', ''),
+            ('FILE_SHORTDISLPAY', 'Short List', ''),
+            ('FILE_LONGDISPLAY', 'Long List', ''),
+            ('FILE_IMGDISPLAY', 'Thumbnails', '')
+        ),
+        default = 'FILE_IMGDISPLAY',
+        options = {'HIDDEN', 'SKIP_SAVE'}
+    )
 
     relative : BoolProperty(name="Relative Path", default=True, description="Apply relative paths")
 
     interpolation : EnumProperty(
-            name = 'Image Interpolation Type',
-            description = 'image interpolation type',
-            items = interpolation_type_items,
-            default = 'Linear')
+        name = 'Image Interpolation Type',
+        description = 'image interpolation type',
+        items = interpolation_type_items,
+        default = 'Linear'
+    )
 
     texcoord_type : EnumProperty(
-            name = 'Mask Coordinate Type',
-            description = 'Mask Coordinate Type',
-            items = mask_texcoord_type_items,
-            default = 'UV')
+        name = 'Mask Coordinate Type',
+        description = 'Mask Coordinate Type',
+        items = mask_texcoord_type_items,
+        default = 'UV'
+    )
 
     uv_map : StringProperty(default='')
     uv_map_coll : CollectionProperty(type=bpy.types.PropertyGroup)
@@ -738,19 +768,24 @@ class YOpenImageAsMask(bpy.types.Operator, ImportHelper):
         name = 'Blend',
         description = 'Blend type',
         items = mask_blend_type_items,
-        default = 'MULTIPLY')
+        default = 'MULTIPLY'
+    )
 
     source_input : EnumProperty(
-            name = 'Source Input',
-            description = 'Source data for mask input',
-            items = (('RGB', 'Color', ''),
-                ('ALPHA', 'Alpha', '')),
-            default = 'RGB')
+        name = 'Source Input',
+        description = 'Source data for mask input',
+        items = (
+            ('RGB', 'Color', ''),
+            ('ALPHA', 'Alpha', '')
+        ),
+        default = 'RGB'
+    )
 
     use_udim_detecting : BoolProperty(
-            name = 'Detect UDIMs',
-            description = 'Detect selected UDIM files and load all matching tiles.',
-            default = True)
+        name = 'Detect UDIMs',
+        description = 'Detect selected UDIM files and load all matching tiles.',
+        default = True
+    )
 
     file_browser_filepath : StringProperty(default='')
 
@@ -880,8 +915,10 @@ class YOpenImageAsMask(bpy.types.Operator, ImportHelper):
             bpy.context.area.type = 'IMAGE_EDITOR'
             images = []
             for path in import_list:
-                bpy.ops.image.open(filepath=directory+os.sep+path, directory=directory, 
-                        relative_path=self.relative, use_udim_detecting=self.use_udim_detecting)
+                bpy.ops.image.open(
+                    filepath=directory + os.sep + path, directory=directory, 
+                    relative_path=self.relative, use_udim_detecting=self.use_udim_detecting
+                )
                 image = bpy.context.space_data.image
                 if image not in images:
                     images.append(image)
@@ -896,10 +933,11 @@ class YOpenImageAsMask(bpy.types.Operator, ImportHelper):
                 image.colorspace_settings.name = get_noncolor_name()
 
             # Add new mask
-            mask = add_new_mask(layer, image.name, 'IMAGE', self.texcoord_type, self.uv_map, image, None, 
-                                blend_type=self.blend_type, source_input=self.source_input,
-                                interpolation=self.interpolation
-                                )
+            mask = add_new_mask(
+                layer, image.name, 'IMAGE', self.texcoord_type, self.uv_map, image, None, 
+                blend_type=self.blend_type, source_input=self.source_input,
+                interpolation = self.interpolation
+            )
 
         reconnect_layer_nodes(layer)
         rearrange_layer_nodes(layer)
@@ -948,29 +986,37 @@ class YOpenAvailableDataAsMask(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
     
     type : EnumProperty(
-            name = 'Layer Type',
-            items = (('IMAGE', 'Image', ''),
-                ('VCOL', 'Vertex Color', '')),
-            default = 'IMAGE')
+        name = 'Layer Type',
+        items = (
+            ('IMAGE', 'Image', ''),
+            ('VCOL', 'Vertex Color', '')
+        ),
+        default = 'IMAGE'
+    )
 
     interpolation : EnumProperty(
-            name = 'Image Interpolation Type',
-            description = 'image interpolation type',
-            items = interpolation_type_items,
-            default = 'Linear')
+        name = 'Image Interpolation Type',
+        description = 'image interpolation type',
+        items = interpolation_type_items,
+        default = 'Linear'
+    )
 
     texcoord_type : EnumProperty(
-            name = 'Mask Coordinate Type',
-            description = 'Mask Coordinate Type',
-            items = mask_texcoord_type_items,
-            default = 'UV')
+        name = 'Mask Coordinate Type',
+        description = 'Mask Coordinate Type',
+        items = mask_texcoord_type_items,
+        default = 'UV'
+    )
 
     source_input : EnumProperty(
-            name = 'Source Input',
-            description = 'Source data for mask input',
-            items = (('RGB', 'Color', ''),
-                ('ALPHA', 'Alpha', '')),
-            default = 'RGB')
+        name = 'Source Input',
+        description = 'Source data for mask input',
+        items = (
+            ('RGB', 'Color', ''),
+            ('ALPHA', 'Alpha', '')
+        ),
+        default = 'RGB'
+    )
 
     uv_map : StringProperty(default='')
     uv_map_coll : CollectionProperty(type=bpy.types.PropertyGroup)
@@ -985,7 +1031,8 @@ class YOpenAvailableDataAsMask(bpy.types.Operator):
         name = 'Blend',
         description = 'Blend type',
         items = mask_blend_type_items,
-        default = 'MULTIPLY')
+        default = 'MULTIPLY'
+    )
 
     @classmethod
     def poll(cls, context):
@@ -1174,10 +1221,11 @@ class YOpenAvailableDataAsMask(bpy.types.Operator):
                     set_active_vertex_color(o, other_v)
 
         # Add new mask
-        mask = add_new_mask(layer, name, self.type, self.texcoord_type, self.uv_map, image, vcol, 
-                            blend_type=self.blend_type, source_input=self.source_input,
-                            interpolation=self.interpolation
-                            )
+        mask = add_new_mask(
+            layer, name, self.type, self.texcoord_type, self.uv_map, image, vcol, 
+            blend_type=self.blend_type, source_input=self.source_input,
+            interpolation = self.interpolation
+        )
 
         # Enable edit mask
         if self.type in {'IMAGE', 'VCOL'} and self.source_input == 'RGB':
@@ -1208,10 +1256,13 @@ class YMoveLayerMask(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     direction : EnumProperty(
-            name = 'Direction',
-            items = (('UP', 'Up', ''),
-                     ('DOWN', 'Down', '')),
-            default = 'UP')
+        name = 'Direction',
+        items = (
+            ('UP', 'Up', ''),
+            ('DOWN', 'Down', '')
+        ),
+        default = 'UP'
+    )
 
     @classmethod
     def poll(cls, context):
@@ -1253,11 +1304,12 @@ class YMoveLayerMask(bpy.types.Operator):
         check_layer_tree_ios(layer)
 
         # Swap UI expand content
-        props = ['expand_content',
-                'expand_channels',
-                'expand_source',
-                'expand_vector'
-                 ]
+        props = [
+            'expand_content',
+            'expand_channels',
+            'expand_source',
+            'expand_vector'
+        ]
 
         for p in props:
             neighbor_prop = getattr(ypui.layer_ui.masks[new_index], p)
@@ -1548,7 +1600,7 @@ def update_enable_layer_masks(self, context):
     reconnect_yp_nodes(self.id_data)
     rearrange_yp_nodes(self.id_data)
 
-def update_mask_texcoord_type(self, context, reconnect_nodes=True):
+def update_mask_texcoord_type(self, context, reconnect=True):
     yp = self.id_data.yp
     if yp.halt_update: return
 
@@ -1569,7 +1621,7 @@ def update_mask_texcoord_type(self, context, reconnect_nodes=True):
         source = get_mask_source(mask)
         source.projection = 'BOX' if mask.texcoord_type in {'Generated', 'Object'} else 'FLAT'
 
-    if reconnect_nodes:
+    if reconnect:
         reconnect_layer_nodes(layer)
         rearrange_layer_nodes(layer)
 
@@ -1660,8 +1712,10 @@ def update_mask_hemi_camera_ray_mask(self, context):
 
         # Check if source has the inputs, if not reload the node
         if 'Camera Ray Mask' not in source.inputs:
-            source = replace_new_node(tree, self, 'source', 'ShaderNodeGroup', 'Mask Source', 
-                    lib.HEMI, force_replace=True)
+            source = replace_new_node(
+                tree, self, 'source', 'ShaderNodeGroup', 'Mask Source', 
+                lib.HEMI, force_replace=True
+            )
             duplicate_lib_node_tree(source)
             trans = source.node_tree.nodes.get('Vector Transform')
             if trans: trans.convert_from = self.hemi_space
@@ -1823,21 +1877,25 @@ class YLayerMask(bpy.types.PropertyGroup):
     group_node : StringProperty(default='')
 
     enable : BoolProperty(
-            name='Enable Mask', 
-            description = 'Enable mask',
-            default=True, update=update_layer_mask_enable)
+        name = 'Enable Mask', 
+        description = 'Enable mask',
+        default = True,
+        update = update_layer_mask_enable
+    )
 
     active_edit : BoolProperty(
-            name='Active mask for editing or preview', 
-            description='Active mask for editing or preview', 
-            default=False,
-            update=update_mask_active_edit)
+        name = 'Active mask for editing or preview', 
+        description = 'Active mask for editing or preview', 
+        default = False,
+        update = update_mask_active_edit
+    )
 
     source_input : EnumProperty(
-            name = 'Mask Source Input',
-            description = 'Source input for mask',
-            items = entity_input_items,
-            update = update_mask_source_input)
+        name = 'Mask Source Input',
+        description = 'Source input for mask',
+        items = entity_input_items,
+        update = update_mask_source_input
+    )
 
     #active_vcol_edit : BoolProperty(
     #        name='Active vertex color for editing', 
@@ -1846,120 +1904,146 @@ class YLayerMask(bpy.types.PropertyGroup):
     #        update=update_mask_active_vcol_edit)
 
     type : EnumProperty(
-            name = 'Mask Type',
-            items = mask_type_items,
-            default = 'IMAGE')
+        name = 'Mask Type',
+        items = mask_type_items,
+        default = 'IMAGE'
+    )
 
     texcoord_type : EnumProperty(
-            name = 'Mask Coordinate Type',
-            description = 'Mask Coordinate Type',
-            items = mask_texcoord_type_items,
-            default = 'UV',
-            # Using a lambda because update function is expected to have an arity of 2
-            update = lambda self, context:
-                update_mask_texcoord_type(self, context))
+        name = 'Mask Coordinate Type',
+        description = 'Mask Coordinate Type',
+        items = mask_texcoord_type_items,
+        default = 'UV',
+        # Using a lambda because update function is expected to have an arity of 2
+        update = lambda self, context:
+            update_mask_texcoord_type(self, context)
+    )
 
     original_texcoord : EnumProperty(
-            name = 'Original Layer Coordinate Type',
-            items = mask_texcoord_type_items,
-            default = 'UV'
-            )
+        name = 'Original Layer Coordinate Type',
+        items = mask_texcoord_type_items,
+        default = 'UV'
+    )
 
     original_image_extension : StringProperty(
-            name = 'Original Image Extension Type',
-            default = ''
-            )
+        name = 'Original Image Extension Type',
+        default = ''
+    )
 
     modifier_type : EnumProperty(
-            name = 'Mask Modifier Type',
-            items = MaskModifier.mask_modifier_type_items,
-            default = 'INVERT')
+        name = 'Mask Modifier Type',
+        items = MaskModifier.mask_modifier_type_items,
+        default = 'INVERT'
+    )
 
     hemi_space : EnumProperty(
-            name = 'Fake Lighting Space',
-            description = 'Fake lighting space',
-            items = hemi_space_items,
-            default = 'OBJECT',
-            update=update_mask_hemi_space)
+        name = 'Fake Lighting Space',
+        description = 'Fake lighting space',
+        items = hemi_space_items,
+        default = 'OBJECT',
+        update = update_mask_hemi_space
+    )
 
     hemi_camera_ray_mask : BoolProperty(
-            name = 'Camera Ray Mask',
-            description = "Use Camera Ray value so the back of the mesh won't be affected by fake lighting",
-            default = False, update=update_mask_hemi_camera_ray_mask)
+        name = 'Camera Ray Mask',
+        description = "Use Camera Ray value so the back of the mesh won't be affected by fake lighting",
+        default = False,
+        update = update_mask_hemi_camera_ray_mask
+    )
 
     hemi_use_prev_normal : BoolProperty(
-            name = 'Use previous Normal',
-            description = 'Take account previous Normal',
-            default = False, update=update_mask_hemi_use_prev_normal)
+        name = 'Use previous Normal',
+        description = 'Take account previous Normal',
+        default = False,
+        update = update_mask_hemi_use_prev_normal
+    )
 
     uv_name : StringProperty(
-            name = 'UV Name',
-            description = 'UV Name to use for mask coordinate',
-            default='', update=update_mask_uv_name)
+        name = 'UV Name',
+        description = 'UV Name to use for mask coordinate',
+        default = '',
+        update = update_mask_uv_name
+    )
 
     baked_uv_name : StringProperty(
-            name = 'Baked UV Name',
-            description = 'UV Name to use for baked mask coordinate',
-            default='')
+        name = 'Baked UV Name',
+        description = 'UV Name to use for baked mask coordinate',
+        default = ''
+    )
 
     blend_type : EnumProperty(
         name = 'Blend',
         items = mask_blend_type_items,
         default = 'MULTIPLY',
-        update = update_mask_blend_type)
+        update = update_mask_blend_type
+    )
 
     intensity_value : FloatProperty(
-            name = 'Mask Opacity', 
-            description = 'Mask opacity',
-            default=1.0, min=0.0, max=1.0, subtype='FACTOR', precision=3)
+        name = 'Mask Opacity', 
+        description = 'Mask opacity',
+        subtype = 'FACTOR',
+        default=1.0, min=0.0, max=1.0, precision=3
+    )
 
     # Transform
     translation : FloatVectorProperty(
-            name='Translation', size=3, precision=3, 
-            default=(0.0, 0.0, 0.0),
-            update=update_mask_transform
-            ) #, step=1)
+        name = 'Translation',
+        size = 3,
+        precision = 3, 
+        default = (0.0, 0.0, 0.0),
+        update = update_mask_transform
+    )
 
     rotation : FloatVectorProperty(
-            name='Rotation', subtype='AXISANGLE', size=3, precision=3, unit='ROTATION', 
-            default=(0.0, 0.0, 0.0),
-            update=update_mask_transform
-            ) #, step=3)
+        name = 'Rotation',
+        subtype = 'AXISANGLE',
+        size = 3,
+        precision = 3,
+        unit = 'ROTATION',
+        default = (0.0, 0.0, 0.0),
+        update = update_mask_transform
+    )
 
     scale : FloatVectorProperty(
-            name='Scale', size=3, precision=3, 
-            default=(1.0, 1.0, 1.0),
-            update=update_mask_transform,
-            ) #, step=3)
+        name = 'Scale',
+        size = 3,
+        precision = 3, 
+        default = (1.0, 1.0, 1.0),
+        update = update_mask_transform,
+    )
 
     enable_blur_vector : BoolProperty(
-            name = 'Enable Blur Vector',
-            description = "Enable blur vector",
-            default = False, update=update_mask_blur_vector)
+        name = 'Enable Blur Vector',
+        description = "Enable blur vector",
+        default = False,
+        update = update_mask_blur_vector
+    )
 
     blur_vector_factor : FloatProperty(
-            name = 'Blur Vector Factor', 
-            description = 'Mask Intensity Factor',
-            default=1.0, min=0.0, max=100.0, precision=3)
+        name = 'Blur Vector Factor', 
+        description = 'Mask Intensity Factor',
+        default=1.0, min=0.0, max=100.0, precision=3
+    )
 
     decal_distance_value : FloatProperty(
-            name = 'Decal Distance',
-            description = 'Distance between surface and the decal object',
-            min=0.0, max=100.0, default=0.5, precision=3)
+        name = 'Decal Distance',
+        description = 'Distance between surface and the decal object',
+        min=0.0, max=100.0, default=0.5, precision=3
+    )
 
     color_id : FloatVectorProperty(
-            name='Color ID', size=3,
-            subtype='COLOR',
-            default=(1.0, 0.0, 1.0),
-            min=0.0, max=1.0,
-            )
+        name = 'Color ID',
+        size = 3,
+        subtype = 'COLOR',
+        default=(1.0, 0.0, 1.0), min=0.0, max=1.0,
+    )
 
     use_baked : BoolProperty(
-            name = 'Use Baked',
-            description = 'Use baked image rather generated mask',
-            default = False,
-            update=update_mask_use_baked
-            )
+        name = 'Use Baked',
+        description = 'Use baked image rather generated mask',
+        default = False,
+        update = update_mask_use_baked
+    )
 
     segment_name : StringProperty(default='')
     baked_segment_name : StringProperty(default='')
@@ -1970,45 +2054,50 @@ class YLayerMask(bpy.types.PropertyGroup):
 
     # For object index
     object_index : IntProperty(
-            name = 'Object Index',
-            description = 'Object Pass Index',
-            default = 0,
-            min=0,
-            update=update_mask_object_index)
+        name = 'Object Index',
+        description = 'Object Pass Index',
+        default=0, min=0,
+        update = update_mask_object_index
+    )
 
     # For temporary bake
     use_temp_bake : BoolProperty(
-            name = 'Use Temporary Bake',
-            description = 'Use temporary bake, it can be useful to prevent glitching with cycles',
-            default = False,
-            )
+        name = 'Use Temporary Bake',
+        description = 'Use temporary bake, it can be useful to prevent glitching with cycles',
+        default = False,
+    )
 
     original_type : EnumProperty(
-            name = 'Original Mask Type',
-            items = mask_type_items,
-            default = 'IMAGE')
+        name = 'Original Mask Type',
+        items = mask_type_items,
+        default = 'IMAGE'
+    )
 
     # For fake lighting
 
     hemi_vector : FloatVectorProperty(
-            name='Cache Hemi vector', size=3, precision=3,
-            default=(0.0, 0.0, 1.0))
+        name = 'Cache Hemi vector',
+        size = 3,
+        precision = 3,
+        default = (0.0, 0.0, 1.0)
+    )
 
     # For edge detection
     edge_detect_radius : FloatProperty(
-            name = 'Edge Detect Radius',
-            description = 'Edge detect radius',
-            default=0.05, min=0.0, max=10.0,
-            update=update_mask_edge_detect_radius)
+        name = 'Edge Detect Radius',
+        description = 'Edge detect radius',
+        default=0.05, min=0.0, max=10.0,
+        update = update_mask_edge_detect_radius
+    )
 
     # Specific for voronoi
     voronoi_feature : EnumProperty(
-            name = 'Voronoi Feature',
-            description = 'The voronoi feature that will be used for compute',
-            items = voronoi_feature_items,
-            default = 'F1',
-            update = update_mask_voronoi_feature
-            )
+        name = 'Voronoi Feature',
+        description = 'The voronoi feature that will be used for compute',
+        items = voronoi_feature_items,
+        default = 'F1',
+        update = update_mask_voronoi_feature
+    )
 
     # Nodes
     source : StringProperty(default='')
@@ -2030,7 +2119,7 @@ class YLayerMask(bpy.types.PropertyGroup):
         description = 'Use the same value for all scale components',
         default = False,
         update = update_mask_uniform_scale_enabled
-        )
+    )
 
     uniform_scale_value : FloatProperty(default=1)
 

--- a/MaskModifier.py
+++ b/MaskModifier.py
@@ -5,15 +5,15 @@ from .node_connections import *
 from .node_arrangements import *
 
 mask_modifier_type_items = (
-        ('INVERT', 'Invert', 'Invert', 'MODIFIER', 0),
-        ('RAMP', 'Ramp', '', 'MODIFIER', 1),
-        ('CURVE', 'Curve', '', 'MODIFIER', 2),
-        )
+    ('INVERT', 'Invert', 'Invert', 'MODIFIER', 0),
+    ('RAMP', 'Ramp', '', 'MODIFIER', 1),
+    ('CURVE', 'Curve', '', 'MODIFIER', 2),
+)
 
 can_be_expanded = {
-        'RAMP',
-        'CURVE',
-        }
+    'RAMP',
+    'CURVE',
+}
 
 def update_mask_modifier_enable(self, context):
 
@@ -128,7 +128,8 @@ class YNewMaskModifier(bpy.types.Operator):
     type : EnumProperty(
         name = 'Modifier Type',
         items = mask_modifier_type_items,
-        default = 'INVERT')
+        default = 'INVERT'
+    )
 
     @classmethod
     def poll(cls, context):
@@ -158,10 +159,13 @@ class YMoveMaskModifier(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     direction : EnumProperty(
-            name = 'Direction',
-            items = (('UP', 'Up', ''),
-                     ('DOWN', 'Down', '')),
-            default = 'UP')
+        name = 'Direction',
+        items = (
+            ('UP', 'Up', ''),
+            ('DOWN', 'Down', '')
+        ),
+        default = 'UP'
+    )
 
     @classmethod
     def poll(cls, context):
@@ -241,15 +245,19 @@ class YRemoveMaskModifier(bpy.types.Operator):
 
 class YMaskModifier(bpy.types.PropertyGroup):
     enable : BoolProperty(
-            name = 'Enable Modifier',
-            description = 'Enable modifier',
-            default=True, update=update_mask_modifier_enable)
+        name = 'Enable Modifier',
+        description = 'Enable modifier',
+        default = True,
+        update = update_mask_modifier_enable
+    )
+
     name : StringProperty(default='')
 
     type : EnumProperty(
         name = 'Modifier Type',
         items = mask_modifier_type_items,
-        default = 'INVERT')
+        default = 'INVERT'
+    )
 
     ramp : StringProperty(default='')
     ramp_mix : StringProperty(default='')

--- a/Modifier.py
+++ b/Modifier.py
@@ -5,45 +5,49 @@ from .modifier_common import *
 from .subtree import *
 from .node_connections import *
 from .node_arrangements import *
-from . import lib
 
 modifier_type_items = (
-        ('INVERT', 'Invert', 
-            'Invert input RGB and/or Alpha', 'MODIFIER', 0),
+    ('INVERT', 'Invert', 'Invert input RGB and/or Alpha', 'MODIFIER', 0),
 
-        ('RGB_TO_INTENSITY', 'RGB to Intensity',
-            'Input RGB will be used as alpha output, Output RGB will be replaced using custom color.', 
-            'MODIFIER', 1),
+    (
+        'RGB_TO_INTENSITY', 'RGB to Intensity',
+        'Input RGB will be used as alpha output, Output RGB will be replaced using custom color.', 
+        'MODIFIER', 1
+    ),
 
-        ('INTENSITY_TO_RGB', 'Intensity to RGB',
-            'Input alpha will be used as RGB output, Output Alpha will use solid value of one.', 
-            'MODIFIER', 2),
+    (
+        'INTENSITY_TO_RGB', 'Intensity to RGB',
+        'Input alpha will be used as RGB output, Output Alpha will use solid value of one.', 
+        'MODIFIER', 2
+    ),
 
-        # Deprecated
-        ('OVERRIDE_COLOR', 'Override Color',
-            'Input RGB will be replaced with custom RGB', 
-            'MODIFIER', 3),
+    # Deprecated
+    (
+        'OVERRIDE_COLOR', 'Override Color',
+        'Input RGB will be replaced with custom RGB', 
+        'MODIFIER', 3
+    ),
 
-        ('COLOR_RAMP', 'Color Ramp', '', 'MODIFIER', 4),
-        ('RGB_CURVE', 'RGB Curve', '', 'MODIFIER', 5),
-        ('HUE_SATURATION', 'Hue Saturation', '', 'MODIFIER', 6),
-        ('BRIGHT_CONTRAST', 'Brightness Contrast', '', 'MODIFIER', 7),
-        # Deprecated
-        ('MULTIPLIER', 'Multiplier', '', 'MODIFIER', 8),
-        ('MATH', 'Math', '', 'MODIFIER',9)
-        )
+    ('COLOR_RAMP', 'Color Ramp', '', 'MODIFIER', 4),
+    ('RGB_CURVE', 'RGB Curve', '', 'MODIFIER', 5),
+    ('HUE_SATURATION', 'Hue Saturation', '', 'MODIFIER', 6),
+    ('BRIGHT_CONTRAST', 'Brightness Contrast', '', 'MODIFIER', 7),
+    # Deprecated
+    ('MULTIPLIER', 'Multiplier', '', 'MODIFIER', 8),
+    ('MATH', 'Math', '', 'MODIFIER',9)
+)
 
 can_be_expanded = {
-        'INVERT', 
-        'RGB_TO_INTENSITY', 
-        'OVERRIDE_COLOR', # Deprecated
-        'COLOR_RAMP',
-        'RGB_CURVE',
-        'HUE_SATURATION',
-        'BRIGHT_CONTRAST',
-        'MULTIPLIER', # Deprecated
-        'MATH'
-        }
+    'INVERT', 
+    'RGB_TO_INTENSITY', 
+    'OVERRIDE_COLOR', # Deprecated
+    'COLOR_RAMP',
+    'RGB_CURVE',
+    'HUE_SATURATION',
+    'BRIGHT_CONTRAST',
+    'MULTIPLIER', # Deprecated
+    'MATH'
+}
 
 def get_modifier_channel_type(mod, return_non_color=False):
 
@@ -121,7 +125,8 @@ class YNewYPaintModifier(bpy.types.Operator):
     type : EnumProperty(
         name = 'Modifier Type',
         items = modifier_type_items,
-        default = 'INVERT')
+        default = 'INVERT'
+    )
 
     @classmethod
     def poll(cls, context):
@@ -180,10 +185,13 @@ class YMoveYPaintModifier(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     direction : EnumProperty(
-            name = 'Direction',
-            items = (('UP', 'Up', ''),
-                     ('DOWN', 'Down', '')),
-            default = 'UP')
+        name = 'Direction',
+        items = (
+            ('UP', 'Up', ''),
+            ('DOWN', 'Down', '')
+        ),
+        default = 'UP'
+    )
 
     @classmethod
     def poll(cls, context):
@@ -582,13 +590,18 @@ class YPaintModifier(bpy.types.PropertyGroup):
     type : EnumProperty(
         name = 'Modifier Type',
         items = modifier_type_items,
-        default = 'INVERT')
+        default = 'INVERT'
+    )
 
     # RGB to Intensity nodes
     rgb2i : StringProperty(default='')
 
-    rgb2i_col : FloatVectorProperty(name='RGB to Intensity Color', size=4, subtype='COLOR', 
-            default=(1.0,0.0,1.0,1.0), min=0.0, max=1.0)
+    rgb2i_col : FloatVectorProperty(
+        name = 'RGB to Intensity Color',
+        size = 4,
+        subtype = 'COLOR', 
+        default=(1.0, 0.0, 1.0, 1.0), min=0.0, max=1.0
+    )
 
     # Intensity to RGB nodes
     i2rgb : StringProperty(default='')
@@ -596,13 +609,20 @@ class YPaintModifier(bpy.types.PropertyGroup):
     # Override Color nodes (Deprecated)
     oc : StringProperty(default='')
 
-    oc_col : FloatVectorProperty(name='Override Color', size=4, subtype='COLOR', 
-            default=(1.0,1.0,1.0,1.0), min=0.0, max=1.0,
-            update=update_oc_col)
+    oc_col : FloatVectorProperty(
+        name = 'Override Color',
+        size = 4,
+        subtype = 'COLOR', 
+        default=(1.0, 1.0, 1.0, 1.0), min=0.0, max=1.0,
+        update = update_oc_col
+    )
 
-    oc_val : FloatProperty(name='Override Value', subtype='FACTOR', 
-            default=1.0, min=0.0, max=1.0,
-            update=update_oc_col)
+    oc_val : FloatProperty(
+        name = 'Override Value',
+        subtype = 'FACTOR', 
+        default=1.0, min=0.0, max=1.0,
+        update = update_oc_col
+    )
 
     # Invert nodes
     invert : StringProperty(default='')
@@ -627,10 +647,17 @@ class YPaintModifier(bpy.types.PropertyGroup):
     # Brightness Contrast nodes
     brightcon : StringProperty(default='')
 
-    brightness_value : FloatProperty(name='Brightness', description='Brightness', 
-            default=0.0, min=-100.0, max=100.0)
-    contrast_value : FloatProperty(name='Contrast', description='Contrast', 
-            default=0.0, min=-100.0, max=100.0)
+    brightness_value : FloatProperty(
+        name = 'Brightness',
+        description = 'Brightness', 
+        default=0.0, min=-100.0, max=100.0
+    )
+
+    contrast_value : FloatProperty(
+        name = 'Contrast',
+        description = 'Contrast', 
+        default=0.0, min=-100.0, max=100.0
+    )
 
     # Hue Saturation nodes
     huesat : StringProperty(default='')
@@ -658,8 +685,9 @@ class YPaintModifier(bpy.types.PropertyGroup):
     math_meth : EnumProperty(
         name = 'Method',
         items = math_method_items,
-        default = "MULTIPLY",
-        update = update_math_method)
+        default = 'MULTIPLY',
+        update = update_math_method
+    )
 
     affect_alpha : BoolProperty(name='Affect Alpha', default=False, update=update_affect_alpha) 
 
@@ -670,10 +698,11 @@ class YPaintModifier(bpy.types.PropertyGroup):
     use_clamp : BoolProperty(name='Use Clamp', default=False, update=update_use_clamp)
 
     shortcut : BoolProperty(
-            name = 'Property Shortcut',
-            description = 'Property shortcut on layer list (currently only available on RGB to Intensity)',
-            default=False,
-            update=update_modifier_shortcut)
+        name = 'Property Shortcut',
+        description = 'Property shortcut on layer list (currently only available on RGB to Intensity)',
+        default = False,
+        update = update_modifier_shortcut
+    )
 
     expand_content : BoolProperty(default=True)
 

--- a/NormalMapModifier.py
+++ b/NormalMapModifier.py
@@ -4,12 +4,11 @@ from .common import *
 from .modifier_common import *
 from .node_connections import *
 from .node_arrangements import *
-from . import lib
 
 normalmap_modifier_type_items = (
-        ('INVERT', 'Invert', 'Invert', 'MODIFIER', 0),
-        ('MATH', 'Math', '', 'MODIFIER', 1),
-        )
+    ('INVERT', 'Invert', 'Invert', 'MODIFIER', 0),
+    ('MATH', 'Math', '', 'MODIFIER', 1),
+)
 
 def add_new_normalmap_modifier(ch, layer, modifier_type):
     tree = get_tree(layer)
@@ -34,7 +33,8 @@ class YNewNormalmapModifier(bpy.types.Operator):
     type : EnumProperty(
         name = 'Modifier Type',
         items = normalmap_modifier_type_items,
-        default = 'INVERT')
+        default = 'INVERT'
+    )
 
     @classmethod
     def poll(cls, context):
@@ -71,15 +71,21 @@ class YMoveNormalMapModifier(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     direction : EnumProperty(
-            name = 'Direction',
-            items = (('UP', 'Up', ''),
-                     ('DOWN', 'Down', '')),
-            default = 'UP')
+        name = 'Direction',
+        items = (
+            ('UP', 'Up', ''),
+            ('DOWN', 'Down', '')
+        ),
+        default = 'UP'
+    )
 
     @classmethod
     def poll(cls, context):
-        return (get_active_ypaint_node() and 
-                hasattr(context, 'parent') and hasattr(context, 'modifier'))
+        return (
+            get_active_ypaint_node() and 
+            hasattr(context, 'parent') and
+            hasattr(context, 'modifier')
+        )
 
     def execute(self, context):
         node = get_active_ypaint_node()
@@ -272,7 +278,8 @@ class YNormalMapModifier(bpy.types.PropertyGroup):
     type : EnumProperty(
         name = 'Modifier Type',
         items = normalmap_modifier_type_items,
-        default = 'INVERT')
+        default = 'INVERT'
+    )
 
     # Invert toggles
     invert_r_enable : BoolProperty(default=True, update=update_invert_channel)
@@ -289,7 +296,8 @@ class YNormalMapModifier(bpy.types.PropertyGroup):
         name = 'Method',
         items = math_method_items,
         default = "MULTIPLY",
-        update = update_math_method)
+        update = update_math_method
+    )
 
     affect_alpha : BoolProperty(name='Affect Alpha', default=False, update=update_affect_alpha) 
     use_clamp : BoolProperty(name='Use Clamp', default=False, update=update_use_clamp)

--- a/Root.py
+++ b/Root.py
@@ -44,7 +44,7 @@ def set_input_default_value(group_node, channel, custom_value=None):
     # Set default value
     if channel.type == 'RGB':
         #group_node.inputs[channel.io_index].default_value = (1,1,1,1)
-        group_node.inputs[channel.name].default_value = (1,1,1,1)
+        group_node.inputs[channel.name].default_value = (1, 1, 1, 1)
 
     if channel.type == 'VALUE':
         #group_node.inputs[channel.io_index].default_value = 0.0
@@ -52,7 +52,7 @@ def set_input_default_value(group_node, channel, custom_value=None):
     if channel.type == 'NORMAL':
         # Use 999 as normal z value so it will fallback to use geometry normal at checking process
         #group_node.inputs[channel.io_index].default_value = (999,999,999)
-        group_node.inputs[channel.name].default_value = (999,999,999)
+        group_node.inputs[channel.name].default_value = (999, 999, 999)
 
         # Update height default value
         io_name = channel.name + io_suffix['HEIGHT']
@@ -152,7 +152,7 @@ def create_new_yp_channel(group_tree, name, channel_type, non_color=True, enable
     channel.type = channel_type
 
     # Get last index
-    last_index = len(yp.channels)-1
+    last_index = len(yp.channels) - 1
 
     # Link new channel
     check_yp_channel_nodes(yp)
@@ -180,24 +180,28 @@ class YSelectMaterialPolygons(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     new_uv : BoolProperty(
-            name = 'Create New UV',
-            description = 'Create new UV rather than using available one',
-            default = False)
+        name = 'Create New UV',
+        description = 'Create new UV rather than using available one',
+        default = False
+    )
 
     new_uv_name : StringProperty(
-            name='New UV Name', 
-            description="Name of the new uv", 
-            default='UVMap')
+        name = 'New UV Name', 
+        description = 'Name of the new UV',
+        default = 'UVMap'
+    )
 
     uv_map : StringProperty(
-            name='Active UV Map', 
-            description="It will create one if other objects don't have it.\nIf empty, it will use the current active uv map for each object",
-            default='')
+        name = 'Active UV Map', 
+        description = "It will create one if other objects don't have it.\nIf empty, it will use the current active uv map for each object",
+        default = ''
+    )
 
     set_canvas_to_empty : BoolProperty(
-            name='Set Image Editor to empty',
-            description="Set image editor & canvas image to empty, so it's easier to see",
-            default=True)
+        name = 'Set Image Editor to empty',
+        description = "Set image editor & canvas image to empty, so it's easier to see",
+        default = True
+    )
 
     uv_map_coll : CollectionProperty(type=bpy.types.PropertyGroup)
 
@@ -311,16 +315,18 @@ class YRenameUVMaterial(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     uv_map : StringProperty(
-            name='Target UV Map', 
-            description="Target UV Map that will be renamed", 
-            default='')
+        name = 'Target UV Map', 
+        description = "Target UV Map that will be renamed", 
+        default = ''
+    )
 
     uv_map_coll : CollectionProperty(type=bpy.types.PropertyGroup)
 
     new_uv_name : StringProperty(
-            name='New UV Name', 
-            description="New name for the UV", 
-            default='UVMap')
+        name = 'New UV Name', 
+        description = 'New name for the UV',
+        default = 'UVMap'
+    )
 
     @classmethod
     def poll(cls, context):
@@ -423,13 +429,14 @@ class YQuickYPaintNodeSetup(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     type : EnumProperty(
-            name = 'Type',
-            items = (('BSDF_PRINCIPLED', 'Principled', ''),
-                     ('BSDF_DIFFUSE', 'Diffuse', ''),
-                     ('EMISSION', 'Emission', ''),
-                     ),
-            default = 'BSDF_PRINCIPLED')
-            #update=update_quick_setup_type)
+        name = 'Type',
+        items = (
+            ('BSDF_PRINCIPLED', 'Principled', ''),
+            ('BSDF_DIFFUSE', 'Diffuse', ''),
+            ('EMISSION', 'Emission', ''),
+        ),
+        default = 'BSDF_PRINCIPLED'
+    )
 
     color : BoolProperty(name='Color', default=True)
     ao : BoolProperty(name='Ambient Occlusion', default=False)
@@ -438,23 +445,26 @@ class YQuickYPaintNodeSetup(bpy.types.Operator):
     normal : BoolProperty(name='Normal', default=True)
 
     mute_texture_paint_overlay : BoolProperty(
-            name = 'Mute Stencil Mask Opacity',
-            description = 'Set Stencil Mask Opacity found in the 3D Viewport\'s Overlays menu to 0',
-            default = True)
+        name = 'Mute Stencil Mask Opacity',
+        description = 'Set Stencil Mask Opacity found in the 3D Viewport\'s Overlays menu to 0',
+        default = True
+    )
 
     use_linear_blending : BoolProperty(
-            name = 'Use Linear Color Blending',
-            description = 'Use more accurate linear color blending (it will behave differently than Photoshop)',
-            default = True)
+        name = 'Use Linear Color Blending',
+        description = 'Use more accurate linear color blending (it will behave differently than Photoshop)',
+        default = True
+    )
 
     switch_to_material_view : BoolProperty(
-            name = 'Switch to Material View',
-            description = 'Switch to material view so the node setup is automatically visible',
-            default = True)
+        name = 'Switch to Material View',
+        description = 'Switch to material view so the node setup is automatically visible',
+        default = True
+    )
 
-    target_bsdf_name : StringProperty(default = '')
-    not_muted_paint_opacity : BoolProperty(default = False)
-    not_on_material_view : BoolProperty(default = True)
+    target_bsdf_name : StringProperty(default='')
+    not_muted_paint_opacity : BoolProperty(default=False)
+    not_on_material_view : BoolProperty(default=True)
 
     @classmethod
     def poll(cls, context):
@@ -540,7 +550,7 @@ class YQuickYPaintNodeSetup(bpy.types.Operator):
         obj = context.object
 
         if not obj.data or not hasattr(obj.data, 'materials'):
-            self.report({'ERROR'}, "Cannot use "+get_addon_title()+" with object '"+obj.name+"'!")
+            self.report({'ERROR'}, "Cannot use " + get_addon_title() + " with object '" + obj.name + "'!")
             return {'CANCELLED'}
 
         mat = get_active_material()
@@ -730,7 +740,7 @@ class YQuickYPaintNodeSetup(bpy.types.Operator):
                 links.new(node.outputs[ch_color.name], inp)
 
         if ch_ao:
-            set_input_default_value(node, ch_ao, (1,1,1))
+            set_input_default_value(node, ch_ao, (1, 1, 1))
 
         if ch_metallic:
             inp = main_bsdf.inputs['Metallic']
@@ -799,8 +809,7 @@ class YNewYPaintNode(bpy.types.Operator):
         # convert mouse position to the View2D for later node placement
         if context.region.type == 'WINDOW':
             # convert mouse position to the View2D for later node placement
-            space.cursor_location_from_region(
-                    event.mouse_region_x, event.mouse_region_y)
+            space.cursor_location_from_region(event.mouse_region_x, event.mouse_region_y)
         else:
             space.cursor_location = tree.view_center
 
@@ -808,8 +817,11 @@ class YNewYPaintNode(bpy.types.Operator):
     def poll(cls, context):
         space = context.space_data
         # needs active node editor and a tree to add nodes to
-        return ((space.type == 'NODE_EDITOR') and
-                space.edit_tree and not space.edit_tree.library)
+        return (
+            space.type == 'NODE_EDITOR' and
+            space.edit_tree and
+            not space.edit_tree.library
+        )
 
     def execute(self, context):
         space = context.space_data
@@ -870,9 +882,11 @@ class YNewYPaintNode(bpy.types.Operator):
         return result
 
 def new_channel_items(self, context):
-    items = [('VALUE', 'Value', '', lib.get_icon(lib.channel_custom_icon_dict['VALUE']), 0),
-             ('RGB', 'RGB', '', lib.get_icon(lib.channel_custom_icon_dict['RGB']), 1),
-             ('NORMAL', 'Normal', '', lib.get_icon(lib.channel_custom_icon_dict['NORMAL']), 2)]
+    items = [
+        ('VALUE', 'Value', '', lib.get_icon(lib.channel_custom_icon_dict['VALUE']), 0),
+        ('RGB', 'RGB', '', lib.get_icon(lib.channel_custom_icon_dict['RGB']), 1),
+        ('NORMAL', 'Normal', '', lib.get_icon(lib.channel_custom_icon_dict['NORMAL']), 2)
+    ]
 
     return items
 
@@ -1096,42 +1110,48 @@ class YNewYPaintChannel(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     name : StringProperty(
-            name='Channel Name', 
-            description = 'Name of the channel',
-            default='Albedo')
+        name = 'Channel Name', 
+        description = 'Name of the channel',
+        default = 'Albedo'
+    )
 
     type : EnumProperty(
-            name = 'Channel Type',
-            items = new_channel_items)
+        name = 'Channel Type',
+        items = new_channel_items
+    )
 
     connect_to : StringProperty(name='Connect To', default='', update=update_connect_to)
     input_coll : CollectionProperty(type=YPaintNodeInputCollItem)
 
     colorspace : EnumProperty(
-            name = 'Color Space',
-            description = "Non-color won't be converted to linear first before blending",
-            items = colorspace_items,
-            default='LINEAR')
+        name = 'Color Space',
+        description = "Non-color won't be converted to linear first before blending",
+        items = colorspace_items,
+        default = 'LINEAR'
+    )
 
     use_clamp : BoolProperty(
-            name='Use Clamp', 
-            description = 'Use clamp of newly the channel',
-            default=True)
+        name = 'Use Clamp', 
+        description = 'Use clamp of newly the channel',
+        default = True
+    )
 
     set_strength_to_one : BoolProperty(
-            name='Set Strength to One', 
-            description = 'Set socket strength to one',
-            default=True)
+        name = 'Set Strength to One', 
+        description = 'Set socket strength to one',
+        default = True
+    )
 
     blend_method : EnumProperty(
-            name='Blend Method', 
-            description = 'Blend method for transparent material',
-            items = (
-                ('CLIP', 'Alpha Clip', ''),
-                ('HASHED', 'Alpha Hashed', ''),
-                ('BLEND', 'Alpha Blend', '')),
-            default='HASHED'
-            )
+        name = 'Blend Method', 
+        description = 'Blend method for transparent material',
+        items = (
+            ('CLIP', 'Alpha Clip', ''),
+            ('HASHED', 'Alpha Hashed', ''),
+            ('BLEND', 'Alpha Blend', '')
+        ),
+        default = 'HASHED'
+    )
 
     @classmethod
     def poll(cls, context):
@@ -1231,8 +1251,10 @@ class YNewYPaintChannel(bpy.types.Operator):
             return {'CANCELLED'}
 
         # Create new yp channel
-        channel = create_new_yp_channel(group_tree, self.name, self.type, 
-                non_color=self.colorspace == 'LINEAR')
+        channel = create_new_yp_channel(
+            group_tree, self.name, self.type, 
+            non_color = self.colorspace == 'LINEAR'
+        )
 
         # Update io
         check_all_channel_ios(yp, yp_node=node)
@@ -1300,10 +1322,13 @@ class YMoveYPaintChannel(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     direction : EnumProperty(
-            name = 'Direction',
-            items = (('UP', 'Up', ''),
-                     ('DOWN', 'Down', '')),
-            default = 'UP')
+        name = 'Direction',
+        items = (
+            ('UP', 'Up', ''),
+            ('DOWN', 'Down', '')
+        ),
+        default = 'UP'
+    )
 
     @classmethod
     def poll(cls, context):
@@ -1384,9 +1409,10 @@ class YRemoveYPaintChannel(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     also_del_vcol : BoolProperty(
-        name="Also remove baked vertex color",
-        description="Also remove baked vertex color",
-        default=False)
+        name = 'Also remove baked vertex color',
+        description = 'Also remove baked vertex color',
+        default = False
+    )
 
     @classmethod
     def poll(cls, context):
@@ -1873,25 +1899,28 @@ class YDuplicateYPNodes(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     duplicate_node : BoolProperty(
-            name = 'Duplicate this Node',
-            description = 'Duplicate this node',
-            default=False)
+        name = 'Duplicate this Node',
+        description = 'Duplicate this node',
+        default = False
+    )
 
     duplicate_material : BoolProperty(
-            name = 'Also Duplicate Material',
-            description = 'Also Duplicate this node parent materials',
-            default=False)
+        name = 'Also Duplicate Material',
+        description = 'Also Duplicate this node parent materials',
+        default = False
+    )
 
     only_active : BoolProperty(
-            name = 'Only Duplicate on active object',
-            description = 'Only duplicate on active object, rather than all accessible objects using the same material',
-            default=True)
+        name = 'Only Duplicate on active object',
+        description = 'Only duplicate on active object, rather than all accessible objects using the same material',
+        default = True
+    )
 
     ondisk_duplicate : BoolProperty(
-            name = 'Duplicate Images on disk',
-            description = 'Duplicate images on disk, this will create copies of images sourced from external files',
-            default = False
-            )
+        name = 'Duplicate Images on disk',
+        description = 'Duplicate images on disk, this will create copies of images sourced from external files',
+        default = False
+    )
 
     @classmethod
     def poll(cls, context):
@@ -2047,11 +2076,13 @@ def fix_missing_vcol(obj, name, src):
     set_obj_vertex_colors(obj, vcol.name, (0.0, 0.0, 0.0, 0.0))
 
 def fix_missing_img(name, src, is_mask=False):
-    img = bpy.data.images.new(name=name, 
-            width=1024, height=1024, alpha= not is_mask, float_buffer=False)
+    img = bpy.data.images.new(
+        name=name, width=1024, height=1024,
+        alpha=not is_mask, float_buffer=False
+    )
     if is_mask:
-        img.generated_color = (1,1,1,1)
-    else: img.generated_color = (0,0,0,0)
+        img.generated_color = (1, 1, 1, 1)
+    else: img.generated_color = (0, 0, 0, 0)
     src.image = img
 
 class YOptimizeNormalProcess(bpy.types.Operator):
@@ -2250,8 +2281,8 @@ class YRemoveYPaintNode(bpy.types.Operator):
         return context.window_manager.invoke_props_dialog(self)
 
     def draw(self, context):
-        self.layout.label(text= "This " + get_addon_title() + " node setup isn't baked yet!")
-        self.layout.label(text= "Are you sure want to delete?")
+        self.layout.label(text="This " + get_addon_title() + " node setup isn't baked yet!")
+        self.layout.label(text="Are you sure want to delete?")
 
     def execute(self, context):
         mat = get_active_material()
@@ -2399,14 +2430,16 @@ def get_preview(mat, output=None, advanced=False, normal_viewer=False):
     if advanced:
         if normal_viewer:
             preview, dirty = simple_replace_new_node(
-                    tree, EMISSION_VIEWER, 'ShaderNodeGroup', 'Emission Viewer', 
-                    lib.ADVANCED_NORMAL_EMISSION_VIEWER,
-                    return_status=True, hard_replace=True)
+                tree, EMISSION_VIEWER, 'ShaderNodeGroup', 'Emission Viewer', 
+                lib.ADVANCED_NORMAL_EMISSION_VIEWER,
+                return_status=True, hard_replace=True
+            )
         else:
             preview, dirty = simple_replace_new_node(
-                    tree, EMISSION_VIEWER, 'ShaderNodeGroup', 'Emission Viewer', 
-                    lib.ADVANCED_EMISSION_VIEWER,
-                    return_status=True, hard_replace=True)
+                tree, EMISSION_VIEWER, 'ShaderNodeGroup', 'Emission Viewer', 
+                lib.ADVANCED_EMISSION_VIEWER,
+                return_status=True, hard_replace=True
+            )
         if dirty:
             duplicate_lib_node_tree(preview)
             #preview.node_tree = preview.node_tree.copy()
@@ -2421,13 +2454,15 @@ def get_preview(mat, output=None, advanced=False, normal_viewer=False):
     else:
         if normal_viewer:
             preview, dirty = simple_replace_new_node(
-                    tree, EMISSION_VIEWER, 'ShaderNodeGroup', 'Emission Viewer', 
-                    lib.NORMAL_EMISSION_VIEWER,
-                    return_status=True, hard_replace=True)
+                tree, EMISSION_VIEWER, 'ShaderNodeGroup', 'Emission Viewer', 
+                lib.NORMAL_EMISSION_VIEWER,
+                return_status=True, hard_replace=True
+            )
         else:
             preview, dirty = simple_replace_new_node(
-                    tree, EMISSION_VIEWER, 'ShaderNodeEmission', 'Emission Viewer', 
-                    return_status=True)
+                tree, EMISSION_VIEWER, 'ShaderNodeEmission', 'Emission Viewer', 
+                return_status = True
+            )
 
     if dirty:
         preview.hide = True
@@ -2524,10 +2559,10 @@ def layer_preview_mode_type_items(self, context):
     #yp = node.node_tree.yp
 
     items = (
-            ('LAYER', 'Layer', '',  lib.get_icon('texture'), 0),
-            ('MASK', 'Mask', '', lib.get_icon('mask'), 1),
-            ('SPECIFIC_MASK', 'Specific Mask', '', lib.get_icon('mask'), 2)
-            )
+        ('LAYER', 'Layer', '',  lib.get_icon('texture'), 0),
+        ('MASK', 'Mask', '', lib.get_icon('mask'), 1),
+        ('SPECIFIC_MASK', 'Specific Mask', '', lib.get_icon('mask'), 2)
+    )
 
     #for i, ch in enumerate(yp.channels):
     #    #if hasattr(lib, 'custom_icons'):
@@ -2677,8 +2712,8 @@ def update_preview_mode(self, context):
             # Cycle outputs
             for i, o in enumerate(outs):
                 if o == from_socket:
-                    if i != len(outs)-1:
-                        tree.links.new(outs[i+1], preview.inputs[0])
+                    if i != len(outs) - 1:
+                        tree.links.new(outs[i + 1], preview.inputs[0])
                     else: tree.links.new(outs[0], preview.inputs[0])
 
         tree.links.new(preview.outputs[0], output.inputs[0])
@@ -2769,7 +2804,7 @@ def update_channel_colorspace(self, context):
                     rgb2i = nodes.get(mod.rgb2i)
                     if self.colorspace == 'LINEAR':
                         rgb2i.inputs['Gamma'].default_value = 1.0
-                    else: rgb2i.inputs['Gamma'].default_value = 1.0/GAMMA
+                    else: rgb2i.inputs['Gamma'].default_value = 1.0 / GAMMA
 
                 if mod.type == 'COLOR_RAMP':
 
@@ -2782,7 +2817,7 @@ def update_channel_colorspace(self, context):
                     color_ramp_linear = nodes.get(mod.color_ramp_linear)
                     if color_ramp_linear:
                         if self.colorspace == 'SRGB':
-                            color_ramp_linear.inputs[1].default_value = 1.0/GAMMA
+                            color_ramp_linear.inputs[1].default_value = 1.0 / GAMMA
                         else: color_ramp_linear.inputs[1].default_value = 1.0
 
     for layer in yp.layers:
@@ -2817,13 +2852,13 @@ def update_channel_colorspace(self, context):
                     rgb2i = mod_tree.nodes.get(mod.rgb2i)
                     if self.colorspace == 'LINEAR':
                         rgb2i.inputs['Gamma'].default_value = 1.0
-                    else: rgb2i.inputs['Gamma'].default_value = 1.0/GAMMA
+                    else: rgb2i.inputs['Gamma'].default_value = 1.0 / GAMMA
 
                 if mod.type == 'OVERRIDE_COLOR':
                     oc = mod_tree.nodes.get(mod.oc)
                     if self.colorspace == 'LINEAR':
                         oc.inputs['Gamma'].default_value = 1.0
-                    else: oc.inputs['Gamma'].default_value = 1.0/GAMMA
+                    else: oc.inputs['Gamma'].default_value = 1.0 / GAMMA
 
                 if mod.type == 'COLOR_RAMP':
 
@@ -2836,21 +2871,21 @@ def update_channel_colorspace(self, context):
                     color_ramp_linear = mod_tree.nodes.get(mod.color_ramp_linear)
                     if color_ramp_linear:
                         if self.colorspace == 'SRGB':
-                            color_ramp_linear.inputs[1].default_value = 1.0/GAMMA
+                            color_ramp_linear.inputs[1].default_value = 1.0 / GAMMA
                         else: color_ramp_linear.inputs[1].default_value = 1.0
 
         if ch.enable_transition_ramp:
             tr_ramp = tree.nodes.get(ch.tr_ramp)
             if tr_ramp:
                 if self.colorspace == 'SRGB':
-                    tr_ramp.inputs['Gamma'].default_value = 1.0/GAMMA
+                    tr_ramp.inputs['Gamma'].default_value = 1.0 / GAMMA
                 else: tr_ramp.inputs['Gamma'].default_value = 1.0
 
         if ch.enable_transition_ao:
             tao = tree.nodes.get(ch.tao)
             if tao:
                 if self.colorspace == 'SRGB':
-                    tao.inputs['Gamma'].default_value = 1.0/GAMMA
+                    tao.inputs['Gamma'].default_value = 1.0 / GAMMA
                 else: tao.inputs['Gamma'].default_value = 1.0
 
         for mod in ch.modifiers:
@@ -2859,13 +2894,13 @@ def update_channel_colorspace(self, context):
                 rgb2i = tree.nodes.get(mod.rgb2i)
                 if self.colorspace == 'LINEAR':
                     rgb2i.inputs['Gamma'].default_value = 1.0
-                else: rgb2i.inputs['Gamma'].default_value = 1.0/GAMMA
+                else: rgb2i.inputs['Gamma'].default_value = 1.0 / GAMMA
 
             if mod.type == 'OVERRIDE_COLOR':
                 oc = tree.nodes.get(mod.oc)
                 if self.colorspace == 'LINEAR':
                     oc.inputs['Gamma'].default_value = 1.0
-                else: oc.inputs['Gamma'].default_value = 1.0/GAMMA
+                else: oc.inputs['Gamma'].default_value = 1.0 / GAMMA
 
             if mod.type == 'COLOR_RAMP':
 
@@ -2878,7 +2913,7 @@ def update_channel_colorspace(self, context):
                 color_ramp_linear = tree.nodes.get(mod.color_ramp_linear)
                 if color_ramp_linear:
                     if self.colorspace == 'SRGB':
-                        color_ramp_linear.inputs[1].default_value = 1.0/GAMMA
+                        color_ramp_linear.inputs[1].default_value = 1.0 / GAMMA
                     else: color_ramp_linear.inputs[1].default_value = 1.0
 
     check_start_end_root_ch_nodes(group_tree, self)
@@ -3067,12 +3102,12 @@ def update_channel_alpha(self, context):
                 mat.game_settings.alpha_blend = 'OPAQUE'
 
         node = get_active_ypaint_node()
-        inp = node.inputs[self.io_index+1]
+        inp = node.inputs[self.io_index + 1]
 
         if yp.use_baked and yp.enable_baked_outside and tex:
             outp = tex.outputs[1]
         else:
-            outp = node.outputs[self.io_index+1]
+            outp = node.outputs[self.io_index + 1]
 
         # Remember the connections
         if len(inp.links) > 0:
@@ -3340,133 +3375,160 @@ class YNodeConnections(bpy.types.PropertyGroup):
 
 class YPaintChannel(bpy.types.PropertyGroup):
     name : StringProperty(
-            name='Channel Name', 
-            description = 'Name of the channel',
-            default='Albedo',
-            update=update_channel_name, get=get_channel_name, set=set_channel_name)
+        name = 'Channel Name', 
+        description = 'Name of the channel',
+        default = 'Albedo',
+        update = update_channel_name,
+        get = get_channel_name,
+        set = set_channel_name
+    )
 
     type : EnumProperty(
-            name = 'Channel Type',
-            items = (('VALUE', 'Value', ''),
-                     ('RGB', 'RGB', ''),
-                     ('NORMAL', 'Normal', '')),
-            default = 'RGB')
+        name = 'Channel Type',
+        items = (
+            ('VALUE', 'Value', ''),
+            ('RGB', 'RGB', ''),
+            ('NORMAL', 'Normal', '')
+        ),
+        default = 'RGB'
+    )
 
     enable_smooth_bump : BoolProperty(
-            name = 'Enable Smooth Bump',
-            description = 'Enable smooth bump map.\nLooks better but bump height scaling will be different than standard bump map.\nSmooth bump map -> Texture space.\nStandard bump map -> World space',
-            default=True,
-            update=update_enable_smooth_bump)
+        name = 'Enable Smooth Bump',
+        description = 'Enable smooth bump map.\nLooks better but bump height scaling will be different than standard bump map.\nSmooth bump map -> Texture space.\nStandard bump map -> World space',
+        default = True,
+        update = update_enable_smooth_bump
+    )
 
     use_clamp : BoolProperty(
-            name = 'Use Clamp',
-            description = 'Clamp result to 0..1 range.\nDisabling this will make the baked channel uses float image',
-            default = True,
-            update=update_channel_use_clamp)
+        name = 'Use Clamp',
+        description = 'Clamp result to 0..1 range.\nDisabling this will make the baked channel uses float image',
+        default = True,
+        update = update_channel_use_clamp
+    )
 
     # Input output index
     io_index : IntProperty(default=-1)
 
     # Alpha for transparent materials
     enable_alpha : BoolProperty(
-            name = 'Enable Alpha Blend on Channel',
-            description = 'Enable alpha blend on channel',
-            default=False, update=update_channel_alpha)
+        name = 'Enable Alpha Blend on Channel',
+        description = 'Enable alpha blend on channel',
+        default = False,
+        update = update_channel_alpha
+    )
 
     alpha_blend_mode : EnumProperty(
-            name = 'Alpha Blend Mode',
-            description = 'This will change your material blend mode if alpha is enabled',
-            items = (
-                ('CLIP', 'Alpha Clip', ''),
-                ('HASHED', 'Alpha Hashed', ''),
-                ('BLEND', 'Alpha Blend', ''),
-                ),
-            default = 'HASHED',
-            update=update_channel_alpha_blend_mode
-            )
+        name = 'Alpha Blend Mode',
+        description = 'This will change your material blend mode if alpha is enabled',
+        items = (
+            ('CLIP', 'Alpha Clip', ''),
+            ('HASHED', 'Alpha Hashed', ''),
+            ('BLEND', 'Alpha Blend', ''),
+        ),
+        default = 'HASHED',
+        update = update_channel_alpha_blend_mode
+    )
 
     alpha_shadow_mode : EnumProperty(
-            name = 'Alpha Shadow Mode',
-            description = 'This will change your material shadow mode if alpha is enabled',
-            items = (
-                ('NONE', 'None', ''),
-                ('OPAQUE', 'Opaque', ''),
-                ('HASHED', 'Alpha Hashed', ''),
-                ('CLIP', 'Alpha Clip', ''),
-                ),
-            default = 'HASHED',
-            update=update_channel_alpha_blend_mode
-            )
+        name = 'Alpha Shadow Mode',
+        description = 'This will change your material shadow mode if alpha is enabled',
+        items = (
+            ('NONE', 'None', ''),
+            ('OPAQUE', 'Opaque', ''),
+            ('HASHED', 'Alpha Hashed', ''),
+            ('CLIP', 'Alpha Clip', ''),
+        ),
+        default = 'HASHED',
+        update = update_channel_alpha_blend_mode
+    )
 
     # Backface mode for alpha
     backface_mode : EnumProperty(
-            name = 'Backface Mode',
-            description = 'Backface mode',
-            items = (
-                ('BOTH', 'Both', ''),
-                ('FRONT_ONLY', 'Front Only / Backface Culling', ''),
-                ('BACK_ONLY', 'Back Only', ''),
-                ),
-            default = 'BOTH', update=update_backface_mode)
+        name = 'Backface Mode',
+        description = 'Backface mode',
+        items = (
+            ('BOTH', 'Both', ''),
+            ('FRONT_ONLY', 'Front Only / Backface Culling', ''),
+            ('BACK_ONLY', 'Back Only', ''),
+        ),
+        default = 'BOTH',
+        update = update_backface_mode
+    )
 
-    enable_bake_to_vcol : BoolProperty(name='Enable Bake to Vertex Color',
-            description='Enable vertex color as bake target',
-            default=False, update=Bake.update_enable_bake_to_vcol)
+    enable_bake_to_vcol : BoolProperty(
+        name = 'Enable Bake to Vertex Color',
+        description = 'Enable vertex color as bake target',
+        default = False,
+        update = Bake.update_enable_bake_to_vcol
+    )
 
     bake_to_vcol_alpha : BoolProperty(
-            name='Bake To Vertex Color Alpha', 
-            description='When enabled, the channel are baked only to Alpha with vertex color', 
-            default=False)
+        name = 'Bake To Vertex Color Alpha', 
+        description = 'When enabled, the channel are baked only to Alpha with vertex color', 
+        default = False
+    )
 
     bake_to_vcol_name : StringProperty(
-            name='Target Vertex Color Name',
-            description='Target Vertex Color Name',
-            default='', get=get_channel_vcol_name, set=set_channel_vcol_name)
+        name = 'Target Vertex Color Name',
+        description = 'Target Vertex Color Name',
+        default = '',
+        get = get_channel_vcol_name,
+        set = set_channel_vcol_name
+    )
 
     # Displacement for normal channel
     enable_parallax : BoolProperty(
-            name = 'Enable Parallax Mapping',
-            description = 'Enable Parallax Mapping.\nIt will use texture space scaling, so it may looks different when using it as real displacement map',
-            default=False, update=update_channel_parallax)
+        name = 'Enable Parallax Mapping',
+        description = 'Enable Parallax Mapping.\nIt will use texture space scaling, so it may looks different when using it as real displacement map',
+        default = False,
+        update = update_channel_parallax
+    )
 
     #parallax_num_of_layers : IntProperty(default=8, min=4, max=128,
     #        update=update_parallax_num_of_layers)
     parallax_num_of_layers : EnumProperty(
-            name = 'Parallax Mapping Number of Layers',
-            description = 'Parallax Mapping Number of Layers',
-            items = (('4', '4', ''),
-                     ('8', '8', ''),
-                     ('16', '16', ''),
-                     ('24', '24', ''),
-                     ('32', '32', ''),
-                     ('64', '64', ''),
-                     ('96', '96', ''),
-                     ('128', '128', ''),
-                     ),
-            default='8',
-            update=update_parallax_num_of_layers)
+        name = 'Parallax Mapping Number of Layers',
+        description = 'Parallax Mapping Number of Layers',
+        items = (
+            ('4', '4', ''),
+            ('8', '8', ''),
+            ('16', '16', ''),
+            ('24', '24', ''),
+            ('32', '32', ''),
+            ('64', '64', ''),
+            ('96', '96', ''),
+            ('128', '128', ''),
+        ),
+        default = '8',
+        update = update_parallax_num_of_layers
+    )
 
     baked_parallax_num_of_layers : EnumProperty(
-            name = 'Baked Parallax Mapping Number of Layers',
-            description = 'Baked Parallax Mapping Number of Layers',
-            items = (('4', '4', ''),
-                     ('8', '8', ''),
-                     ('16', '16', ''),
-                     ('24', '24', ''),
-                     ('32', '32', ''),
-                     ('64', '64', ''),
-                     ('96', '96', ''),
-                     ('128', '128', ''),
-                     ('192', '192', ''),
-                     ('256', '256', ''),
-                     ),
-            default='32',
-            update=update_parallax_num_of_layers)
+        name = 'Baked Parallax Mapping Number of Layers',
+        description = 'Baked Parallax Mapping Number of Layers',
+        items = (
+            ('4', '4', ''),
+            ('8', '8', ''),
+            ('16', '16', ''),
+            ('24', '24', ''),
+            ('32', '32', ''),
+            ('64', '64', ''),
+            ('96', '96', ''),
+            ('128', '128', ''),
+            ('192', '192', ''),
+            ('256', '256', ''),
+        ),
+        default = '32',
+        update = update_parallax_num_of_layers
+    )
 
     disable_global_baked : BoolProperty(
-            name = 'Disable Global Baked', 
-            description = 'Disable baked image for this channel if global baked is on',
-            default=False, update=update_channel_disable_global_baked)
+        name = 'Disable Global Baked', 
+        description = 'Disable baked image for this channel if global baked is on',
+        default = False,
+        update = update_channel_disable_global_baked
+    )
 
     #use_baked : BoolProperty(
     #        name = 'Use Baked Image', 
@@ -3479,24 +3541,36 @@ class YPaintChannel(bpy.types.PropertyGroup):
     # To mark if channel needed to be baked or not
     no_layer_using : BoolProperty(default=True)
 
-    parallax_rim_hack : BoolProperty(default=False, 
-            update=update_parallax_rim_hack)
+    parallax_rim_hack : BoolProperty(
+        default = False, 
+        update = update_parallax_rim_hack
+    )
 
-    parallax_rim_hack_hardness : FloatProperty(default=1.0, min=1.0, max=100.0, 
-            update=update_parallax_rim_hack)
+    parallax_rim_hack_hardness : FloatProperty(
+        default=1.0, min=1.0, max=100.0, 
+        update = update_parallax_rim_hack
+    )
 
-    parallax_height_tweak : FloatProperty(subtype='FACTOR', default=1.0, min=0.0, max=1.0,
-            update=update_parallax_height_tweak)
+    parallax_height_tweak : FloatProperty(
+        subtype = 'FACTOR',
+        default=1.0, min=0.0, max=1.0,
+        update = update_parallax_height_tweak
+    )
 
     # Currently unused
-    parallax_ref_plane : FloatProperty(subtype='FACTOR', default=0.5, min=0.0, max=1.0,
-            update=update_displacement_ref_plane)
+    parallax_ref_plane : FloatProperty(
+        subtype = 'FACTOR',
+        default=0.5, min=0.0, max=1.0,
+        update = update_displacement_ref_plane
+    )
 
     # Real displacement using height map
     enable_subdiv_setup : BoolProperty(
-            name = 'Enable Displacement Setup',
-            description = 'Enable displacement setup. Only works with Cycles or Eevee Next.',
-            default=False, update=Bake.update_enable_subdiv_setup)
+        name = 'Enable Displacement Setup',
+        description = 'Enable displacement setup. Only works with Cycles or Eevee Next.',
+        default = False,
+        update = Bake.update_enable_subdiv_setup
+    )
 
     #subdiv_standard_type : EnumProperty(
     #        name = 'Subdivision Standard Type',
@@ -3510,17 +3584,18 @@ class YPaintChannel(bpy.types.PropertyGroup):
     #        )
 
     subdiv_adaptive : BoolProperty(
-            name = 'Use Adaptive Subdivision',
-            description = 'Use Adaptive Subdivision (only works with Cycles)',
-            default=False, update=Bake.update_subdiv_setup
-            )
+        name = 'Use Adaptive Subdivision',
+        description = 'Use Adaptive Subdivision (only works with Cycles)',
+        default = False,
+        update = Bake.update_subdiv_setup
+    )
     
     subdiv_on_max_polys : IntProperty(
-            name = 'Subdiv On Max Polygons',
-            description = 'Max Polygons (in thousand) when displacement setup is on',
-            default=1000, min=1, max=10000, 
-            update=Bake.update_subdiv_max_polys
-            )
+        name = 'Subdiv On Max Polygons',
+        description = 'Max Polygons (in thousand) when displacement setup is on',
+        default=1000, min=1, max=10000, 
+        update = Bake.update_subdiv_max_polys
+    )
 
     #subdiv_on_level : IntProperty(
     #        name = 'Subdiv On Level',
@@ -3536,55 +3611,60 @@ class YPaintChannel(bpy.types.PropertyGroup):
 
     # Depcrecated
     subdiv_tweak : FloatProperty(
-            name = 'Subdiv Tweak',
-            description = 'Tweak displacement height',
-            default=1.0, min=-1000.0, max=1000.0
-            )
+        name = 'Subdiv Tweak',
+        description = 'Tweak displacement height',
+        default=1.0, min=-1000.0, max=1000.0
+    )
 
     height_tweak : FloatProperty(
-            name = 'Height Tweak',
-            description = 'Multiply height value',
-            default=1.0, min=-1000.0, max=1000.0
-            )
+        name = 'Height Tweak',
+        description = 'Multiply height value',
+        default=1.0, min=-1000.0, max=1000.0
+    )
 
     enable_height_tweak : BoolProperty(
-            name = 'Height Tweak',
-            description = 'Tweak displacement height',
-            default=False,
-            update=update_enable_height_tweak
-            )
+        name = 'Height Tweak',
+        description = 'Tweak displacement height',
+        default = False,
+        update = update_enable_height_tweak
+    )
 
     enable_smooth_normal_tweak : BoolProperty(
-            name = 'Smooth Normal Tweak',
-            description = 'Tweak smooth normal',
-            default=False,
-            update=update_enable_height_tweak
-            )
+        name = 'Smooth Normal Tweak',
+        description = 'Tweak smooth normal',
+        default = False,
+        update = update_enable_height_tweak
+    )
 
     smooth_normal_tweak : FloatProperty(
-            name = 'Smooth Normal Tweak',
-            description = 'Tweak smooth normal value',
-            default=1.0, min=-1000.0, max=1000.0
-            )
+        name = 'Smooth Normal Tweak',
+        description = 'Tweak smooth normal value',
+        default=1.0, min=-1000.0, max=1000.0
+    )
 
-    subdiv_global_dicing : FloatProperty(subtype='PIXEL', default=1.0, min=0.5, max=1000,
-            update=Bake.update_subdiv_global_dicing)
+    subdiv_global_dicing : FloatProperty(
+        subtype = 'PIXEL',
+        default=1.0, min=0.5, max=1000,
+        update = Bake.update_subdiv_global_dicing
+    )
 
     subdiv_subsurf_only : BoolProperty(
-            name = 'Use Subsurf Modifier Only',
-            description = 'Ignore Multires and use subsurf modifier exclusively (useful if you already baked the multires to layer)',
-            default=False, update=Bake.update_subdiv_setup
-            )
+        name = 'Use Subsurf Modifier Only',
+        description = 'Ignore Multires and use subsurf modifier exclusively (useful if you already baked the multires to layer)',
+        default = False,
+        update = Bake.update_subdiv_setup
+    )
 
     # Main uv is used for normal calculation of normal channel
     main_uv : StringProperty(default='', update=update_channel_main_uv)
 
     colorspace : EnumProperty(
-            name = 'Color Space',
-            description = "Non-color won't be converted to linear first before blending",
-            items = colorspace_items,
-            default='LINEAR',
-            update=update_channel_colorspace)
+        name = 'Color Space',
+        description = "Non-color won't be converted to linear first before blending",
+        items = colorspace_items,
+        default = 'LINEAR',
+        update = update_channel_colorspace
+    )
 
     modifiers : CollectionProperty(type=Modifier.YPaintModifier)
     active_modifier_index : IntProperty(default=0)
@@ -3679,51 +3759,65 @@ class YPaint(bpy.types.PropertyGroup):
     is_ypaint_layer_node : BoolProperty(default=False)
     version : StringProperty(default='')
     blender_version : StringProperty(default='1.0.0')
+
     is_unstable : BoolProperty(
-            name= 'Unstable Save Flag',
-            description= 'Flag to check if the node saved using unstable (Alpha/Beta) version',
-            default=False)
+        name = 'Unstable Save Flag',
+        description = 'Flag to check if the node saved using unstable (Alpha/Beta) version',
+        default = False
+    )
 
     # Channels
     channels : CollectionProperty(type=YPaintChannel)
+
     active_channel_index : IntProperty(
-            name = 'Active Channel Index',
-            description = 'Active channel index',
-            default=0, update=update_active_yp_channel)
+        name = 'Active Channel Index',
+        description = 'Active channel index',
+        default = 0,
+        update = update_active_yp_channel
+    )
 
     # Layers
     layers : CollectionProperty(type=Layer.YLayer)
+
     active_layer_index : IntProperty(
-            name = 'Active Layer Index',
-            description = 'Active layer index',
-            default=0, update=update_layer_index)
+        name = 'Active Layer Index',
+        description = 'Active layer index',
+        default = 0,
+        update = update_layer_index
+    )
 
     # UVs
     uvs : CollectionProperty(type=YPaintUV)
 
     # Bake Targets
     bake_targets : CollectionProperty(type=BakeTarget.YBakeTarget)
+
     active_bake_target_index : IntProperty(
-            name = 'Active Bake Target Index',
-            description = 'Active bake target index',
-            default=0, update=BakeTarget.update_active_bake_target_index)
+        name = 'Active Bake Target Index',
+        description = 'Active bake target index',
+        default = 0,
+        update = BakeTarget.update_active_bake_target_index
+    )
 
     # Temp channels to remember last channel selected when adding new layer
     #temp_channels = CollectionProperty(type=YChannelUI)
     preview_mode : BoolProperty(
-            name= 'Enable Channel Preview Mode',
-            description= 'Enable channel preview mode',
-            default=False, update=update_preview_mode)
+        name = 'Enable Channel Preview Mode',
+        description = 'Enable channel preview mode',
+        default = False,
+        update = update_preview_mode
+    )
 
     # Disable all vector displacement layers when sculpt mode is on
     sculpt_mode : BoolProperty(default=False, update=update_sculpt_mode)
 
     # Layer Preview Mode
     layer_preview_mode : BoolProperty(
-            name= 'Enable Layer Preview Mode',
-            description= 'Enable layer preview mode',
-            default=False,
-            update=update_layer_preview_mode)
+        name = 'Enable Layer Preview Mode',
+        description = 'Enable layer preview mode',
+        default = False,
+        update = update_layer_preview_mode
+    )
 
     # Mask Preview Mode
     #mask_preview_mode : BoolProperty(
@@ -3733,41 +3827,46 @@ class YPaint(bpy.types.PropertyGroup):
     #        update=update_mask_preview_mode)
 
     layer_preview_mode_type : EnumProperty(
-            name= 'Layer Preview Mode Type',
-            description = 'Layer preview mode type',
-            #items = (('LAYER', 'Layer', '', lib.get_icon('mask'), 0),
-            #         ('MASK', 'Mask', '', lib.get_icon('mask'), 1),
-            #         ('SPECIFIC_MASK', 'Specific Mask', '', lib.get_icon('mask'), 2),
-            #         ),
-            #items = (('LAYER', 'Layer', '', 'TEXTURE', 0),
-            #         ('MASK', 'Mask', '', 'MOD_MASK', 1),
-            #         ('SPECIFIC_MASK', 'Specific Mask', '', 'MOD_MASK', 2),
-            #         ),
-            items = (('LAYER', 'Layer', ''),
-                     ('ALPHA', 'Alpha', ''),
-                     ('SPECIFIC_MASK', 'Active Mask / Override', ''),
-                     ),
-            #items = layer_preview_mode_type_items,
-            default = 'LAYER',
-            update=update_layer_preview_mode
-            )
+        name = 'Layer Preview Mode Type',
+        description = 'Layer preview mode type',
+        #items = (('LAYER', 'Layer', '', lib.get_icon('mask'), 0),
+        #         ('MASK', 'Mask', '', lib.get_icon('mask'), 1),
+        #         ('SPECIFIC_MASK', 'Specific Mask', '', lib.get_icon('mask'), 2),
+        #         ),
+        #items = (('LAYER', 'Layer', '', 'TEXTURE', 0),
+        #         ('MASK', 'Mask', '', 'MOD_MASK', 1),
+        #         ('SPECIFIC_MASK', 'Specific Mask', '', 'MOD_MASK', 2),
+        #         ),
+        items = (
+            ('LAYER', 'Layer', ''),
+            ('ALPHA', 'Alpha', ''),
+            ('SPECIFIC_MASK', 'Active Mask / Override', ''),
+        ),
+        #items = layer_preview_mode_type_items,
+        default = 'LAYER',
+        update = update_layer_preview_mode
+    )
 
     # Mode exclusively for merging mask
     #merge_mask_mode = BoolProperty(default=False,
     #        update=update_merge_mask_mode)
 
     # Toggle to use baked results or not
-    use_baked : BoolProperty(default=False, 
-            name = 'Use Baked',
-            description = 'Use baked channels rather than layer channels',
-            update=Bake.update_use_baked)
+    use_baked : BoolProperty(
+        default = False, 
+        name = 'Use Baked',
+        description = 'Use baked channels rather than layer channels',
+        update = Bake.update_use_baked
+    )
 
     baked_uv_name : StringProperty(default='')
 
     enable_baked_outside : BoolProperty(
-            name= 'Enable Baked Outside',
-            description= 'Create baked texture nodes outside of main node\n(Can be useful for exporting material to other application)',
-            default=False, update=Bake.update_enable_baked_outside)
+        name = 'Enable Baked Outside',
+        description = 'Create baked texture nodes outside of main node\n(Can be useful for exporting material to other application)',
+        default = False,
+        update = Bake.update_enable_baked_outside
+    )
     
     # Outside nodes
     baked_outside_uv : StringProperty(default='')
@@ -3777,9 +3876,11 @@ class YPaint(bpy.types.PropertyGroup):
 
     # Flip backface
     enable_backface_always_up : BoolProperty(
-            name= 'Make backface normal always up',
-            description= 'Make sure normal will face toward camera even at backface\n(Need Normal channel with smooth bump on to enable this feature)',
-            default=True, update=update_flip_backface)
+        name = 'Make backface normal always up',
+        description = 'Make sure normal will face toward camera even at backface\n(Need Normal channel with smooth bump on to enable this feature)',
+        default = True,
+        update = update_flip_backface
+    )
 
     # Layer alpha Viewer Mode
     #enable_layer_alpha_viewer : BoolProperty(
@@ -3805,9 +3906,11 @@ class YPaint(bpy.types.PropertyGroup):
     #        default='SLOW_TOGGLE')
 
     enable_tangent_sign_hacks : BoolProperty(
-            name = 'Enable Tangent Sign VCol Hacks for Blender 2.80+ Cycles',
-            description = "Tangent sign vertex color needed to make sure Blender 2.8 Cycles normal and parallax works.\n(This is because Blender 2.8 normal map node has different behavior than Blender 2.7)",
-            default=False, update=update_enable_tangent_sign_hacks)
+        name = 'Enable Tangent Sign VCol Hacks for Blender 2.80+ Cycles',
+        description = "Tangent sign vertex color needed to make sure Blender 2.8 Cycles normal and parallax works.\n(This is because Blender 2.8 normal map node has different behavior than Blender 2.7)",
+        default = False,
+        update = update_enable_tangent_sign_hacks
+    )
 
     # When enabled, alpha can create some node setup, disable this to avoid that
     alpha_auto_setup : BoolProperty(default=True)
@@ -3826,9 +3929,11 @@ class YPaint(bpy.types.PropertyGroup):
 
     # Use linear color blending
     use_linear_blending : BoolProperty(
-            name = 'Use Linear Color Blending',
-            description = 'Use more accurate linear color blending (it will behave differently than Photoshop)',
-            default=False, update=update_use_linear_blending)
+        name = 'Use Linear Color Blending',
+        description = 'Use more accurate linear color blending (it will behave differently than Photoshop)',
+        default = False,
+        update = update_use_linear_blending
+    )
 
     # Index pointer to the UI
     #ui_index : IntProperty(default=0)
@@ -3940,7 +4045,7 @@ def ypaint_last_object_update(scene):
             if yp.use_baked and len(yp.channels) > 0:
                 update_active_yp_channel(yp, bpy.context)
 
-            elif len(yp.layers) > 0 :
+            elif len(yp.layers) > 0:
                 try: set_active_paint_slot_entity(yp)
                 except: print('EXCEPTIION: Cannot set image canvas!')
 
@@ -3951,7 +4056,7 @@ def ypaint_last_object_update(scene):
 
         if obj.mode == 'TEXTURE_PAINT' or ypwm.last_mode == 'TEXTURE_PAINT':
             ypwm.last_mode = obj.mode
-            if yp and len(yp.layers) > 0 :
+            if yp and len(yp.layers) > 0:
                 image, uv_name, src_of_img, entity, mapping, vcol = get_active_image_and_stuffs(obj, yp)
 
                 # Store original uv mirror offsets

--- a/UDIM.py
+++ b/UDIM.py
@@ -103,19 +103,22 @@ def get_tile_numbers(objs, uv_name):
         uv = o.data.uv_layers.get(uv_name)
         if not uv: continue
     
-        uv_arr = numpy.zeros(len(o.data.loops)*2, dtype=numpy.float32)
+        uv_arr = numpy.zeros(len(o.data.loops) * 2, dtype=numpy.float32)
         uv.data.foreach_get('uv', uv_arr)
         arr = numpy.append(arr, uv_arr)
 
     # Reshape the array to 2D
-    arr.shape = (arr.shape[0]//2, 2)
+    arr.shape = (arr.shape[0] // 2, 2)
 
     # Tolerance to skip value around x.0
-    trange = [UV_TOLERANCE/2.0, 1.0-(UV_TOLERANCE/2.0)]
-    arr = arr[((arr[:,0]-(numpy.floor(arr[:,0]))) >= trange[0]) &
-              ((arr[:,0]-(numpy.floor(arr[:,0]))) <= trange[1]) & 
-              ((arr[:,1]-(numpy.floor(arr[:,1]))) >= trange[0]) &
-              ((arr[:,1]-(numpy.floor(arr[:,1]))) <= trange[1])]
+    trange = [UV_TOLERANCE / 2.0, 1.0 - (UV_TOLERANCE / 2.0)]
+
+    arr = arr[
+        ((arr[:,0] - (numpy.floor(arr[:,0]))) >= trange[0]) &
+        ((arr[:,0] - (numpy.floor(arr[:,0]))) <= trange[1]) & 
+        ((arr[:,1] - (numpy.floor(arr[:,1]))) >= trange[0]) &
+        ((arr[:,1] - (numpy.floor(arr[:,1]))) <= trange[1])
+    ]
 
     # Floor array to integer
     arr = numpy.floor(arr).astype(int)
@@ -131,7 +134,7 @@ def get_tile_numbers(objs, uv_name):
         v = min(max(i[1], 0), 100)
 
         # Calculate the tile
-        tile = 1001 + u + v*10
+        tile = 1001 + u + v * 10
         if tile not in tiles:
             tiles.append(tile)
     
@@ -163,14 +166,14 @@ def is_uvmap_udim(objs, uv_name):
         uv = o.data.uv_layers.get(uv_name)
         if not uv: continue
     
-        uv_arr = numpy.zeros(len(o.data.loops)*2, dtype=numpy.float32)
+        uv_arr = numpy.zeros(len(o.data.loops) * 2, dtype=numpy.float32)
         uv.data.foreach_get('uv', uv_arr)
         arr = numpy.append(arr, uv_arr)
 
     if ori_mode != 'OBJECT':
         bpy.ops.object.mode_set(mode=ori_mode)
 
-    is_udim = numpy.any(arr > 1.0 + UV_TOLERANCE/2)
+    is_udim = numpy.any(arr > 1.0 + UV_TOLERANCE / 2)
 
     print('INFO: UDIM checking is done in', '{:0.2f}'.format((time.time() - T) * 1000), 'ms!')
 
@@ -185,7 +188,7 @@ def get_temp_udim_dir():
 
 def is_using_temp_dir(image):
     directory = os.path.dirname(bpy.path.abspath(image.filepath))
-    if directory == get_temp_udim_dir() or (bpy.data.filepath == '' and directory == tempfile.gettempdir()) or os.sep+UDIM_DIR+os.sep in image.filepath:
+    if directory == get_temp_udim_dir() or (bpy.data.filepath == '' and directory == tempfile.gettempdir()) or os.sep + UDIM_DIR + os.sep in image.filepath:
         return True
     return False
 
@@ -635,7 +638,7 @@ def set_udim_segment_mapping(entity, segment, image, use_baked=False):
 
     if mapping: mapping.inputs[1].default_value[1] = offset_y
 
-def create_udim_atlas(tilenums, name='', width=1024, height=1024, color=(0,0,0,0), colorspace='', hdr=False):
+def create_udim_atlas(tilenums, name='', width=1024, height=1024, color=(0, 0, 0, 0), colorspace='', hdr=False):
     if name != '':
         name = '~' + name + ' UDIM Atlas'
     else: name = '~UDIM Atlas'
@@ -646,8 +649,10 @@ def create_udim_atlas(tilenums, name='', width=1024, height=1024, color=(0,0,0,0
 
     name = get_unique_name(name, bpy.data.images)
 
-    image = bpy.data.images.new(name=name, 
-            width=width, height=height, alpha=True, float_buffer=hdr, tiled=True)
+    image = bpy.data.images.new(
+        name=name, width=width, height=height,
+        alpha=True, float_buffer=hdr, tiled=True
+    )
     image.yua.is_udim_atlas = True
     image.yui.base_color = color
 
@@ -672,7 +677,7 @@ def refresh_udim_segment_base_tilenums(segment, tilenums):
         if btile.number not in tilenums:
             segment.base_tiles.remove(i)
 
-def create_udim_atlas_segment(image, tilenums, width=1024, height=1024, color=(0,0,0,0), source_image=None, source_tilenums=[], yp=None):
+def create_udim_atlas_segment(image, tilenums, width=1024, height=1024, color=(0, 0, 0, 0), source_image=None, source_tilenums=[], yp=None):
 
     #if yp: refresh_udim_atlas(image, yp)
 
@@ -726,10 +731,12 @@ def is_tilenums_fit_in_udim_atlas(image, tilenums):
     
     return remains_y > max_y
 
-def get_set_udim_atlas_segment(tilenums, 
-        width=1024, height=1024, color=(0,0,0,0), colorspace='', hdr=False, yp=None, 
+def get_set_udim_atlas_segment(
+        tilenums, 
+        width=1024, height=1024, color=(0, 0, 0, 0), colorspace='', hdr=False, yp=None, 
         source_image=None, source_tilenums=[], 
-        image_exception=None, image_inclusions=[]):
+        image_exception=None, image_inclusions=[]
+    ):
 
     ypup = get_user_preferences()
     segment = None
@@ -751,16 +758,20 @@ def get_set_udim_atlas_segment(tilenums,
         if image_exception and image == image_exception: continue
         if image.yua.is_udim_atlas and image.is_float == hdr and is_tilenums_fit_in_udim_atlas(image, tilenums):
             if colorspace != '' and image.colorspace_settings.name != colorspace: continue
-            segment = create_udim_atlas_segment(image, tilenums, width, height, color, 
-                    source_image=source_image, source_tilenums=source_tilenums, yp=yp)
+            segment = create_udim_atlas_segment(
+                image, tilenums, width, height, color, 
+                source_image=source_image, source_tilenums=source_tilenums, yp=yp
+            )
         if segment:
             break
 
     if not segment:
         # If proper UDIM atlas can't be found, create new one
         image = create_udim_atlas(tilenums, name, width, height, color, colorspace, hdr)
-        segment = create_udim_atlas_segment(image, tilenums, width, height, color, 
-                source_image=source_image, source_tilenums=source_tilenums, yp=yp)
+        segment = create_udim_atlas_segment(
+            image, tilenums, width, height, color, 
+            source_image=source_image, source_tilenums=source_tilenums, yp=yp
+        )
 
     return segment
 
@@ -934,10 +945,12 @@ def refresh_udim_atlas(image, yp=None, check_uv=True, remove_index=-1):
         segment = image.yua.segments.get(name)
         segment_base_tilenums = get_udim_segment_base_tilenums(segment)
         segment_tilenums = get_udim_segment_tilenums(segment)
-        new_segment = get_set_udim_atlas_segment(segment_base_tilenums, color=segment.base_color, 
-                colorspace=image.colorspace_settings.name, hdr=image.is_float, yp=yp,
-                source_image=image, source_tilenums=segment_tilenums,
-                image_exception=image, image_inclusions=new_atlas_images)
+        new_segment = get_set_udim_atlas_segment(
+            segment_base_tilenums, color=segment.base_color, 
+            colorspace=image.colorspace_settings.name, hdr=image.is_float, yp=yp,
+            source_image=image, source_tilenums=segment_tilenums,
+            image_exception=image, image_inclusions=new_atlas_images
+        )
 
         oob_dict[name] = new_segment
         if new_segment.id_data not in new_atlas_images:
@@ -1058,7 +1071,7 @@ class YNewUDIMAtlasSegmentTest(bpy.types.Operator):
         objs = get_all_objects_with_same_materials(mat, True, uv_name)
         tilenums = get_tile_numbers(objs, uv_name)
 
-        new_segment = get_set_udim_atlas_segment(tilenums, 1024, 1024, color=(0,0,0,0), colorspace=get_srgb_name(), hdr=False)
+        new_segment = get_set_udim_atlas_segment(tilenums, 1024, 1024, color=(0, 0, 0, 0), colorspace=get_srgb_name(), hdr=False)
 
         image = new_segment.id_data
 
@@ -1097,9 +1110,9 @@ class YRemoveUDIMAtlasSegment(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     index : IntProperty(
-        name="Segment Index",
-        description="UDIM Atlas Segment Index",
-        default=0
+        name = 'Segment Index',
+        description = 'UDIM Atlas Segment Index',
+        default = 0
     )
 
     def invoke(self, context, event):
@@ -1136,9 +1149,10 @@ class YConvertImageTiled(bpy.types.Operator):
         image = context.image
 
         # Create new image
-        new_image = bpy.data.images.new(image.name,
-                                width=image.size[0], height=image.size[1], 
-                                alpha=True, float_buffer=image.is_float, tiled= not image.source=='TILED')
+        new_image = bpy.data.images.new(
+            image.name, width=image.size[0], height=image.size[1], 
+            alpha=True, float_buffer=image.is_float, tiled=not image.source=='TILED'
+        )
 
         if new_image.source == 'TILED':
 
@@ -1203,9 +1217,10 @@ class YUDIMAtlasSegmentTile(bpy.types.PropertyGroup):
 class YUDIMAtlasSegment(bpy.types.PropertyGroup):
 
     name : StringProperty(
-            name='Name',
-            description='Name of UDIM Atlas Segments',
-            default='')
+        name = 'Name',
+        description = 'Name of UDIM Atlas Segments',
+        default = ''
+    )
 
     unused : BoolProperty(default=False)
 
@@ -1216,9 +1231,10 @@ class YUDIMAtlasSegment(bpy.types.PropertyGroup):
 
 class YUDIMAtlas(bpy.types.PropertyGroup):
     name : StringProperty(
-            name='Name',
-            description='Name of UDIM Atlas',
-            default='')
+        name = 'Name',
+        description = 'Name of UDIM Atlas',
+        default = ''
+    )
 
     is_udim_atlas : BoolProperty(default=False)
 

--- a/addon_updater.py
+++ b/addon_updater.py
@@ -115,7 +115,9 @@ class SingletonUpdater:
         self._addon = __package__.lower()
         self._addon_package = __package__  # Must not change.
         self._updater_path = os.path.join(
-            os.path.dirname(__file__), self._addon + "_updater")
+            os.path.dirname(__file__),
+            self._addon + "_updater"
+        )
         self._addon_root = os.path.dirname(__file__)
         self._json = dict()
         self._error = None
@@ -207,11 +209,13 @@ class SingletonUpdater:
 
     @property
     def check_interval(self):
-        return (self._check_interval_enabled,
-                self._check_interval_months,
-                self._check_interval_days,
-                self._check_interval_hours,
-                self._check_interval_minutes)
+        return (
+            self._check_interval_enabled,
+            self._check_interval_months,
+            self._check_interval_days,
+            self._check_interval_hours,
+            self._check_interval_minutes
+        )
 
     @property
     def current_version(self):
@@ -226,12 +230,10 @@ class SingletonUpdater:
             try:
                 tuple(tuple_values)
             except:
-                raise ValueError(
-                    "current_version must be a tuple of integers")
+                raise ValueError("current_version must be a tuple of integers")
         for i in tuple_values:
             if type(i) is not int:
-                raise ValueError(
-                    "current_version must be a tuple of integers")
+                raise ValueError("current_version must be a tuple of integers")
         self._current_version = tuple(tuple_values)
 
     @property
@@ -294,13 +296,11 @@ class SingletonUpdater:
                     self._include_branch_list = ['master']
 
             elif not isinstance(value, list) or len(value) == 0:
-                raise ValueError(
-                    "include_branch_list should be a list of valid branches")
+                raise ValueError("include_branch_list should be a list of valid branches")
             else:
                 self._include_branch_list = value
         except:
-            raise ValueError(
-                "include_branch_list should be a list of valid branches")
+            raise ValueError("include_branch_list should be a list of valid branches")
 
     @property
     def include_branches(self):
@@ -369,8 +369,7 @@ class SingletonUpdater:
         if value is None:
             self._remove_pre_update_patterns = list()
         elif not isinstance(value, list):
-            raise ValueError(
-                "remove_pre_update_patterns needs to be in a list format")
+            raise ValueError("remove_pre_update_patterns needs to be in a list format")
         else:
             self._remove_pre_update_patterns = value
 
@@ -435,7 +434,7 @@ class SingletonUpdater:
                 if label == LEGACY_BRANCH:
                     label = "Master (Blender 2.7x)"
             else:
-                label = "Stable ("+nm+")"
+                label = "Stable (" + nm + ")"
             tag_names.append((nm, label, "Select to install " + nm))
         return tag_names
 
@@ -562,8 +561,11 @@ class SingletonUpdater:
             tag_names.append(tag["name"])
         return tag_names
 
-    def set_check_interval(self, enabled=False,
-                           months=0, days=14, hours=0, minutes=0):
+    def set_check_interval(
+            self, enabled=False,
+            months=0, days=14, hours=0, minutes=0
+        ):
+
         """Set the time interval between automated checks, and if enabled.
 
         Has enabled = False as default to not check against frequency,
@@ -581,10 +583,7 @@ class SingletonUpdater:
         if type(minutes) is not int:
             raise ValueError("Minutes must be an integer value")
 
-        if not enabled:
-            self._check_interval_enabled = False
-        else:
-            self._check_interval_enabled = True
+        self._check_interval_enabled = enabled
 
         self._check_interval_months = months
         self._check_interval_days = days
@@ -592,11 +591,12 @@ class SingletonUpdater:
         self._check_interval_minutes = minutes
 
     def __repr__(self):
-        return "<Module updater from {a}>".format(a=__file__)
+        return "<Module updater from {}>".format(__file__)
 
     def __str__(self):
-        return "Updater, with user: {a}, repository: {b}, url: {c}".format(
-            a=self._user, b=self._repo, c=self.form_repo_url())
+        return "Updater, with user: {}, repository: {}, url: {}".format(
+            self._user, self._repo, self.form_repo_url()
+        )
 
     # -------------------------------------------------------------------------
     # API-related functions
@@ -666,13 +666,15 @@ class SingletonUpdater:
             if not self._error:
                 self._tag_latest = self._tags[0]
             branch = self._include_branch_list[0]
-            self.print_verbose("{} branch found, no releases: {}".format(
-                branch, self._tags[0]))
+            self.print_verbose(
+                "{} branch found, no releases: {}".format(branch, self._tags[0])
+            )
 
-        elif ((len(self._tags) - len(self._include_branch_list) == 0
-                and self._include_branches)
+        elif (
+                (len(self._tags) - len(self._include_branch_list) == 0 and self._include_branches)
                 or (len(self._tags) == 0 and not self._include_branches)
-                and self._prefiltered_tag_count > 0):
+                and self._prefiltered_tag_count > 0
+            ):
             self._tag_latest = None
             self._error = "No releases available"
             self._error_msg = "No versions found within compatible version range"
@@ -681,8 +683,7 @@ class SingletonUpdater:
         else:
             
             self._tag_latest = self._tags[0]
-            self.print_verbose(
-                "Most recent tag found:" + str(self._tags[0]['name']))
+            self.print_verbose("Most recent tag found:" + str(self._tags[0]['name']))
             
         self._json["branches"] = self._tags
     
@@ -691,7 +692,7 @@ class SingletonUpdater:
         self._tags.clear()
 
         request = self.form_branch_list_url()
-        self.print_verbose("Getting branches from server "+request)
+        self.print_verbose("Getting branches from server " + request)
         all_branches = self.get_api(request)
 
         if all_branches is None:
@@ -716,10 +717,10 @@ class SingletonUpdater:
         request_br = self.form_branch_url(branch_name)
 
         return {
-            "name": branch_name,
-            "last_commit": last_commit,
-            "label": branch_name,
-            "zipball_url": request_br
+            "name" : branch_name,
+            "last_commit" : last_commit,
+            "label" : branch_name,
+            "zipball_url" : request_br
         }
 
     def get_raw(self, url):
@@ -740,8 +741,7 @@ class SingletonUpdater:
                 self.print_verbose("Tokens not setup for engine yet")
 
         # Always set user agent.
-        request.add_header(
-            'User-Agent', "Python/" + str(platform.python_version()))
+        request.add_header('User-Agent', "Python/" + str(platform.python_version()))
 
         # Run the request.
         try:
@@ -802,8 +802,7 @@ class SingletonUpdater:
         error = None
 
         # Make/clear the staging folder, to ensure the folder is always clean.
-        self.print_verbose(
-            "Preparing staging folder for download:\n" + str(local))
+        self.print_verbose("Preparing staging folder for download:\n" + str(local))
         if os.path.isdir(local):
             try:
                 shutil.rmtree(local)
@@ -841,19 +840,19 @@ class SingletonUpdater:
                 if self._engine.name == "gitlab":
                     request.add_header('PRIVATE-TOKEN', self._engine.token)
                 else:
-                    self.print_verbose(
-                        "Tokens not setup for selected engine yet")
+                    self.print_verbose("Tokens not setup for selected engine yet")
 
             # Always set user agent
-            request.add_header(
-                'User-Agent', "Python/" + str(platform.python_version()))
+            request.add_header('User-Agent', "Python/" + str(platform.python_version()))
 
             if context:
-                self.url_retrieve(urllib.request.urlopen(request, context=context),
-                                  self._source_zip)
+                self.url_retrieve(
+                    urllib.request.urlopen(request, context=context), self._source_zip
+                )
             else:
-                self.url_retrieve(urllib.request.urlopen(request),
-                                  self._source_zip)
+                self.url_retrieve(
+                    urllib.request.urlopen(request), self._source_zip
+                )
             # Add additional checks on file size being non-zero.
             self.print_verbose("Successfully downloaded update zip")
             return True
@@ -870,7 +869,8 @@ class SingletonUpdater:
         self.print_verbose("Backing up current addon folder")
         local = os.path.join(self._updater_path, "backup")
         tempdest = os.path.join(
-            self._addon_root, os.pardir, self._addon + "_updater_backup_temp")
+            self._addon_root, os.pardir, self._addon + "_updater_backup_temp"
+        )
 
         self.print_verbose("Backup destination path: " + str(local))
 
@@ -888,16 +888,16 @@ class SingletonUpdater:
             try:
                 shutil.rmtree(tempdest)
             except:
-                self.print_verbose(
-                    "Failed to remove existing temp folder, continuing")
+                self.print_verbose("Failed to remove existing temp folder, continuing")
                 self.print_trace()
 
         # Make a full addon copy, temporarily placed outside the addon folder.
         if self._backup_ignore_patterns is not None:
             try:
-                shutil.copytree(self._addon_root, tempdest,
-                                ignore=shutil.ignore_patterns(
-                                    *self._backup_ignore_patterns))
+                shutil.copytree(
+                    self._addon_root, tempdest,
+                    ignore = shutil.ignore_patterns(*self._backup_ignore_patterns)
+                )
             except:
                 print("Failed to create backup, still attempting update.")
                 self.print_trace()
@@ -914,7 +914,8 @@ class SingletonUpdater:
         # Save the date for future reference.
         now = datetime.now()
         self._json["backup_date"] = "{m}-{d}-{yr}".format(
-            m=now.strftime("%B"), d=now.day, yr=now.year)
+            m=now.strftime("%B"), d=now.day, yr=now.year
+        )
         self.save_updater_json()
 
     def restore_backup(self):
@@ -922,7 +923,8 @@ class SingletonUpdater:
         self.print_verbose("Restoring backup, backing up current addon folder")
         backuploc = os.path.join(self._updater_path, "backup")
         tempdest = os.path.join(
-            self._addon_root, os.pardir, self._addon + "_updater_backup_temp")
+            self._addon_root, os.pardir, self._addon + "_updater_backup_temp"
+        )
         tempdest = os.path.abspath(tempdest)
 
         # Move instead contents back in place, instead of copy.
@@ -996,7 +998,8 @@ class SingletonUpdater:
                     try:
                         os.mkdir(os.path.join(outdir, sub_path))
                         self.print_verbose(
-                            "Extract - mkdir: " + os.path.join(outdir, sub_path))
+                            "Extract - mkdir: " + os.path.join(outdir, sub_path)
+                        )
                     except OSError as exc:
                         if exc.errno != errno.EEXIST:
                             self._error = "Install failed"
@@ -1008,7 +1011,8 @@ class SingletonUpdater:
                         data = zfile.read(name)
                         outfile.write(data)
                         self.print_verbose(
-                            "Extract - create: " + os.path.join(outdir, sub_path))
+                            "Extract - create: " + os.path.join(outdir, sub_path)
+                        )
 
         self.print_verbose("Extracted source")
 
@@ -1085,26 +1089,30 @@ class SingletonUpdater:
                 # Careful, this deletes entire subdirectories recursively...
                 # Make sure that base is not a high level shared folder, but
                 # is dedicated just to the addon itself.
-                self.print_verbose(
-                    "clean=True, clearing addon folder to fresh install state")
+                self.print_verbose("clean=True, clearing addon folder to fresh install state")
 
                 # Remove root files and folders (except update folder).
-                files = [f for f in os.listdir(base)
-                         if os.path.isfile(os.path.join(base, f))]
-                folders = [f for f in os.listdir(base)
-                           if os.path.isdir(os.path.join(base, f))]
+                files = [
+                    f for f in os.listdir(base)
+                        if os.path.isfile(os.path.join(base, f))
+                ]
+                folders = [
+                    f for f in os.listdir(base)
+                        if os.path.isdir(os.path.join(base, f))
+                ]
 
                 for f in files:
                     os.remove(os.path.join(base, f))
                     self.print_verbose(
-                        "Clean removing file {}".format(os.path.join(base, f)))
+                        "Clean removing file {}".format(os.path.join(base, f))
+                    )
                 for f in folders:
                     if os.path.join(base, f) is self._updater_path:
                         continue
                     shutil.rmtree(os.path.join(base, f))
                     self.print_verbose(
-                        "Clean removing folder and contents {}".format(
-                            os.path.join(base, f)))
+                        "Clean removing folder and contents {}".format(os.path.join(base, f))
+                    )
 
             except Exception as err:
                 error = "failed to create clean existing addon folder"
@@ -1115,8 +1123,10 @@ class SingletonUpdater:
         # but avoid removing/altering backup and updater file.
         for path, dirs, files in os.walk(base):
             # Prune ie skip updater folder.
-            dirs[:] = [d for d in dirs
-                       if os.path.join(path, d) not in [self._updater_path]]
+            dirs[:] = [
+                d for d in dirs
+                    if os.path.join(path, d) not in [self._updater_path]
+            ]
             for file in files:
                 for pattern in self.remove_pre_update_patterns:
                     if fnmatch.filter([file], pattern):
@@ -1134,8 +1144,10 @@ class SingletonUpdater:
         # actual file copying/replacements.
         for path, dirs, files in os.walk(merger):
             # Verify structure works to prune updater sub folder overwriting.
-            dirs[:] = [d for d in dirs
-                       if os.path.join(path, d) not in [self._updater_path]]
+            dirs[:] = [
+                d for d in dirs
+                    if os.path.join(path, d) not in [self._updater_path]
+            ]
             rel_path = os.path.relpath(path, merger)
             dest_path = os.path.join(base, rel_path)
             if not os.path.exists(dest_path):
@@ -1162,19 +1174,23 @@ class SingletonUpdater:
                     else:
                         self.print_verbose(
                             "Pattern not matched to {}, not overwritten".format(
-                                os.path.basename(dest_file)))
+                                os.path.basename(dest_file)
+                            )
+                        )
                 else:
                     # File did not previously exist, simply move it over.
                     os.rename(srcFile, dest_file)
-                    self.print_verbose(
-                        "New file " + os.path.basename(dest_file))
+                    self.print_verbose("New file " + os.path.basename(dest_file))
 
         # now remove the temp staging folder and downloaded zip
         try:
             shutil.rmtree(staging_path)
         except:
-            error = ("Error: Failed to remove existing staging directory, "
-                     "consider manually removing ") + staging_path
+            error = (
+                "Error: Failed to remove existing staging directory, "
+                "consider manually removing "
+            ) + staging_path
+
             self.print_verbose(error)
             self.print_trace()
 
@@ -1306,8 +1322,7 @@ class SingletonUpdater:
             self.print_verbose("Skipping async check, already started")
             # already running the bg thread
         elif self._update_ready is None:
-            print("{} updater: Running background check for update".format(
-                  self.addon))
+            print("{} updater: Running background check for update".format(self.addon))
             self.start_async_check_update(False, callback)
 
     def check_for_update_now(self, callback=None):
@@ -1367,9 +1382,11 @@ class SingletonUpdater:
         # avoid running again in, just return past result if found
         # but if force now check, then still do it
         if self._update_ready is not None and not now:
-            return (self._update_ready,
-                    self._update_version,
-                    self._update_link)
+            return (
+                self._update_ready,
+                self._update_version,
+                self._update_link
+            )
 
         if self._current_version is None:
             raise ValueError("current_version not yet defined")
@@ -1383,22 +1400,22 @@ class SingletonUpdater:
         self.set_updater_json()  # self._json
 
         if not now and not self.past_interval_timestamp():
-            self.print_verbose(
-                "Aborting check for updated, check interval not reached")
+            self.print_verbose("Aborting check for updated, check interval not reached")
             return (False, None, None)
 
         # check if using tags or releases
         # note that if called the first time, this will pull tags from online
         if self._fake_install:
-            self.print_verbose(
-                "fake_install = True, setting fake version as ready")
+            self.print_verbose("fake_install = True, setting fake version as ready")
             self._update_ready = True
             self._update_version = "(999,999,999)"
             self._update_link = "http://127.0.0.1"
 
-            return (self._update_ready,
-                    self._update_version,
-                    self._update_link)
+            return (
+                self._update_ready,
+                self._update_version,
+                self._update_link
+            )
 
         # Primary internet call, sets self._tags and self._tag_latest.
         self.get_tags()
@@ -1439,7 +1456,7 @@ class SingletonUpdater:
                         self.save_updater_json()
                         print("use branch build(",self.current_branch,") there is update", new_version, "|", link)
                         return (True, new_version, link) 
-                    self.print_verbose("use branch "+self.current_branch+" build no update")
+                    self.print_verbose("use branch " + self.current_branch + " build no update")
             self.print_verbose("use branch build no update")
         else:
             if new_version > self._current_version:
@@ -1458,7 +1475,7 @@ class SingletonUpdater:
         self._update_link = None
         return (False, None, None)
     
-    def check_for_branches(self, update_last_check:bool = True):
+    def check_for_branches(self, update_last_check:bool=True):
         """Check for update not in a syncrhonous manner.
 
         This function is not async, will always return in sequential fashion
@@ -1474,16 +1491,18 @@ class SingletonUpdater:
         # but if force now check, then still do it
         if self._update_ready is not None:
             self.print_verbose(
-                "Aborting check for brannches, update ready="+str(self._update_ready))
-            return (self._update_ready,
-                    self._update_version,
-                    self._update_link)
+                "Aborting check for brannches, update ready=" + str(self._update_ready)
+            )
+            return (
+                self._update_ready,
+                self._update_version,
+                self._update_link
+            )
 
         self.set_updater_json()  # self._json
 
         if not self.past_interval_timestamp():
-            self.print_verbose(
-                "Aborting check for brannches, check interval not reached")
+            self.print_verbose("Aborting check for brannches, check interval not reached")
             return (False, None, None)
 
         # check if using tags or releases
@@ -1598,8 +1617,7 @@ class SingletonUpdater:
         if self._fake_install:
             # Change to True, to trigger the reload/"update installed" handler.
             self.print_verbose("fake_install=True")
-            self.print_verbose(
-                "Just reloading and running any handler triggers")
+            self.print_verbose("Just reloading and running any handler triggers")
             self._json["just_updated"] = True
             self.save_updater_json()
             if self._backup_current is True:
@@ -1614,14 +1632,17 @@ class SingletonUpdater:
                 if callback:
                     callback(
                         self._addon_package,
-                        "Update stopped, new version not ready")
+                        "Update stopped, new version not ready"
+                    )
                 return "Update stopped, new version not ready"
             elif self._update_link is None:
                 # this shouldn't happen if update is ready
                 self.print_verbose("Update stopped, update link unavailable")
                 if callback:
-                    callback(self._addon_package,
-                             "Update stopped, update link unavailable")
+                    callback(
+                        self._addon_package,
+                        "Update stopped, update link unavailable"
+                    )
                 return "Update stopped, update link unavailable"
 
             if revert_tag is None:
@@ -1705,7 +1726,8 @@ class SingletonUpdater:
         """
         json_path = os.path.join(
             self._updater_path,
-            "{}_updater_status.json".format(self._addon_package))
+            "{}_updater_status.json".format(self._addon_package)
+        )
         old_json_path = os.path.join(self._updater_path, "updater_status.json")
 
         # Rename old file if it exists.
@@ -1733,16 +1755,16 @@ class SingletonUpdater:
                 self.print_verbose("Read in JSON settings from file")
         else:
             self._json = {
-                "last_check": "",
-                "backup_date": "",
+                "last_check" : "",
+                "backup_date" : "",
                 "using_development_build" : self.using_development_build,
                 "current_branch" : self.current_branch,
                 "last_commit" : self._last_commit,
-                "update_ready": False,
-                "ignore": False,
-                "just_restored": False,
-                "just_updated": False,
-                "version_text": dict()
+                "update_ready" : False,
+                "ignore" : False,
+                "just_restored" : False,
+                "just_updated" : False,
+                "version_text" : dict()
             }
             self.save_updater_json()
 
@@ -1762,8 +1784,10 @@ class SingletonUpdater:
 
         jpath = self.get_json_path()
         if not os.path.isdir(os.path.dirname(jpath)):
-            print("State error: Directory does not exist, cannot save json: ",
-                  os.path.basename(jpath))
+            print(
+                "State error: Directory does not exist, cannot save json: ",
+                os.path.basename(jpath)
+            )
             return
         try:
             with open(jpath, 'w') as outf:
@@ -1799,8 +1823,10 @@ class SingletonUpdater:
         if self._async_checking:
             return
         self.print_verbose("Starting background checking thread")
-        check_thread = threading.Thread(target=self.async_check_update,
-                                        args=(now, callback,))
+        check_thread = threading.Thread(
+            target = self.async_check_update,
+            args = (now, callback,)
+        )
         check_thread.daemon = True
         self._check_thread = check_thread
         check_thread.start()
@@ -1854,8 +1880,10 @@ class SingletonUpdater:
         if self._async_checking:
             return
         self.print_verbose("Starting background checking thread")
-        check_thread = threading.Thread(target=self.async_check_branches,
-                                        args=(callback,))
+        check_thread = threading.Thread(
+            target=self.async_check_branches,
+            args=(callback,)
+        )
         check_thread.daemon = True
         self._check_thread = check_thread
         check_thread.start()
@@ -1865,8 +1893,10 @@ class SingletonUpdater:
         if self._async_checking:
             return
         self.print_verbose("Starting background checking thread")
-        check_thread = threading.Thread(target=self.async_check_branches_releases,
-                                        args=(callback,))
+        check_thread = threading.Thread(
+            target = self.async_check_branches_releases,
+            args = (callback,)
+        )
         check_thread.daemon = True
         self._check_thread = check_thread
         check_thread.start()
@@ -1943,10 +1973,10 @@ class SingletonUpdater:
         self._async_checking = False
         self._error = None
         self._error_msg = None
+
 # -----------------------------------------------------------------------------
 # Updater Engines
 # -----------------------------------------------------------------------------
-
 
 class BitbucketEngine:
     """Integration to Bitbucket API for git-formatted repositories"""
@@ -1958,7 +1988,8 @@ class BitbucketEngine:
 
     def form_repo_url(self, updater):
         return "{}/2.0/repositories/{}/{}".format(
-            self.api_url, updater.user, updater.repo)
+            self.api_url, updater.user, updater.repo
+        )
 
     def form_tags_url(self, updater):
         return self.form_repo_url(updater) + "/refs/tags?sort=-name"
@@ -1968,17 +1999,18 @@ class BitbucketEngine:
 
     def get_zip_url(self, name, updater):
         return "https://bitbucket.org/{user}/{repo}/get/{name}.zip".format(
-            user=updater.user,
-            repo=updater.repo,
-            name=name)
+            user = updater.user,
+            repo = updater.repo,
+            name = name
+        )
 
     def parse_tags(self, response, updater):
         if response is None:
             return list()
         return [
             {
-                "name": tag["name"],
-                "zipball_url": self.get_zip_url(tag["name"], updater)
+                "name" : tag["name"],
+                "zipball_url" : self.get_zip_url(tag["name"], updater)
             } for tag in response["values"]]
 
 
@@ -1992,7 +2024,8 @@ class GithubEngine:
 
     def form_repo_url(self, updater):
         return "{}/repos/{}/{}".format(
-            self.api_url, updater.user, updater.repo)
+            self.api_url, updater.user, updater.repo
+        )
 
     def form_tags_url(self, updater):
         if updater.use_releases:
@@ -2028,19 +2061,20 @@ class GitlabEngine:
 
     def form_branch_list_url(self, updater):
         # does not validate branch name.
-        return "{}/repository/branches".format(
-            self.form_repo_url(updater))
+        return "{}/repository/branches".format(self.form_repo_url(updater))
 
     def form_branch_url(self, branch, updater):
         # Could clash with tag names and if it does, it will download TAG zip
         # instead of branch zip to get direct path, would need.
         return "{}/repository/archive.zip?sha={}".format(
-            self.form_repo_url(updater), branch)
+            self.form_repo_url(updater), branch
+        )
 
     def get_zip_url(self, sha, updater):
         return "{base}/repository/archive.zip?sha={sha}".format(
-            base=self.form_repo_url(updater),
-            sha=sha)
+            base = self.form_repo_url(updater),
+            sha = sha
+        )
 
     # def get_commit_zip(self, id, updater):
     # 	return self.form_repo_url(updater)+"/repository/archive.zip?sha:"+id
@@ -2050,8 +2084,8 @@ class GitlabEngine:
             return list()
         return [
             {
-                "name": tag["name"],
-                "zipball_url": self.get_zip_url(tag["commit"]["id"], updater)
+                "name" : tag["name"],
+                "zipball_url" : self.get_zip_url(tag["commit"]["id"], updater)
             } for tag in response]
 
 

--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -115,7 +115,7 @@ def layout_split(layout, factor=0.0, align=False):
 # Simple popup to prompt use to check for update & offer install if available.
 class AddonUpdaterInstallPopup(bpy.types.Operator):
     """Check and install update if available"""
-    bl_label = "Update {x} addon".format(x=updater.addon)
+    bl_label = "Update {} addon".format(updater.addon)
     bl_idname = updater.addon + ".updater_install_popup"
     bl_description = "Popup to check and display current updates available"
     bl_options = {'REGISTER', 'INTERNAL'}
@@ -124,22 +124,24 @@ class AddonUpdaterInstallPopup(bpy.types.Operator):
     # equivalent to deleting the addon and reinstalling, except the
     # updater folder/backup folder remains
     clean_install : BoolProperty(
-        name="Clean install",
-        description=("If enabled, completely clear the addon's folder before "
-                     "installing new update, creating a fresh install"),
-        default=False,
-        options={'HIDDEN'}
+        name = "Clean install",
+        description = (
+            "If enabled, completely clear the addon's folder before "
+            "installing new update, creating a fresh install"
+        ),
+        default = False,
+        options = {'HIDDEN'}
     )
 
     ignore_enum : EnumProperty(
-        name="Process update",
-        description="Decide to install, ignore, or defer new addon update",
-        items=[
+        name = "Process update",
+        description = "Decide to install, ignore, or defer new addon update",
+        items = [
             ("install", "Update Now", "Install update now"),
             ("ignore", "Ignore", "Ignore this update to prevent future popups"),
             ("defer", "Defer", "Defer choice till next blender session")
         ],
-        options={'HIDDEN'}
+        options = {'HIDDEN'}
     )
 
     def check(self, context):
@@ -156,11 +158,18 @@ class AddonUpdaterInstallPopup(bpy.types.Operator):
         elif updater.update_ready:
             col = layout.column()
             col.scale_y = 0.7
-            col.label(text="Update {} ready!".format(updater.update_version),
-                      icon="LOOP_FORWARDS")
-            col.label(text="Choose 'Update Now' & press OK to install, ",
-                      icon="BLANK1")
-            col.label(text="or click outside window to defer", icon="BLANK1")
+            col.label(
+                text = "Update {} ready!".format(updater.update_version),
+                icon = "LOOP_FORWARDS"
+            )
+            col.label(
+                text = "Choose 'Update Now' & press OK to install, ",
+                icon = "BLANK1"
+            )
+            col.label(
+                text = "or click outside window to defer",
+                icon = "BLANK1"
+            )
             row = col.row()
             row.prop(self, "ignore_enum", expand=True)
             col.split()
@@ -193,9 +202,11 @@ class AddonUpdaterInstallPopup(bpy.types.Operator):
                 updater.ignore_update()
                 return {'FINISHED'}
 
-            res = updater.run_update(force=False,
-                                     callback=post_update_callback,
-                                     clean=self.clean_install)
+            res = updater.run_update(
+                force = False,
+                callback = post_update_callback,
+                clean = self.clean_install
+            )
 
             # Should return 0, if not something happened.
             if updater.verbose:
@@ -212,6 +223,7 @@ class AddonUpdaterInstallPopup(bpy.types.Operator):
         else:
             updater.print_verbose("Doing nothing, not ready for update")
         return {'FINISHED'}
+
 # User preference check-now operator
 class RefreshBranchesNow(bpy.types.Operator):
     bl_label = "Refresh branches"
@@ -243,8 +255,7 @@ class RefreshBranchesReleasesNow(bpy.types.Operator):
 class AddonUpdaterCheckNow(bpy.types.Operator):
     bl_label = "Check for update"
     bl_idname = updater.addon + ".updater_check_now"
-    bl_description = "Check now for an update to the {} addon".format(
-        updater.addon)
+    bl_description = "Check now for an update to the {} addon".format(updater.addon)
     bl_options = {'REGISTER', 'INTERNAL'}
 
     def execute(self, context):
@@ -261,16 +272,17 @@ class AddonUpdaterCheckNow(bpy.types.Operator):
         settings = get_user_preferences()
         if not settings:
             updater.print_verbose(
-                "Could not get {} preferences, update check skipped".format(
-                    __package__))
+                "Could not get {} preferences, update check skipped".format(__package__)
+            )
             return {'CANCELLED'}
 
         updater.set_check_interval(
-            enabled=settings.auto_check_update,
-            months=settings.updater_interval_months,
-            days=settings.updater_interval_days,
-            hours=settings.updater_interval_hours,
-            minutes=settings.updater_interval_minutes)
+            enabled = settings.auto_check_update,
+            months = settings.updater_interval_months,
+            days = settings.updater_interval_days,
+            hours = settings.updater_interval_hours,
+            minutes = settings.updater_interval_minutes
+        )
 
         # Input is an optional callback function. This function should take a
         # bool input. If true: update ready, if false: no update ready.
@@ -282,19 +294,20 @@ class AddonUpdaterCheckNow(bpy.types.Operator):
 class AddonUpdaterUpdateNow(bpy.types.Operator):
     bl_label = "Update " + updater.addon + " addon now"
     bl_idname = updater.addon + ".updater_update_now"
-    bl_description = "Update to the latest version of the {x} addon".format(
-        x=updater.addon)
+    bl_description = "Update to the latest version of the {} addon".format(updater.addon)
     bl_options = {'REGISTER', 'INTERNAL'}
 
     # If true, run clean install - ie remove all files before adding new
     # equivalent to deleting the addon and reinstalling, except the updater
     # folder/backup folder remains.
     clean_install : BoolProperty(
-        name="Clean install",
-        description=("If enabled, completely clear the addon's folder before "
-                     "installing new update, creating a fresh install"),
-        default=False,
-        options={'HIDDEN'}
+        name = "Clean install",
+        description = (
+            "If enabled, completely clear the addon's folder before "
+            "installing new update, creating a fresh install"
+        ),
+        default = False,
+        options = {'HIDDEN'}
     )
 
     def execute(self, context):
@@ -317,10 +330,12 @@ class AddonUpdaterUpdateNow(bpy.types.Operator):
                 else:
                     tag = updater._tags[0]["name"]
 
-                res = updater.run_update(force=False,
-                                        revert_tag=tag,
-                                        callback=post_update_callback,
-                                        clean=self.clean_install)
+                res = updater.run_update(
+                    force = False,
+                    revert_tag = tag,
+                    callback = post_update_callback,
+                    clean = self.clean_install
+                )
               
                 # Should return 0, if not something happened.
                 if updater.verbose:
@@ -344,8 +359,7 @@ class AddonUpdaterUpdateNow(bpy.types.Operator):
             self.report({'INFO'}, "Nothing to update")
             return {'CANCELLED'}
         else:
-            self.report(
-                {'ERROR'}, "Encountered a problem while trying to update")
+            self.report({'ERROR'}, "Encountered a problem while trying to update")
             return {'CANCELLED'}
 
         return {'FINISHED'}
@@ -354,8 +368,7 @@ class AddonUpdaterUpdateNow(bpy.types.Operator):
 class AddonUpdaterUpdateTarget(bpy.types.Operator):
     bl_label = get_addon_title() + " Version Target"
     bl_idname = updater.addon + ".updater_update_target"
-    bl_description = "Install a targeted version of the {x} addon".format(
-        x=updater.addon)
+    bl_description = "Install a targeted version of the {} addon".format(updater.addon)
     bl_options = {'REGISTER', 'INTERNAL'}
 
     def target_version(self, context):
@@ -371,9 +384,9 @@ class AddonUpdaterUpdateTarget(bpy.types.Operator):
         return ret
 
     target : EnumProperty(
-        name="Target version to install",
-        description="Select the version to install",
-        items=target_version
+        name = "Target version to install",
+        description = "Select the version to install",
+        items = target_version
     )
 
     @classmethod
@@ -407,16 +420,16 @@ class AddonUpdaterUpdateTarget(bpy.types.Operator):
             return {'CANCELLED'}
 
         res = updater.run_update(
-            force=False,
-            revert_tag=self.target,
-            callback=post_update_callback)
+            force = False,
+            revert_tag = self.target,
+            callback = post_update_callback
+        )
 
         # Should return 0, if not something happened.
         if res == 0:
             updater.print_verbose("Updater returned successful")
         else:
-            updater.print_verbose(
-                "Updater returned {}, , error occurred".format(res))
+            updater.print_verbose("Updater returned {}, , error occurred".format(res))
             return {'CANCELLED'}
 
         return {'FINISHED'}
@@ -424,18 +437,17 @@ class AddonUpdaterUpdateTarget(bpy.types.Operator):
 class AddonUpdaterUpdateBranch(bpy.types.Operator):
     bl_label = "Install new branch"
     bl_idname = updater.addon + ".updater_update_branch"
-    bl_description = "Install a targeted version of the {x} addon".format(
-        x=updater.addon)
+    bl_description = "Install a targeted version of the {} addon".format(updater.addon)
     bl_options = {'REGISTER', 'INTERNAL'}
 
     target : StringProperty(
-        name="Target version to install",
-        description="Select the version to install",
+        name = "Target version to install",
+        description = "Select the version to install",
     )
 
     label : StringProperty(
-        name="Target version to install",
-        description="Select the version to install",
+        name = "Target version to install",
+        description = "Select the version to install",
     )
 
     @classmethod
@@ -457,7 +469,7 @@ class AddonUpdaterUpdateBranch(bpy.types.Operator):
             row.label(text="Updater error")
             return
         
-        row.label(text="Do you want to install branch "+self.label+"?")
+        row.label(text="Do you want to install branch " + self.label + "?")
 
     def execute(self, context):
 
@@ -470,16 +482,16 @@ class AddonUpdaterUpdateBranch(bpy.types.Operator):
             return {'CANCELLED'}
 
         res = updater.run_update(
-            force=False,
-            revert_tag=self.target,
-            callback=post_update_callback)
+            force = False,
+            revert_tag = self.target,
+            callback = post_update_callback
+        )
 
         # Should return 0, if not something happened.
         if res == 0:
             updater.print_verbose("Updater returned successful")
         else:
-            updater.print_verbose(
-                "Updater returned {}, , error occurred".format(res))
+            updater.print_verbose("Updater returned {}, , error occurred".format(res))
             return {'CANCELLED'}
 
         return {'FINISHED'}
@@ -493,9 +505,9 @@ class AddonUpdaterInstallManually(bpy.types.Operator):
     bl_options = {'REGISTER', 'INTERNAL'}
 
     error : StringProperty(
-        name="Error Occurred",
-        default="",
-        options={'HIDDEN'}
+        name = "Error Occurred",
+        default = "",
+        options = {'HIDDEN'}
     )
 
     def invoke(self, context, event):
@@ -512,11 +524,18 @@ class AddonUpdaterInstallManually(bpy.types.Operator):
         if self.error != "":
             col = layout.column()
             col.scale_y = 0.7
-            col.label(text="There was an issue trying to auto-install",
-                      icon="ERROR")
-            col.label(text="Press the download button below and install",
-                      icon="BLANK1")
-            col.label(text="the zip file like a normal addon.", icon="BLANK1")
+            col.label(
+                text = "There was an issue trying to auto-install",
+                icon = "ERROR"
+            )
+            col.label(
+                text = "Press the download button below and install",
+                icon = "BLANK1"
+            )
+            col.label(
+                text = "the zip file like a normal addon.",
+                icon = "BLANK1"
+            )
         else:
             col = layout.column()
             col.scale_y = 0.7
@@ -532,11 +551,13 @@ class AddonUpdaterInstallManually(bpy.types.Operator):
         if updater.update_link is not None:
             row.operator(
                 "wm.url_open",
-                text="Direct download").url = updater.update_link
+                text = "Direct download"
+            ).url = updater.update_link
         else:
             row.operator(
                 "wm.url_open",
-                text="(failed to retrieve direct download)")
+                text = "(failed to retrieve direct download)"
+            )
             row.enabled = False
 
             if updater.website is not None:
@@ -559,9 +580,9 @@ class AddonUpdaterUpdatedSuccessful(bpy.types.Operator):
     bl_options = {'REGISTER', 'INTERNAL', 'UNDO'}
 
     error : StringProperty(
-        name="Error Occurred",
-        default="",
-        options={'HIDDEN'}
+        name = "Error Occurred",
+        default = "",
+        options = {'HIDDEN'}
     )
 
     def invoke(self, context, event):
@@ -588,8 +609,9 @@ class AddonUpdaterUpdatedSuccessful(bpy.types.Operator):
             rw.scale_y = 2
             rw.operator(
                 "wm.url_open",
-                text="Click for manual download.",
-                icon="BLANK1").url = updater.website
+                text = "Click for manual download.",
+                icon = "BLANK1"
+            ).url = updater.website
         elif not updater.auto_reload_post_update:
             # Tell user to restart blender after an update/restore!
             if "just_restored" in saved and saved["just_restored"]:
@@ -599,19 +621,23 @@ class AddonUpdaterUpdatedSuccessful(bpy.types.Operator):
                 alert_row.alert = True
                 alert_row.operator(
                     "wm.quit_blender",
-                    text="Restart blender to reload",
-                    icon="BLANK1")
+                    text = "Restart blender to reload",
+                    icon = "BLANK1"
+                )
                 updater.json_reset_restore()
             else:
                 col = layout.column()
                 col.label(
-                    text="Addon successfully installed", icon="FILE_TICK")
+                    text = "Addon successfully installed",
+                    icon = "FILE_TICK"
+                )
                 alert_row = col.row()
                 alert_row.alert = True
                 alert_row.operator(
                     "wm.quit_blender",
-                    text="Restart blender to reload",
-                    icon="BLANK1")
+                    text = "Restart blender to reload",
+                    icon = "BLANK1"
+                )
 
         else:
             # reload addon, but still recommend they restart blender
@@ -620,17 +646,21 @@ class AddonUpdaterUpdatedSuccessful(bpy.types.Operator):
                 col.scale_y = 0.7
                 col.label(text="Addon restored", icon="RECOVER_LAST")
                 col.label(
-                    text="Consider restarting blender to fully reload.",
-                    icon="BLANK1")
+                    text = "Consider restarting blender to fully reload.",
+                    icon = "BLANK1"
+                )
                 updater.json_reset_restore()
             else:
                 col = layout.column()
                 col.scale_y = 0.7
                 col.label(
-                    text="Addon successfully installed", icon="FILE_TICK")
+                    text = "Addon successfully installed",
+                    icon = "FILE_TICK"
+                )
                 col.label(
-                    text="Consider restarting blender to fully reload.",
-                    icon="BLANK1")
+                    text = "Consider restarting blender to fully reload.",
+                    icon = "BLANK1"
+                )
 
     def execute(self, context):
         return {'FINISHED'}
@@ -730,16 +760,17 @@ class UpdaterPendingUpdate(bpy.types.Operator):
         ypui = wm.ypui
         ypui.hide_update = True
         return {'FINISHED'}
+
+
 # -----------------------------------------------------------------------------
 # Handler related, to create popups
 # -----------------------------------------------------------------------------
 
-
-# global vars used to prevent duplicate popup handlers
+# Global vars used to prevent duplicate popup handlers
 ran_auto_check_install_popup = False
 ran_update_success_popup = False
 
-# global var for preventing successive calls
+# Global var for preventing successive calls
 ran_background_check = False
 
 def list_branches(self, context):
@@ -753,7 +784,7 @@ def updater_run_success_popup_handler(scene):
     global ran_update_success_popup
     ran_update_success_popup = True
 
-    # in case of error importing updater
+    # In case of error importing updater
     if updater.invalid_updater:
         return
 
@@ -777,7 +808,7 @@ def updater_run_install_popup_handler(scene):
     ran_auto_check_install_popup = True
     updater.print_verbose("Running the install popup handler.")
 
-    # in case of error importing updater
+    # In case of error importing updater
     if updater.invalid_updater:
         return
 
@@ -801,8 +832,8 @@ def updater_run_install_popup_handler(scene):
             # User probably manually installed to get the up to date addon
             # in here. Clear out the update flag using this function.
             updater.print_verbose(
-                "{} updater: appears user updated, clearing flag".format(
-                    updater.addon))
+                "{} updater: appears user updated, clearing flag".format(updater.addon)
+            )
             updater.json_reset_restore()
             return
     atr = AddonUpdaterInstallPopup.bl_idname.split(".")
@@ -862,7 +893,8 @@ def post_update_callback(module_name, res=None):
         # This is the same code as in conditional at the end of the register
         # function, ie if "auto_reload_post_update" == True, skip code.
         updater.print_verbose(
-            "{} updater: Running post update callback".format(updater.addon))
+            "{} updater: Running post update callback".format(updater.addon)
+        )
 
         atr = AddonUpdaterUpdatedSuccessful.bl_idname.split(".")
         getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
@@ -905,11 +937,14 @@ def check_for_update_background():
     settings = get_user_preferences()
     if not settings:
         return
-    updater.set_check_interval(enabled=settings.auto_check_update,
-                               months=settings.updater_interval_months,
-                               days=settings.updater_interval_days,
-                               hours=settings.updater_interval_hours,
-                               minutes=settings.updater_interval_minutes)
+
+    updater.set_check_interval(
+        enabled = settings.auto_check_update,
+        months = settings.updater_interval_months,
+        days = settings.updater_interval_days,
+        hours = settings.updater_interval_hours,
+        minutes = settings.updater_interval_minutes
+    )
 
     # Input is an optional callback function. This function should take a bool
     # input, if true: update ready, if false: no update ready.
@@ -927,14 +962,16 @@ def check_for_update_nonthreaded(self, context):
     settings = get_user_preferences()
     if not settings:
         if updater.verbose:
-            print("Could not get {} preferences, update check skipped".format(
-                __package__))
+            print("Could not get {} preferences, update check skipped".format(__package__))
         return
-    updater.set_check_interval(enabled=settings.auto_check_update,
-                               months=settings.updater_interval_months,
-                               days=settings.updater_interval_days,
-                               hours=settings.updater_interval_hours,
-                               minutes=settings.updater_interval_minutes)
+
+    updater.set_check_interval(
+        enabled = settings.auto_check_update,
+        months = settings.updater_interval_months,
+        days = settings.updater_interval_days,
+        hours = settings.updater_interval_hours,
+        minutes = settings.updater_interval_minutes
+    )
 
     (update_ready, version, link) = updater.check_for_update(now=False)
     if update_ready:
@@ -1012,8 +1049,9 @@ def update_notice_box_ui(self, context):
             alert_row.alert = True
             alert_row.operator(
                 "wm.quit_blender",
-                text="Restart blender",
-                icon="ERROR")
+                text = "Restart blender",
+                icon = "ERROR"
+            )
             col.label(text="to complete update")
             return
 
@@ -1038,13 +1076,17 @@ def update_notice_box_ui(self, context):
     colR = split.column(align=True)
     colR.scale_y = 1.5
     if not updater.manual_only:
-        colR.operator(AddonUpdaterUpdateNow.bl_idname,
-                      text="Update", icon="LOOP_FORWARDS")
+        colR.operator(
+            AddonUpdaterUpdateNow.bl_idname,
+            text="Update", icon="LOOP_FORWARDS"
+        )
         col.operator("wm.url_open", text="Open website").url = updater.website
         # ops = col.operator("wm.url_open",text="Direct download")
         # ops.url=updater.update_link
-        col.operator(AddonUpdaterInstallManually.bl_idname,
-                     text="Install manually")
+        col.operator(
+            AddonUpdaterInstallManually.bl_idname,
+            text="Install manually"
+        )
     else:
         # ops = col.operator("wm.url_open", text="Direct download")
         # ops.url=updater.update_link
@@ -1085,9 +1127,11 @@ def update_settings_ui(self, context, element=None):
         saved_state = updater.json
         if "just_updated" in saved_state and saved_state["just_updated"]:
             row.alert = True
-            row.operator("wm.quit_blender",
-                         text="Restart blender to complete update",
-                         icon="ERROR")
+            row.operator(
+                "wm.quit_blender",
+                text = "Restart blender to complete update",
+                icon = "ERROR"
+            )
             return
 
     # print("use releases", updater.use_releases, "| use branch", updater.include_branches)
@@ -1102,15 +1146,15 @@ def update_settings_ui(self, context, element=None):
         split = sub_col.split(align=True)
         if "ssl" in updater.error_msg.lower():
             split.enabled = True
-            split.operator(AddonUpdaterInstallManually.bl_idname,
-                        text=updater.error)
+            split.operator(
+                AddonUpdaterInstallManually.bl_idname,
+                text = updater.error
+            )
         else:
             split.enabled = False
-            split.operator(check_operator,
-                        text=updater.error)
+            split.operator(check_operator, text=updater.error)
         split = sub_col.split(align=True)
-        split.operator(check_operator,
-                    text="", icon="FILE_REFRESH")
+        split.operator(check_operator, text="", icon="FILE_REFRESH")
     elif updater.update_ready is None and not updater.async_checking:
         row.operator(check_operator)
     elif updater.update_ready is None:  # async is running
@@ -1127,35 +1171,34 @@ def update_settings_ui(self, context, element=None):
         # No releases found, but still show the appropriate branch.
         sub_col = row.row(align=True)
         split = sub_col.split(align=True)
-        update_now_txt = "Update to latest commit on '{}' branch".format(
-            settings.branches)
+        update_now_txt = "Update to latest commit on '{}' branch".format(settings.branches)
         split.operator(AddonUpdaterUpdateNow.bl_idname, text=update_now_txt)
         split = sub_col.split(align=True)
-        split.operator(check_operator,
-                    text="", icon="FILE_REFRESH")
+        split.operator(check_operator, text="", icon="FILE_REFRESH")
 
     elif updater.update_ready and not updater.manual_only:
         sub_col = row.row(align=True)
         split = sub_col.split(align=True)
-        split.operator(AddonUpdaterUpdateNow.bl_idname,
-                    text="Update now to " + str(updater.update_version))
+        split.operator(
+            AddonUpdaterUpdateNow.bl_idname,
+            text = "Update now to " + str(updater.update_version)
+        )
         split = sub_col.split(align=True)
-        split.operator(check_operator,
-                    text="", icon="FILE_REFRESH")
+        split.operator(
+            check_operator,
+            text="", icon="FILE_REFRESH"
+        )
 
     elif updater.update_ready and updater.manual_only:
         dl_now_txt = "Download " + str(updater.update_version)
-        row.operator("wm.url_open",
-                    text=dl_now_txt).url = updater.website
+        row.operator("wm.url_open", text=dl_now_txt).url = updater.website
     else:  # i.e. that updater.update_ready == False.
         sub_col = row.row(align=True)
         split = sub_col.split(align=True)
         split.enabled = False
-        split.operator(check_operator,
-                    text="Addon is up to date")
+        split.operator(check_operator, text="Addon is up to date")
         split = sub_col.split(align=True)
-        split.operator(check_operator,
-                    text="", icon="FILE_REFRESH")
+        split.operator(check_operator, text="", icon="FILE_REFRESH")
     if updater.update_ready is not None:
         row.prop(settings, 'branches', text="Branch")
 
@@ -1498,11 +1541,12 @@ def register():
         if not first_time:
             settings = get_user_preferences()
             updater.set_check_interval(
-                enabled=settings.auto_check_update,
-                months=settings.updater_interval_months,
-                days=settings.updater_interval_days,
-                hours=settings.updater_interval_hours,
-                minutes=settings.updater_interval_minutes)
+                enabled = settings.auto_check_update,
+                months = settings.updater_interval_months,
+                days = settings.updater_interval_days,
+                hours = settings.updater_interval_hours,
+                minutes = settings.updater_interval_minutes
+            )
         
         if updater.past_interval_timestamp():
             updater.check_for_branches_releases_now(None)

--- a/bake_common.py
+++ b/bake_common.py
@@ -8,15 +8,15 @@ from . import lib, Layer, ImageAtlas, UDIM
 BL28_HACK = True
 
 BAKE_PROBLEMATIC_MODIFIERS = {
-        'MIRROR',
-        'SOLIDIFY',
-        'ARRAY',
-        }
+    'MIRROR',
+    'SOLIDIFY',
+    'ARRAY',
+}
 
 JOIN_PROBLEMATIC_TEXCOORDS = {
-        'Object',
-        'Generated',
-        }
+    'Object',
+    'Generated',
+}
 
 EMPTY_IMG_NODE = '___EMPTY_IMAGE__'
 ACTIVE_UV_NODE = '___ACTIVE_UV__'
@@ -252,7 +252,6 @@ def add_active_render_uv_node(tree, active_render_uv_name):
             add_active_render_uv_node(n.node_tree, active_render_uv_name)
 
 def prepare_other_objs_channels(yp, other_objs):
-
     ch_other_objects = []
     ch_other_mats = []
     ch_other_sockets = []
@@ -290,7 +289,6 @@ def prepare_other_objs_channels(yp, other_objs):
                         m.use_nodes = True
 
             for mat in o.data.materials:
-
                 if mat == None: continue
                 if mat in mats: continue
                 if not mat.use_nodes: continue
@@ -366,11 +364,13 @@ def recover_other_objs_channels(other_objs, ori_mat_no_nodes):
 
     remove_temp_default_material()
 
-def prepare_bake_settings(book, objs, yp=None, samples=1, margin=5, uv_map='', bake_type='EMIT', 
+def prepare_bake_settings(
+        book, objs, yp=None, samples=1, margin=5, uv_map='', bake_type='EMIT', 
         disable_problematic_modifiers=False, hide_other_objs=True, bake_from_multires=False, 
         tile_x=64, tile_y=64, use_selected_to_active=False, max_ray_distance=0.0, cage_extrusion=0.0,
         bake_target = 'IMAGE_TEXTURES',
-        source_objs=[], bake_device='CPU', use_denoising=False, margin_type='ADJACENT_FACES', cage_object_name=''):
+        source_objs=[], bake_device='CPU', use_denoising=False, margin_type='ADJACENT_FACES', cage_object_name=''
+    ):
 
     scene = bpy.context.scene
     ypui = bpy.context.window_manager.ypui
@@ -1057,9 +1057,9 @@ def create_plane_on_object_mode():
 
     if not is_bl_newer_than(2, 77):
         bpy.ops.mesh.primitive_plane_add()
-        bpy.ops.object.mode_set(mode = 'EDIT')
+        bpy.ops.object.mode_set(mode='EDIT')
         bpy.ops.uv.unwrap(method='ANGLE_BASED', margin=0.0)
-        bpy.ops.object.mode_set(mode = 'OBJECT')
+        bpy.ops.object.mode_set(mode='OBJECT')
     else: 
         bpy.ops.mesh.primitive_plane_add(calc_uvs=True)
 
@@ -1322,9 +1322,11 @@ def get_valid_filepath(img, use_hdr):
 
     return img.filepath
 
-def bake_channel(uv_map, mat, node, root_ch, width=1024, height=1024, target_layer=None, use_hdr=False, 
-                 aa_level=1, force_use_udim=False, tilenums=[], interpolation='Linear', 
-                 use_float_for_displacement=False, use_float_for_normal=False):
+def bake_channel(
+        uv_map, mat, node, root_ch, width=1024, height=1024, target_layer=None, use_hdr=False, 
+        aa_level=1, force_use_udim=False, tilenums=[], interpolation='Linear', 
+        use_float_for_displacement=False, use_float_for_normal=False
+    ):
 
     print('BAKE CHANNEL: Baking', root_ch.name + ' channel...')
 
@@ -1442,8 +1444,10 @@ def bake_channel(uv_map, mat, node, root_ch, width=1024, height=1024, target_lay
 
             baked_normal_prep = tree.nodes.get(root_ch.baked_normal_prep)
             if not baked_normal_prep:
-                baked_normal_prep = new_node(tree, root_ch, 'baked_normal_prep', 'ShaderNodeGroup', 
-                        'Baked Normal Preparation')
+                baked_normal_prep = new_node(
+                    tree, root_ch, 'baked_normal_prep',
+                    'ShaderNodeGroup', 'Baked Normal Preparation'
+                )
                 if is_bl_newer_than(2, 80):
                     baked_normal_prep.node_tree = get_node_tree_lib(lib.NORMAL_MAP_PREP)
                 else: baked_normal_prep.node_tree = get_node_tree_lib(lib.NORMAL_MAP_PREP_LEGACY)
@@ -1511,8 +1515,10 @@ def bake_channel(uv_map, mat, node, root_ch, width=1024, height=1024, target_lay
         if use_udim:
 
             # Create new udim image
-            img = bpy.data.images.new(name=img_name, width=width, height=height, 
-                    alpha=True, tiled=True) #float_buffer=hdr)
+            img = bpy.data.images.new(
+                name=img_name, width=width, height=height,
+                alpha=True, tiled=True
+            )
 
             # Fill tiles
             if segment:
@@ -1528,8 +1534,9 @@ def bake_channel(uv_map, mat, node, root_ch, width=1024, height=1024, target_lay
 
         else:
             # Create new standard image
-            img = bpy.data.images.new(name=img_name,
-                    width=width, height=height, alpha=True) #, alpha=True, float_buffer=hdr)
+            img = bpy.data.images.new(
+                name=img_name, width=width, height=height, alpha=True
+            )
             img.generated_type = 'BLANK'
 
         # Set image base color
@@ -1604,8 +1611,10 @@ def bake_channel(uv_map, mat, node, root_ch, width=1024, height=1024, target_lay
 
                 baked_normal_overlay = tree.nodes.get(root_ch.baked_normal_overlay)
                 if not baked_normal_overlay:
-                    baked_normal_overlay = new_node(tree, root_ch, 'baked_normal_overlay', 'ShaderNodeTexImage', 
-                            'Baked ' + root_ch.name + ' Overlay Only')
+                    baked_normal_overlay = new_node(
+                        tree, root_ch, 'baked_normal_overlay', 'ShaderNodeTexImage', 
+                        'Baked ' + root_ch.name + ' Overlay Only'
+                    )
                     if hasattr(baked_normal_overlay, 'color_space'):
                         baked_normal_overlay.color_space = 'NONE'
 
@@ -1681,8 +1690,10 @@ def bake_channel(uv_map, mat, node, root_ch, width=1024, height=1024, target_lay
 
                 baked_vdisp = tree.nodes.get(root_ch.baked_vdisp)
                 if not baked_vdisp:
-                    baked_vdisp = new_node(tree, root_ch, 'baked_vdisp', 'ShaderNodeTexImage', 
-                            'Baked ' + root_ch.name + ' Vector Displacement')
+                    baked_vdisp = new_node(
+                        tree, root_ch, 'baked_vdisp', 'ShaderNodeTexImage', 
+                        'Baked ' + root_ch.name + ' Vector Displacement'
+                    )
                     if hasattr(baked_vdisp, 'color_space'):
                         baked_vdisp.color_space = 'NONE'
 
@@ -1717,8 +1728,11 @@ def bake_channel(uv_map, mat, node, root_ch, width=1024, height=1024, target_lay
                 tex.image = vdisp_img
 
                 # Bake setup 
-                create_link(mat.node_tree, node.outputs[root_ch.name + io_suffix['VDISP']], 
-                        emit.inputs[0])
+                create_link(
+                    mat.node_tree,
+                    node.outputs[root_ch.name + io_suffix['VDISP']], 
+                    emit.inputs[0]
+                )
 
                 # Bake
                 print('BAKE CHANNEL: Baking vector displacement image of ' + root_ch.name + ' channel...')
@@ -1738,11 +1752,15 @@ def bake_channel(uv_map, mat, node, root_ch, width=1024, height=1024, target_lay
 
             # Create target image
             if UDIM.is_udim_supported():
-                mh_img = bpy.data.images.new(name='____MAXHEIGHT_TEMP', width=100, height=100, 
-                        alpha=False, tiled=False, float_buffer=True)
+                mh_img = bpy.data.images.new(
+                    name='____MAXHEIGHT_TEMP', width=100, height=100, 
+                    alpha=False, tiled=False, float_buffer=True
+                )
             else:
-                mh_img = bpy.data.images.new(name='____MAXHEIGHT_TEMP', width=100, height=100, 
-                        alpha=False, float_buffer=True)
+                mh_img = bpy.data.images.new(
+                    name='____MAXHEIGHT_TEMP', width=100, height=100, 
+                    alpha=False, float_buffer=True
+                )
 
             mh_img.colorspace_settings.name = get_noncolor_name()
             tex.image = mh_img
@@ -1791,8 +1809,10 @@ def bake_channel(uv_map, mat, node, root_ch, width=1024, height=1024, target_lay
             # Create target image
             baked_disp = tree.nodes.get(root_ch.baked_disp)
             if not baked_disp:
-                baked_disp = new_node(tree, root_ch, 'baked_disp', 'ShaderNodeTexImage', 
-                        'Baked ' + root_ch.name + ' Displacement')
+                baked_disp = new_node(
+                    tree, root_ch, 'baked_disp', 'ShaderNodeTexImage', 
+                    'Baked ' + root_ch.name + ' Displacement'
+                )
                 if hasattr(baked_disp, 'color_space'):
                     baked_disp.color_space = 'NONE'
 
@@ -1836,10 +1856,15 @@ def bake_channel(uv_map, mat, node, root_ch, width=1024, height=1024, target_lay
                 spread_height = mat.node_tree.nodes.new('ShaderNodeGroup')
                 spread_height.node_tree = get_node_tree_lib(lib.SPREAD_NORMALIZED_HEIGHT)
 
-                create_link(mat.node_tree, node.outputs[root_ch.name + io_suffix['HEIGHT']], 
-                        spread_height.inputs[0])
-                create_link(mat.node_tree, node.outputs[root_ch.name + io_suffix['ALPHA']], 
-                        spread_height.inputs[1])
+                create_link(
+                    mat.node_tree, node.outputs[root_ch.name + io_suffix['HEIGHT']], 
+                    spread_height.inputs[0]
+                )
+                create_link(
+                    mat.node_tree, node.outputs[root_ch.name + io_suffix['ALPHA']], 
+                    spread_height.inputs[1]
+                )
+
                 create_link(mat.node_tree, spread_height.outputs[0], emit.inputs[0])
 
                 #create_link(mat.node_tree, node.outputs[root_ch.name + io_suffix['HEIGHT']], srgb2lin.inputs[0])
@@ -1974,8 +1999,10 @@ def temp_bake(context, entity, width, height, hdr, samples, margin, uv_map, bake
     name = entity.name + ' Temp'
 
     # New target image
-    image = bpy.data.images.new(name=name,
-            width=width, height=height, alpha=True, float_buffer=hdr)
+    image = bpy.data.images.new(
+        name=name, width=width, height=height,
+        alpha=True, float_buffer=hdr
+    )
     image.colorspace_settings.name = get_noncolor_name()
 
     if entity.type == 'HEMI':
@@ -2186,7 +2213,7 @@ def resize_image(image, width, height, colorspace='Non-Color', samples=1, margin
         bpy.context.view_layer.active_layer_collection = bpy.context.view_layer.layer_collection
 
     # Create new plane
-    bpy.ops.object.mode_set(mode = 'OBJECT')
+    bpy.ops.object.mode_set(mode='OBJECT')
     plane_obj = create_plane_on_object_mode()
 
     prepare_bake_settings(book, [plane_obj], samples=samples, margin=margin, bake_device=bake_device)
@@ -2227,7 +2254,8 @@ def resize_image(image, width, height, colorspace='Non-Color', samples=1, margin
 
         if segment:
             new_segment = ImageAtlas.get_set_image_atlas_segment(
-                        width, height, image.yia.color, image.is_float, yp=yp) #, ypup.image_atlas_size)
+                width, height, image.yia.color, image.is_float, yp=yp
+            )
             scaled_img = new_segment.id_data
 
             ori_start_x = segment.width * segment.tile_x
@@ -2272,8 +2300,10 @@ def resize_image(image, width, height, colorspace='Non-Color', samples=1, margin
                     d.uv.y = start_y / scaled_img.size[1]
 
         else:
-            scaled_img = bpy.data.images.new(name='__TEMP__', 
-                width=width, height=height, alpha=True, float_buffer=image.is_float)
+            scaled_img = bpy.data.images.new(
+                name='__TEMP__', width=width, height=height,
+                alpha=True, float_buffer=image.is_float
+            )
             scaled_img.colorspace_settings.name = colorspace
             if image.filepath != '' and not image.packed_file:
                 scaled_img.filepath = image.filepath
@@ -2293,8 +2323,10 @@ def resize_image(image, width, height, colorspace='Non-Color', samples=1, margin
         if alpha_aware:
 
             # Create alpha image as bake target
-            alpha_img = bpy.data.images.new(name='__TEMP_ALPHA__',
-                    width=width, height=height, alpha=True, float_buffer=image.is_float)
+            alpha_img = bpy.data.images.new(
+                name='__TEMP_ALPHA__', width=width, height=height,
+                alpha=True, float_buffer=image.is_float
+            )
             alpha_img.colorspace_settings.name = get_noncolor_name()
 
             # Retransform back uv
@@ -2417,39 +2449,51 @@ def get_output_uv_names_from_geometry_nodes(obj):
 
 class BaseBakeOperator():
     bake_device : EnumProperty(
-            name='Bake Device',
-            description='Device to use for baking',
-            items = (('GPU', 'GPU Compute', ''),
-                     ('CPU', 'CPU', '')),
-            default='CPU'
-            )
+        name = 'Bake Device',
+        description = 'Device to use for baking',
+        items = (
+            ('GPU', 'GPU Compute', ''),
+            ('CPU', 'CPU', '')
+        ),
+        default = 'CPU'
+    )
     
-    samples : IntProperty(name='Bake Samples', 
-            description='Bake Samples, more means less jagged on generated textures', 
-            default=1, min=1)
+    samples : IntProperty(
+        name = 'Bake Samples', 
+        description = 'Bake Samples, more means less jagged on generated textures', 
+        default=1, min=1
+    )
 
-    margin : IntProperty(name='Bake Margin',
-            description = 'Bake margin in pixels',
-            default=5, subtype='PIXEL')
+    margin : IntProperty(
+        name = 'Bake Margin',
+        description = 'Bake margin in pixels',
+        default = 5,
+        subtype = 'PIXEL'
+    )
 
-    margin_type : EnumProperty(name = 'Margin Type',
-            description = '',
-            items = (('ADJACENT_FACES', 'Adjacent Faces', 'Use pixels from adjacent faces across UV seams.'),
-                     ('EXTEND', 'Extend', 'Extend border pixels outwards')),
-            default = 'ADJACENT_FACES')
+    margin_type : EnumProperty(
+        name = 'Margin Type',
+        description = '',
+        items = (
+            ('ADJACENT_FACES', 'Adjacent Faces', 'Use pixels from adjacent faces across UV seams.'),
+            ('EXTEND', 'Extend', 'Extend border pixels outwards')
+        ),
+        default = 'ADJACENT_FACES'
+    )
 
-    width : IntProperty(name='Width', default = 1024, min=1, max=16384)
-    height : IntProperty(name='Height', default = 1024, min=1, max=16384)
+    width : IntProperty(name='Width', default=1024, min=1, max=16384)
+    height : IntProperty(name='Height', default=1024, min=1, max=16384)
 
     image_resolution : EnumProperty(
         name = 'Image Resolution',
         items = image_resolution_items,
-        default = '1024')
+        default = '1024'
+    )
     
     use_custom_resolution : BoolProperty(
-        name= 'Custom Resolution',
-        default=False,
-        description= 'Use custom Resolution to adjust the width and height individually'
+        name = 'Custom Resolution',
+        description = 'Use custom Resolution to adjust the width and height individually',
+        default = False
     )
 
     def invoke_operator(self, context):
@@ -2469,4 +2513,3 @@ class BaseBakeOperator():
     def check_operator(self, context):
         if not self.use_custom_resolution:
             self.height = self.width = int(self.image_resolution)
-

--- a/common.py
+++ b/common.py
@@ -48,50 +48,56 @@ COLOR_ID_VCOL_NAME = '__yp_color_id'
 
 BUMP_MULTIPLY_TWEAK = 5
 
-blend_type_items = (("MIX", "Mix", ""),
-	             ("ADD", "Add", ""),
-	             ("SUBTRACT", "Subtract", ""),
-	             ("MULTIPLY", "Multiply", ""),
-	             ("SCREEN", "Screen", ""),
-	             ("OVERLAY", "Overlay", ""),
-	             ("DIFFERENCE", "Difference", ""),
-	             ("DIVIDE", "Divide", ""),
-	             ("DARKEN", "Darken", ""),
-	             ("LIGHTEN", "Lighten", ""),
-	             ("HUE", "Hue", ""),
-	             ("SATURATION", "Saturation", ""),
-	             ("VALUE", "Value", ""),
-	             ("COLOR", "Color", ""),
-	             ("SOFT_LIGHT", "Soft Light", ""),
-	             ("LINEAR_LIGHT", "Linear Light", ""),
-	             ("DODGE", "Dodge", ""),
-	             ("BURN", "Burn", ""))
+blend_type_items = (
+    ("MIX", "Mix", ""),
+    ("ADD", "Add", ""),
+    ("SUBTRACT", "Subtract", ""),
+    ("MULTIPLY", "Multiply", ""),
+    ("SCREEN", "Screen", ""),
+    ("OVERLAY", "Overlay", ""),
+    ("DIFFERENCE", "Difference", ""),
+    ("DIVIDE", "Divide", ""),
+    ("DARKEN", "Darken", ""),
+    ("LIGHTEN", "Lighten", ""),
+    ("HUE", "Hue", ""),
+    ("SATURATION", "Saturation", ""),
+    ("VALUE", "Value", ""),
+    ("COLOR", "Color", ""),
+    ("SOFT_LIGHT", "Soft Light", ""),
+    ("LINEAR_LIGHT", "Linear Light", ""),
+    ("DODGE", "Dodge", ""),
+    ("BURN", "Burn", "")
+)
 
 
-mask_blend_type_items = (("MIX", "Replace", ""),
-	             ("ADD", "Add", ""),
-	             ("SUBTRACT", "Subtract", ""),
-	             ("MULTIPLY", "Multiply", ""),
-	             ("SCREEN", "Screen", ""),
-	             ("OVERLAY", "Overlay", ""),
-	             ("DIFFERENCE", "Difference", ""),
-	             ("DIVIDE", "Divide", ""),
-	             ("DARKEN", "Darken", ""),
-	             ("LIGHTEN", "Lighten", ""),
-	             ("HUE", "Hue", ""),
-	             ("SATURATION", "Saturation", ""),
-	             ("VALUE", "Value", ""),
-	             ("COLOR", "Color", ""),
-	             ("SOFT_LIGHT", "Soft Light", ""),
-	             ("LINEAR_LIGHT", "Linear Light", ""),
-	             ("DODGE", "Dodge", ""),
-	             ("BURN", "Burn", ""))
+mask_blend_type_items = (
+    ("MIX", "Replace", ""),
+    ("ADD", "Add", ""),
+    ("SUBTRACT", "Subtract", ""),
+    ("MULTIPLY", "Multiply", ""),
+    ("SCREEN", "Screen", ""),
+    ("OVERLAY", "Overlay", ""),
+    ("DIFFERENCE", "Difference", ""),
+    ("DIVIDE", "Divide", ""),
+    ("DARKEN", "Darken", ""),
+    ("LIGHTEN", "Lighten", ""),
+    ("HUE", "Hue", ""),
+    ("SATURATION", "Saturation", ""),
+    ("VALUE", "Value", ""),
+    ("COLOR", "Color", ""),
+    ("SOFT_LIGHT", "Soft Light", ""),
+    ("LINEAR_LIGHT", "Linear Light", ""),
+    ("DODGE", "Dodge", ""),
+    ("BURN", "Burn", "")
+)
 
-voronoi_feature_items = (("F1", "F1", "Compute and return the distance to the closest feature point as well as its position and color"),
-	             ("F2", "F2", "Compute and return the distance to the second closest feature point as well as its position and color."),
-	             ("SMOOTH_F1", "Smooth F1", "Compute and return a smooth version of F1."), 
-	             ("DISTANCE_TO_EDGE", "Distance to Edge", "Compute and return the distance to the edges of the Voronoi cells."), 
-	             ("N_SPHERE_RADIUS", "N-Sphere Radius", "Compute and return the radius of the n-sphere inscribed in the Voronoi cells. In other words, it is half the distance between the closest feature point and the feature point closest to it."))
+voronoi_feature_items = (
+    ("F1", "F1", "Compute and return the distance to the closest feature point as well as its position and color"),
+    ("F2", "F2", "Compute and return the distance to the second closest feature point as well as its position and color."),
+    ("SMOOTH_F1", "Smooth F1", "Compute and return a smooth version of F1."), 
+    ("DISTANCE_TO_EDGE", "Distance to Edge", "Compute and return the distance to the edges of the Voronoi cells."), 
+    ("N_SPHERE_RADIUS", "N-Sphere Radius", "Compute and return the radius of the n-sphere inscribed in the Voronoi cells. In other words, it is half the distance between the closest feature point and the feature point closest to it.")
+)
 
 def entity_input_items(self, context):
     yp = self.id_data.yp
@@ -135,121 +141,121 @@ TANGENT_SIGN_PREFIX = '__tsign_'
 neighbor_directions = ['n', 's', 'e', 'w']
 
 normal_blend_items = (
-        ('MIX', 'Mix', ''),
-        ('OVERLAY', 'Add', ''),
-        ('COMPARE', 'Compare Height', '')
-        )
+    ('MIX', 'Mix', ''),
+    ('OVERLAY', 'Add', ''),
+    ('COMPARE', 'Compare Height', '')
+)
 
 height_blend_items = (
-        ('REPLACE', 'Replace', ''),
-        ('COMPARE', 'Compare', ''),
-        ('ADD', 'Add', ''),
-        )
+    ('REPLACE', 'Replace', ''),
+    ('COMPARE', 'Compare', ''),
+    ('ADD', 'Add', ''),
+)
 
 layer_type_items = (
-        ('IMAGE', 'Image', ''),
-        ('BRICK', 'Brick', ''),
-        ('CHECKER', 'Checker', ''),
-        ('GRADIENT', 'Gradient', ''),
-        ('MAGIC', 'Magic', ''),
-        ('MUSGRAVE', 'Musgrave', ''),
-        ('NOISE', 'Noise', ''),
-        ('VORONOI', 'Voronoi', ''),
-        ('WAVE', 'Wave', ''),
-        ('VCOL', 'Vertex Color', ''),
-        ('BACKGROUND', 'Background', ''),
-        ('COLOR', 'Solid Color', ''),
-        ('GROUP', 'Group', ''),
-        ('HEMI', 'Fake Lighting', ''),
-        ('GABOR', 'Gabor', ''),
-        )
+    ('IMAGE', 'Image', ''),
+    ('BRICK', 'Brick', ''),
+    ('CHECKER', 'Checker', ''),
+    ('GRADIENT', 'Gradient', ''),
+    ('MAGIC', 'Magic', ''),
+    ('MUSGRAVE', 'Musgrave', ''),
+    ('NOISE', 'Noise', ''),
+    ('VORONOI', 'Voronoi', ''),
+    ('WAVE', 'Wave', ''),
+    ('VCOL', 'Vertex Color', ''),
+    ('BACKGROUND', 'Background', ''),
+    ('COLOR', 'Solid Color', ''),
+    ('GROUP', 'Group', ''),
+    ('HEMI', 'Fake Lighting', ''),
+    ('GABOR', 'Gabor', ''),
+)
 
 mask_type_items = (
-        ('IMAGE', 'Image', ''),
-        ('BRICK', 'Brick', ''),
-        ('CHECKER', 'Checker', ''),
-        ('GRADIENT', 'Gradient', ''),
-        ('MAGIC', 'Magic', ''),
-        ('MUSGRAVE', 'Musgrave', ''),
-        ('NOISE', 'Noise', ''),
-        ('VORONOI', 'Voronoi', ''),
-        ('WAVE', 'Wave', ''),
-        ('VCOL', 'Vertex Color', ''),
-        ('HEMI', 'Fake Lighting', ''),
-        ('OBJECT_INDEX', 'Object Index', ''),
-        ('COLOR_ID', 'Color ID', ''),
-        ('BACKFACE', 'Backface', ''),
-        ('EDGE_DETECT', 'Edge Detect', ''),
-        ('MODIFIER', 'Modifier', ''),
-        ('GABOR', 'Gabor', ''),
-        )
+    ('IMAGE', 'Image', ''),
+    ('BRICK', 'Brick', ''),
+    ('CHECKER', 'Checker', ''),
+    ('GRADIENT', 'Gradient', ''),
+    ('MAGIC', 'Magic', ''),
+    ('MUSGRAVE', 'Musgrave', ''),
+    ('NOISE', 'Noise', ''),
+    ('VORONOI', 'Voronoi', ''),
+    ('WAVE', 'Wave', ''),
+    ('VCOL', 'Vertex Color', ''),
+    ('HEMI', 'Fake Lighting', ''),
+    ('OBJECT_INDEX', 'Object Index', ''),
+    ('COLOR_ID', 'Color ID', ''),
+    ('BACKFACE', 'Backface', ''),
+    ('EDGE_DETECT', 'Edge Detect', ''),
+    ('MODIFIER', 'Modifier', ''),
+    ('GABOR', 'Gabor', ''),
+)
 
 channel_override_type_items = (
-        ('DEFAULT', 'Default', ''),
-        ('IMAGE', 'Image', ''),
-        ('BRICK', 'Brick', ''),
-        ('CHECKER', 'Checker', ''),
-        ('GRADIENT', 'Gradient', ''),
-        ('MAGIC', 'Magic', ''),
-        ('MUSGRAVE', 'Musgrave', ''),
-        ('NOISE', 'Noise', ''),
-        ('VORONOI', 'Voronoi', ''),
-        ('WAVE', 'Wave', ''),
-        ('VCOL', 'Vertex Color', ''),
-        ('GABOR', 'Gabor', ''),
-        )
+    ('DEFAULT', 'Default', ''),
+    ('IMAGE', 'Image', ''),
+    ('BRICK', 'Brick', ''),
+    ('CHECKER', 'Checker', ''),
+    ('GRADIENT', 'Gradient', ''),
+    ('MAGIC', 'Magic', ''),
+    ('MUSGRAVE', 'Musgrave', ''),
+    ('NOISE', 'Noise', ''),
+    ('VORONOI', 'Voronoi', ''),
+    ('WAVE', 'Wave', ''),
+    ('VCOL', 'Vertex Color', ''),
+    ('GABOR', 'Gabor', ''),
+)
 
 # Override 1 will only use default value or image for now
 channel_override_1_type_items = (
-        ('DEFAULT', 'Default', ''),
-        ('IMAGE', 'Image', ''),
-        )
+    ('DEFAULT', 'Default', ''),
+    ('IMAGE', 'Image', ''),
+)
 
 hemi_space_items = (
-        ('WORLD', 'World Space', ''),
-        ('OBJECT', 'Object Space', ''),
-        ('CAMERA', 'Camera Space', ''),
-        )
+    ('WORLD', 'World Space', ''),
+    ('OBJECT', 'Object Space', ''),
+    ('CAMERA', 'Camera Space', ''),
+)
 
 layer_type_labels = {
-        'IMAGE' : 'Image',
-        'BRICK' : 'Brick',
-        'CHECKER' : 'Checker',
-        'GRADIENT' : 'Gradient',
-        'MAGIC' : 'Magic',
-        'MUSGRAVE' : 'Musgrave',
-        'NOISE' : 'Noise',
-        'VORONOI' : 'Voronoi',
-        'WAVE' : 'Wave',
-        'VCOL' : 'Vertex Color',
-        'BACKGROUND' : 'Background',
-        'COLOR' : 'Solid Color',
-        'GROUP' : 'Layer Group',
-        'HEMI' : 'Fake Lighting',
-        'GABOR' : 'Gabor',
-        }
+    'IMAGE' : 'Image',
+    'BRICK' : 'Brick',
+    'CHECKER' : 'Checker',
+    'GRADIENT' : 'Gradient',
+    'MAGIC' : 'Magic',
+    'MUSGRAVE' : 'Musgrave',
+    'NOISE' : 'Noise',
+    'VORONOI' : 'Voronoi',
+    'WAVE' : 'Wave',
+    'VCOL' : 'Vertex Color',
+    'BACKGROUND' : 'Background',
+    'COLOR' : 'Solid Color',
+    'GROUP' : 'Layer Group',
+    'HEMI' : 'Fake Lighting',
+    'GABOR' : 'Gabor',
+}
 
 bake_type_items = (
-        ('AO', 'Ambient Occlusion', ''),
-        ('POINTINESS', 'Pointiness', ''),
-        ('CAVITY', 'Cavity', ''),
-        ('DUST', 'Dust', ''),
-        ('PAINT_BASE', 'Paint Base', ''),
+    ('AO', 'Ambient Occlusion', ''),
+    ('POINTINESS', 'Pointiness', ''),
+    ('CAVITY', 'Cavity', ''),
+    ('DUST', 'Dust', ''),
+    ('PAINT_BASE', 'Paint Base', ''),
 
-        ('BEVEL_NORMAL', 'Bevel Normal', ''),
-        ('BEVEL_MASK', 'Bevel Grayscale', ''),
+    ('BEVEL_NORMAL', 'Bevel Normal', ''),
+    ('BEVEL_MASK', 'Bevel Grayscale', ''),
 
-        ('MULTIRES_NORMAL', 'Multires Normal', ''),
-        ('MULTIRES_DISPLACEMENT', 'Multires Displacement', ''),
+    ('MULTIRES_NORMAL', 'Multires Normal', ''),
+    ('MULTIRES_DISPLACEMENT', 'Multires Displacement', ''),
 
-        ('OTHER_OBJECT_NORMAL', 'Other Objects Normal', ''),
-        ('OTHER_OBJECT_EMISSION', 'Other Objects Emission', ''),
-        ('OTHER_OBJECT_CHANNELS', 'Other Objects Ucupaint Channels', ''),
+    ('OTHER_OBJECT_NORMAL', 'Other Objects Normal', ''),
+    ('OTHER_OBJECT_EMISSION', 'Other Objects Emission', ''),
+    ('OTHER_OBJECT_CHANNELS', 'Other Objects Ucupaint Channels', ''),
 
-        ('SELECTED_VERTICES', 'Selected Vertices/Edges/Faces', ''),
+    ('SELECTED_VERTICES', 'Selected Vertices/Edges/Faces', ''),
 
-        ('FLOW', 'Flow Map based on straight UVMap', ''),
-        )
+    ('FLOW', 'Flow Map based on straight UVMap', ''),
+)
 
 image_resolution_items = (
     ('512', "512", 'Create a 512x512 texture image'),
@@ -259,103 +265,103 @@ image_resolution_items = (
 )
 
 channel_override_labels = {
-        'DEFAULT' : 'Default',
-        'IMAGE' : 'Image',
-        'BRICK' : 'Brick',
-        'CHECKER' : 'Checker',
-        'GRADIENT' : 'Gradient',
-        'MAGIC' : 'Magic',
-        'MUSGRAVE' : 'Musgrave',
-        'NOISE' : 'Noise',
-        'VORONOI' : 'Voronoi',
-        'WAVE' : 'Wave',
-        'VCOL' : 'Vertex Color',
-        'HEMI' : 'Fake Lighting',
-        'GABOR' : 'Gabor',
-        }
+    'DEFAULT' : 'Default',
+    'IMAGE' : 'Image',
+    'BRICK' : 'Brick',
+    'CHECKER' : 'Checker',
+    'GRADIENT' : 'Gradient',
+    'MAGIC' : 'Magic',
+    'MUSGRAVE' : 'Musgrave',
+    'NOISE' : 'Noise',
+    'VORONOI' : 'Voronoi',
+    'WAVE' : 'Wave',
+    'VCOL' : 'Vertex Color',
+    'HEMI' : 'Fake Lighting',
+    'GABOR' : 'Gabor',
+}
 
 bake_type_labels = {
-        'AO' : 'Ambient Occlusion',
-        'POINTINESS': 'Pointiness',
-        'CAVITY': 'Cavity',
-        'DUST': 'Dust',
-        'PAINT_BASE': 'Paint Base',
+    'AO' : 'Ambient Occlusion',
+    'POINTINESS': 'Pointiness',
+    'CAVITY': 'Cavity',
+    'DUST': 'Dust',
+    'PAINT_BASE': 'Paint Base',
 
-        'BEVEL_NORMAL': 'Bevel Normal',
-        'BEVEL_MASK': 'Bevel Grayscale',
+    'BEVEL_NORMAL': 'Bevel Normal',
+    'BEVEL_MASK': 'Bevel Grayscale',
 
-        'MULTIRES_NORMAL': 'Multires Normal',
-        'MULTIRES_DISPLACEMENT': 'Multires Displacement',
+    'MULTIRES_NORMAL': 'Multires Normal',
+    'MULTIRES_DISPLACEMENT': 'Multires Displacement',
 
-        'OTHER_OBJECT_NORMAL': 'Other Objects Normal',
-        'OTHER_OBJECT_EMISSION': 'Other Objects Emission',
-        'OTHER_OBJECT_CHANNELS': 'Other Objects Ucupaint Channels',
+    'OTHER_OBJECT_NORMAL': 'Other Objects Normal',
+    'OTHER_OBJECT_EMISSION': 'Other Objects Emission',
+    'OTHER_OBJECT_CHANNELS': 'Other Objects Ucupaint Channels',
 
-        'SELECTED_VERTICES': 'Selected Vertices',
+    'SELECTED_VERTICES': 'Selected Vertices',
 
-        'FLOW': 'Flow'
-        }
+    'FLOW': 'Flow'
+}
 
 bake_type_suffixes = {
-        'AO' : 'AO',
-        'POINTINESS': 'Pointiness',
-        'CAVITY': 'Cavity',
-        'DUST': 'Dust',
-        'PAINT_BASE': 'Paint Base',
+    'AO' : 'AO',
+    'POINTINESS': 'Pointiness',
+    'CAVITY': 'Cavity',
+    'DUST': 'Dust',
+    'PAINT_BASE': 'Paint Base',
 
-        'BEVEL_NORMAL': 'Bevel Normal',
-        'BEVEL_MASK': 'Bevel Grayscale',
+    'BEVEL_NORMAL': 'Bevel Normal',
+    'BEVEL_MASK': 'Bevel Grayscale',
 
-        'MULTIRES_NORMAL': 'Normal Multires',
-        'MULTIRES_DISPLACEMENT': 'Displacement Multires',
+    'MULTIRES_NORMAL': 'Normal Multires',
+    'MULTIRES_DISPLACEMENT': 'Displacement Multires',
 
-        'OTHER_OBJECT_NORMAL': 'OO Normal',
-        'OTHER_OBJECT_EMISSION': 'OO Emission',
-        'OTHER_OBJECT_CHANNELS': 'OO Channel',
+    'OTHER_OBJECT_NORMAL': 'OO Normal',
+    'OTHER_OBJECT_EMISSION': 'OO Emission',
+    'OTHER_OBJECT_CHANNELS': 'OO Channel',
 
-        'SELECTED_VERTICES': 'Selected Vertices',
+    'SELECTED_VERTICES': 'Selected Vertices',
 
-        'FLOW': 'Flow'
-        }
+    'FLOW': 'Flow'
+}
 
 texcoord_lists = [
-        'Generated',
-        'Normal',
-        #'UV',
-        'Object',
-        'Camera',
-        'Window',
-        'Reflection',
-        ]
+    'Generated',
+    'Normal',
+    #'UV',
+    'Object',
+    'Camera',
+    'Window',
+    'Reflection',
+]
 
 texcoord_type_items = (
-        ('Generated', 'Generated', ''),
-        ('Normal', 'Normal', ''),
-        ('UV', 'UV', ''),
-        ('Object', 'Object', ''),
-        ('Camera', 'Camera', ''),
-        ('Window', 'Window', ''),
-        ('Reflection', 'Reflection', ''),
-        ('Decal', 'Decal', ''),
-        )
+    ('Generated', 'Generated', ''),
+    ('Normal', 'Normal', ''),
+    ('UV', 'UV', ''),
+    ('Object', 'Object', ''),
+    ('Camera', 'Camera', ''),
+    ('Window', 'Window', ''),
+    ('Reflection', 'Reflection', ''),
+    ('Decal', 'Decal', ''),
+)
 
 mask_texcoord_type_items = (
-        ('Generated', 'Generated', ''),
-        ('Normal', 'Normal', ''),
-        ('UV', 'UV', ''),
-        ('Object', 'Object', ''),
-        ('Camera', 'Camera', ''),
-        ('Window', 'Window', ''),
-        ('Reflection', 'Reflection', ''),
-        ('Decal', 'Decal', ''),
-        ('Layer', 'Use Layer Vector', ''),
-        )
+    ('Generated', 'Generated', ''),
+    ('Normal', 'Normal', ''),
+    ('UV', 'UV', ''),
+    ('Object', 'Object', ''),
+    ('Camera', 'Camera', ''),
+    ('Window', 'Window', ''),
+    ('Reflection', 'Reflection', ''),
+    ('Decal', 'Decal', ''),
+    ('Layer', 'Use Layer Vector', ''),
+)
 
 interpolation_type_items = (
-        ('Linear', 'Linear', 'Linear interpolation.'),
-        ('Closest', 'Closest', 'No interpolation (sample closest texel).'),
-        ('Cubic', 'Cubic', 'Cubic interpolation.'),
-        )
+    ('Linear', 'Linear', 'Linear interpolation.'),
+    ('Closest', 'Closest', 'No interpolation (sample closest texel).'),
+    ('Cubic', 'Cubic', 'Cubic interpolation.'),
+)
 
 channel_socket_input_bl_idnames = {
     'RGB': 'NodeSocketColor',
@@ -370,82 +376,82 @@ channel_socket_output_bl_idnames = {
 }
 
 possible_object_types = {
-        'MESH',
-        'META',
-        'CURVE',
-        'CURVES',
-        'SURFACE',
-        'FONT'
-        }
+    'MESH',
+    'META',
+    'CURVE',
+    'CURVES',
+    'SURFACE',
+    'FONT'
+}
 
 texture_node_types = {
-        'TEX_IMAGE',
-        'TEX_BRICK',
-        'TEX_ENVIRONMENT',
-        'TEX_CHECKER',
-        'TEX_GRADIENT',
-        'TEX_MAGIC',
-        'TEX_MUSGRAVE',
-        'TEX_NOISE',
-        'TEX_POINTDENSITY',
-        'TEX_SKY',
-        'TEX_VORONOI',
-        'TEX_WAVE',
-        }
+    'TEX_IMAGE',
+    'TEX_BRICK',
+    'TEX_ENVIRONMENT',
+    'TEX_CHECKER',
+    'TEX_GRADIENT',
+    'TEX_MAGIC',
+    'TEX_MUSGRAVE',
+    'TEX_NOISE',
+    'TEX_POINTDENSITY',
+    'TEX_SKY',
+    'TEX_VORONOI',
+    'TEX_WAVE',
+}
 
 layer_node_bl_idnames = {
-        'IMAGE' : 'ShaderNodeTexImage',
-        'ENVIRONMENT' : 'ShaderNodeTexEnvironment',
-        'BRICK' : 'ShaderNodeTexBrick',
-        'CHECKER' : 'ShaderNodeTexChecker',
-        'GRADIENT' : 'ShaderNodeTexGradient',
-        'MAGIC' : 'ShaderNodeTexMagic',
-        'MUSGRAVE' : 'ShaderNodeTexMusgrave',
-        'NOISE' : 'ShaderNodeTexNoise',
-        'POINT_DENSITY' : 'ShaderNodeTexPointDensity',
-        'SKY' : 'ShaderNodeTexSky',
-        'VORONOI' : 'ShaderNodeTexVoronoi',
-        'WAVE' : 'ShaderNodeTexWave',
-        'VCOL' : 'ShaderNodeAttribute',
-        'BACKGROUND' : 'NodeGroupInput',
-        'COLOR' : 'ShaderNodeRGB',
-        'GROUP' : 'NodeGroupInput',
-        'HEMI' : 'ShaderNodeGroup',
-        'OBJECT_INDEX' : 'ShaderNodeGroup',
-        'COLOR_ID' : 'ShaderNodeGroup',
-        'BACKFACE' : 'ShaderNodeNewGeometry',
-        'EDGE_DETECT' : 'ShaderNodeGroup',
-        'GABOR' : 'ShaderNodeTexGabor',
-        }
+    'IMAGE' : 'ShaderNodeTexImage',
+    'ENVIRONMENT' : 'ShaderNodeTexEnvironment',
+    'BRICK' : 'ShaderNodeTexBrick',
+    'CHECKER' : 'ShaderNodeTexChecker',
+    'GRADIENT' : 'ShaderNodeTexGradient',
+    'MAGIC' : 'ShaderNodeTexMagic',
+    'MUSGRAVE' : 'ShaderNodeTexMusgrave',
+    'NOISE' : 'ShaderNodeTexNoise',
+    'POINT_DENSITY' : 'ShaderNodeTexPointDensity',
+    'SKY' : 'ShaderNodeTexSky',
+    'VORONOI' : 'ShaderNodeTexVoronoi',
+    'WAVE' : 'ShaderNodeTexWave',
+    'VCOL' : 'ShaderNodeAttribute',
+    'BACKGROUND' : 'NodeGroupInput',
+    'COLOR' : 'ShaderNodeRGB',
+    'GROUP' : 'NodeGroupInput',
+    'HEMI' : 'ShaderNodeGroup',
+    'OBJECT_INDEX' : 'ShaderNodeGroup',
+    'COLOR_ID' : 'ShaderNodeGroup',
+    'BACKFACE' : 'ShaderNodeNewGeometry',
+    'EDGE_DETECT' : 'ShaderNodeGroup',
+    'GABOR' : 'ShaderNodeTexGabor',
+}
 
 io_suffix = {
-        'GROUP' : ' Group',
-        'BACKGROUND' : ' Background',
-        'ALPHA' : ' Alpha',
-        'DISPLACEMENT' : ' Displacement',
-        'HEIGHT' : ' Height',
-        'MAX_HEIGHT' : ' Max Height',
-        'VDISP' : ' Vector Displacement',
-        'HEIGHT_ONS' : ' Height ONS',
-        'HEIGHT_EW' : ' Height EW',
-        'UV' : ' UV',
-        'TANGENT' : ' Tangent',
-        'BITANGENT' : ' Bitangent',
-        'HEIGHT_N' : ' Height N',
-        'HEIGHT_S' : ' Height S',
-        'HEIGHT_E' : ' Height E',
-        'HEIGHT_W' : ' Height W',
-        }
+    'GROUP' : ' Group',
+    'BACKGROUND' : ' Background',
+    'ALPHA' : ' Alpha',
+    'DISPLACEMENT' : ' Displacement',
+    'HEIGHT' : ' Height',
+    'MAX_HEIGHT' : ' Max Height',
+    'VDISP' : ' Vector Displacement',
+    'HEIGHT_ONS' : ' Height ONS',
+    'HEIGHT_EW' : ' Height EW',
+    'UV' : ' UV',
+    'TANGENT' : ' Tangent',
+    'BITANGENT' : ' Bitangent',
+    'HEIGHT_N' : ' Height N',
+    'HEIGHT_S' : ' Height S',
+    'HEIGHT_E' : ' Height E',
+    'HEIGHT_W' : ' Height W',
+}
 
 io_names = {
-        'Generated' : 'Texcoord Generated',
-        'Object' : 'Texcoord Object',
-        'Normal' : 'Texcoord Normal',
-        'Camera' : 'Texcoord Camera',
-        'Window' : 'Texcoord Window',
-        'Reflection' : 'Texcoord Reflection',
-        'Decal' : 'Texcoord Object',
-        }
+    'Generated' : 'Texcoord Generated',
+    'Object' : 'Texcoord Object',
+    'Normal' : 'Texcoord Normal',
+    'Camera' : 'Texcoord Camera',
+    'Window' : 'Texcoord Window',
+    'Reflection' : 'Texcoord Reflection',
+    'Decal' : 'Texcoord Object',
+}
 
 math_method_items = (
     ("ADD", "Add", ""),
@@ -454,17 +460,17 @@ math_method_items = (
     ("DIVIDE", "Divide", ""),
     ("POWER", "Power", ""),
     ("LOGARITHM", "Logarithm", ""),
-    )
+)
 
 vcol_domain_items = (
     ('POINT', 'Vertex', ''),
     ('CORNER', 'Face Corner', ''),
-    )
+)
 
 vcol_data_type_items = (
     ('FLOAT_COLOR', 'Color', ''),
     ('BYTE_COLOR', 'Byte Color', ''),
-    )
+)
 
 limited_mask_blend_types = {
     'ADD',
@@ -475,13 +481,13 @@ limited_mask_blend_types = {
     'LIGHTEN',
     'VALUE',
     'LINEAR_LIGHT',
-    }
+}
 
 eraser_names = {
-        'TEXTURE_PAINT' : 'Eraser Tex',
-        'VERTEX_PAINT' : 'Eraser Vcol',
-        'SCULPT' : 'Eraser Paint',
-        }
+    'TEXTURE_PAINT' : 'Eraser Tex',
+    'VERTEX_PAINT' : 'Eraser Vcol',
+    'SCULPT' : 'Eraser Paint',
+}
 
 rgba_letters = ['r', 'g', 'b', 'a']
 nsew_letters = ['n', 's', 'e', 'w']
@@ -559,10 +565,10 @@ def get_current_version():
 def is_online():
     return not is_bl_newer_than(4, 2) or bpy.app.online_access
 
-def is_bl_newer_than(major, minor = 0, patch = 0):
+def is_bl_newer_than(major, minor=0, patch=0):
     return bpy.app.version >= (major, minor, patch)
 
-def is_bl_equal(major, minor = None, patch = None):
+def is_bl_equal(major, minor=None, patch=None):
     if minor == None and patch == None:
         return bpy.app.version[0] == major
     elif patch == None:
@@ -570,7 +576,7 @@ def is_bl_equal(major, minor = None, patch = None):
     else:
         return bpy.app.version == (major, minor, patch)
 
-def is_created_before(major, minor = 0, patch = 0):
+def is_created_before(major, minor=0, patch=0):
     return bpy.data.version < (major, minor, patch)
 
 def get_bpytypes():
@@ -790,7 +796,7 @@ def get_addon_filepath():
 
 def srgb_to_linear_per_element(e):
     if e <= 0.03928:
-        return e/12.92
+        return e / 12.92
     else: 
         return pow((e + 0.055) / 1.055, 2.4)
 
@@ -875,7 +881,7 @@ def blend_color_mix_byte(src1, src2, intensity1=1.0, intensity2=1.0):
 
     return dst
 
-def copy_id_props(source, dest, extras = [], reverse=False):
+def copy_id_props(source, dest, extras=[], reverse=False):
 
     bpytypes = get_bpytypes()
     props = dir(source)
@@ -924,7 +930,7 @@ def copy_id_props(source, dest, extras = [], reverse=False):
                 try: setattr(dest, prop, val)
                 except: print('Error set prop:', prop)
 
-def copy_node_props_(source, dest, extras = []):
+def copy_node_props_(source, dest, extras=[]):
 
     bpytypes = get_bpytypes()
     props = dir(source)
@@ -1542,7 +1548,7 @@ def get_masks_with_specific_segment(layer, segment):
 
     return masks
 
-def replace_image(old_image, new_image, yp=None, uv_name = ''):
+def replace_image(old_image, new_image, yp=None, uv_name=''):
 
     if old_image == new_image: return
 
@@ -1726,7 +1732,7 @@ def create_info_nodes(tree):
             loc.y -= 80
             info.location = loc
 
-def check_duplicated_node_group(node_group, duplicated_trees = []):
+def check_duplicated_node_group(node_group, duplicated_trees=[]):
 
     info_frame_found = False
 
@@ -2884,10 +2890,10 @@ def get_upper_neighbor(layer):
     if layer_idx == 0:
         return None, None
 
-    if layer.parent_idx == layer_idx-1:
-        return layer_idx-1, yp.layers[layer_idx-1]
+    if layer.parent_idx == layer_idx - 1:
+        return layer_idx - 1, yp.layers[layer_idx - 1]
 
-    upper_layer = yp.layers[layer_idx-1]
+    upper_layer = yp.layers[layer_idx - 1]
 
     neighbor_idx = get_last_chained_up_layer_ids(upper_layer, layer.parent_idx)
     neighbor = yp.layers[neighbor_idx]
@@ -2898,7 +2904,7 @@ def get_lower_neighbor(layer):
 
     yp = layer.id_data.yp
     layer_idx = get_layer_index(layer)
-    last_index = len(yp.layers)-1
+    last_index = len(yp.layers) - 1
 
     if layer_idx == last_index:
         return None, None
@@ -2911,7 +2917,7 @@ def get_lower_neighbor(layer):
 
         neighbor_idx = last_child_idx + 1
     else:
-        neighbor_idx = layer_idx+1
+        neighbor_idx = layer_idx + 1
 
     neighbor = yp.layers[neighbor_idx]
 
@@ -3070,8 +3076,8 @@ def update_mapping(entity, use_baked=False):
         else:
             segment = image.yia.segments.get(segment_name)
 
-            scale_x = segment.width/image.size[0] * scale_x
-            scale_y = segment.height/image.size[1] * scale_y
+            scale_x = segment.width / image.size[0] * scale_x
+            scale_y = segment.height / image.size[1] * scale_y
 
             offset_x = scale_x * segment.tile_x + offset_x * scale_x
             offset_y = scale_y * segment.tile_y + offset_y * scale_y
@@ -3191,7 +3197,7 @@ def set_uv_mirror_offsets(obj, matrix):
     mirror = get_first_mirror_modifier(obj)
     if not mirror: return
 
-    movec = Vector((mirror.mirror_offset_u/2, mirror.mirror_offset_v/2, 0.0))
+    movec = Vector((mirror.mirror_offset_u / 2, mirror.mirror_offset_v / 2, 0.0))
     if is_bl_newer_than(2, 80):
         # NOTE: For compatibility to older blenders, put matrix multiplication under eval
         movec = eval('matrix @ movec')
@@ -3401,7 +3407,7 @@ def refresh_temp_uv(obj, entity):
             (scale_x, 0, 0),
             (0, scale_y, 0),
             (0, 0, scale_z)
-            ))
+        ))
 
         # Rotate
         m.rotate(Euler((rotation_x, rotation_y, rotation_z)))
@@ -3419,7 +3425,7 @@ def refresh_temp_uv(obj, entity):
             (0, 1, 0, -translation_y),
             (0, 0, 1, -translation_z),
             (0, 0, 0, 1),
-            ))
+        ))
 
         # Rotate z matrix
         m1 = Matrix(((1, 0, 0), (0, 1, 0), (0, 0, 1)))
@@ -3435,15 +3441,15 @@ def refresh_temp_uv(obj, entity):
 
         # Scale matrix
         m4 = Matrix((
-            (1/scale_x, 0, 0),
-            (0, 1/scale_y, 0),
-            (0, 0, 1/scale_z)
-            ))
+            (1 / scale_x, 0, 0),
+            (0, 1 / scale_y, 0),
+            (0, 0, 1 / scale_z)
+        ))
 
     # Create numpy array to store uv coordinates
-    arr = numpy.zeros(len(obj.data.loops)*2, dtype=numpy.float32)
+    arr = numpy.zeros(len(obj.data.loops) * 2, dtype=numpy.float32)
     temp_uv_layer.data.foreach_get('uv', arr)
-    arr.shape = (arr.shape[0]//2, 2)
+    arr.shape = (arr.shape[0] // 2, 2)
 
     # Matrix transformation for each uv coordinates
     if is_bl_newer_than(2, 80):
@@ -3637,7 +3643,7 @@ def create_iterate_group_nodes(iter_tree, match_io=False):
     return group_tree
 
 def calculate_group_needed(num_of_iteration):
-    return int(num_of_iteration/PARALLAX_DIVIDER)
+    return int(num_of_iteration / PARALLAX_DIVIDER)
 
 def calculate_parallax_group_depth(num_of_iteration):
     #iter_inside = 1
@@ -3866,7 +3872,7 @@ def get_layer_channel_max_height(layer, ch, ch_idx=None):
             max_height = abs(get_transition_bump_max_distance_with_crease(ch))
         else:
             if ch.transition_bump_flip:
-                max_height = abs(get_transition_bump_max_distance_with_crease(ch)) + base_distance*2
+                max_height = abs(get_transition_bump_max_distance_with_crease(ch)) + base_distance * 2
 
             else: 
                 max_height = abs(get_transition_bump_max_distance_with_crease(ch)) + base_distance
@@ -3952,7 +3958,7 @@ def get_max_height_from_list_of_layers(layers, ch_index, layer=None, top_layers_
         if (l.enable and c.enable and 
                 (write_height or (not write_height and l == layer)) and
                 c.normal_blend_type in {'MIX', 'COMPARE'} and max_height < ch_max_height
-                ):
+            ):
             max_height = ch_max_height
         if l == layer:
             break
@@ -3966,7 +3972,7 @@ def get_max_height_from_list_of_layers(layers, ch_index, layer=None, top_layers_
         if (l.enable and c.enable and 
                 (write_height or (not write_height and l == layer)) and
                 c.normal_blend_type == 'OVERLAY'
-                ):
+            ):
             max_height += ch_max_height
         if l == layer:
             break
@@ -4258,7 +4264,7 @@ def get_multires_modifier(obj, keyword='', include_hidden=False):
 
     return None
 
-def update_layer_images_interpolation(layer, interpolation='Linear', from_interpolation = ''):
+def update_layer_images_interpolation(layer, interpolation='Linear', from_interpolation=''):
     if layer.type == 'IMAGE':
         source = get_layer_source(layer)
         if source and source.image: 
@@ -4387,14 +4393,14 @@ def move_uv(obj, from_index, to_index):
     # Move the UV map down to the target index
     if from_index < to_index:
         move_uv_to_bottom(obj, from_index)
-        for i in range(len(uv_layers)-1-to_index):
+        for i in range(len(uv_layers) - 1 - to_index):
             move_uv_to_bottom(obj, to_index)
             
     # Move the UV map up to the target index
     elif from_index > to_index:
         for i in range(from_index-to_index):
             move_uv_to_bottom(obj, to_index)
-        for i in range(len(uv_layers)-1-from_index):
+        for i in range(len(uv_layers) - 1 - from_index):
             move_uv_to_bottom(obj, to_index+1)
     
     uv_layers.active_index = to_index
@@ -4867,7 +4873,7 @@ def is_tangent_process_needed(yp, uv_name):
                 #(not height_root_ch.enable_smooth_bump and any_layers_using_bump_map(height_root_ch) and any_layers_using_normal_map(height_root_ch))
                 #any_layers_using_bump_map(height_root_ch) or
                 (is_normal_height_input_connected(height_root_ch) and height_root_ch.enable_smooth_bump)
-                ):
+            ):
             return True
 
         for layer in yp.layers:
@@ -5404,14 +5410,16 @@ def get_yp_entities_images_and_segments(yp):
         if baked_source and baked_source.image:
             image = baked_source.image
             entities, images, segment_names, segment_name_props = check_yp_entities_images_segments_in_lists(
-                    layer, image, layer.baked_segment_name, 'baked_segment_name', entities, images, segment_names, segment_name_props)
+                layer, image, layer.baked_segment_name, 'baked_segment_name', entities, images, segment_names, segment_name_props
+            )
 
         if layer.type == 'IMAGE':
             source = get_layer_source(layer)
             if source and source.image:
                 image = source.image
                 entities, images, segment_names, segment_name_props = check_yp_entities_images_segments_in_lists(
-                        layer, image, layer.segment_name, 'segment_name', entities, images, segment_names, segment_name_props)
+                    layer, image, layer.segment_name, 'segment_name', entities, images, segment_names, segment_name_props
+                )
 
         for mask in layer.masks:
 
@@ -5419,14 +5427,16 @@ def get_yp_entities_images_and_segments(yp):
             if baked_source and baked_source.image:
                 image = baked_source.image
                 entities, images, segment_names, segment_name_props = check_yp_entities_images_segments_in_lists(
-                        mask, image, mask.baked_segment_name, 'baked_segment_name', entities, images, segment_names, segment_name_props)
+                    mask, image, mask.baked_segment_name, 'baked_segment_name', entities, images, segment_names, segment_name_props
+                )
 
             if mask.type == 'IMAGE':
                 source = get_mask_source(mask)
                 if source and source.image:
                     image = source.image
                     entities, images, segment_names, segment_name_props = check_yp_entities_images_segments_in_lists(
-                            mask, image, mask.segment_name, 'segment_name', entities, images, segment_names, segment_name_props)
+                        mask, image, mask.segment_name, 'segment_name', entities, images, segment_names, segment_name_props
+                    )
 
     return entities, images, segment_names, segment_name_props
 
@@ -5868,8 +5878,10 @@ def replace_new_mix_node(tree, entity, prop, label='', return_status=False, hard
 
     group_name = ''
 
-    node, dirty = replace_new_node(tree, entity, prop, node_id_name, label, group_name, 
-            return_status=True, hard_replace=hard_replace, dirty=dirty, force_replace=force_replace)
+    node, dirty = replace_new_node(
+        tree, entity, prop, node_id_name, label, group_name, 
+        return_status=True, hard_replace=hard_replace, dirty=dirty, force_replace=force_replace
+    )
 
     if is_bl_newer_than(3, 4):
         if node.data_type != data_type:
@@ -6349,8 +6361,8 @@ def copy_image_pixels(src, dest, segment=None, segment_src=None):
         src_start_y = height * segment_src.tile_y
 
     if is_bl_newer_than(2, 83):
-        target_pxs = numpy.empty(shape=dest.size[0]*dest.size[1]*4, dtype=numpy.float32)
-        source_pxs = numpy.empty(shape=src.size[0]*src.size[1]*4, dtype=numpy.float32)
+        target_pxs = numpy.empty(shape=dest.size[0]*dest.size[1] * 4, dtype=numpy.float32)
+        source_pxs = numpy.empty(shape=src.size[0]*src.size[1] * 4, dtype=numpy.float32)
         dest.pixels.foreach_get(target_pxs)
         src.pixels.foreach_get(source_pxs)
 
@@ -6641,8 +6653,9 @@ def restore_armature_order(obj):
     ori_obj = bpy.context.object
     bpy.context.view_layer.objects.active = obj
 
-    bpy.ops.object.modifier_move_to_index(modifier=mod.name, 
-            index=min(ys.ori_armature_index, len(obj.modifiers)-1))
+    bpy.ops.object.modifier_move_to_index(
+        modifier=mod.name, index=min(ys.ori_armature_index, len(obj.modifiers)-1)
+    )
 
     bpy.context.view_layer.objects.active = ori_obj    
 

--- a/image_ops.py
+++ b/image_ops.py
@@ -416,21 +416,21 @@ class YSaveImage(bpy.types.Operator):
         return {'FINISHED'}
 
 format_extensions = {
-        'BMP' : '.bmp',
-        'IRIS' : '.rgb',
-        'PNG' : '.png',
-        'JPEG' : '.jpg',
-        'JPEG2000' : '.jp2',
-        'TARGA' : '.tga',
-        'TARGA_RAW' : '.tga',
-        'CINEON' : '.cin',
-        'DPX' : '.dpx',
-        'OPEN_EXR_MULTILAYER' : '.exr',
-        'OPEN_EXR' : '.exr',
-        'HDR' : '.hdr',
-        'TIFF' : '.tif',
-        'WEBP' : '.webp',
-        }
+    'BMP' : '.bmp',
+    'IRIS' : '.rgb',
+    'PNG' : '.png',
+    'JPEG' : '.jpg',
+    'JPEG2000' : '.jp2',
+    'TARGA' : '.tga',
+    'TARGA_RAW' : '.tga',
+    'CINEON' : '.cin',
+    'DPX' : '.dpx',
+    'OPEN_EXR_MULTILAYER' : '.exr',
+    'OPEN_EXR' : '.exr',
+    'HDR' : '.hdr',
+    'TIFF' : '.tif',
+    'WEBP' : '.webp',
+}
 
 def color_mode_items(self, context):
     items = []
@@ -447,26 +447,36 @@ def color_mode_items(self, context):
 
 def color_depth_items(self, context):
     if self.file_format in {'PNG', 'TIFF'}:
-        items = (('8', '8', ''),
-                ('16', '16', ''))
+        items = (
+            ('8', '8', ''),
+            ('16', '16', '')
+        )
     elif self.file_format in {'JPEG2000'}:
-        items = (('8', '8', ''),
-                ('12', '12', ''),
-                ('16', '16', ''))
+        items = (
+            ('8', '8', ''),
+            ('12', '12', ''),
+            ('16', '16', '')
+        )
     elif self.file_format in {'DPX'}:
-        items = (('8', '8', ''),
-                ('10', '10', ''),
-                ('12', '12', ''),
-                ('16', '16', ''))
+        items = (
+            ('8', '8', ''),
+            ('10', '10', ''),
+            ('12', '12', ''),
+            ('16', '16', '')
+        )
     elif self.file_format in {'OPEN_EXR_MULTILAYER', 'OPEN_EXR'}:
-        items = (('16', 'Float (Half)', ''),
-                ('32', 'Float (Full)', ''))
+        items = (
+            ('16', 'Float (Half)', ''),
+            ('32', 'Float (Full)', '')
+        )
     else:
-        items = (('8', '8', ''),
-                ('10', '10', ''),
-                ('12', '12', ''),
-                ('16', '16', ''),
-                ('32', '32', ''))
+        items = (
+            ('8', '8', ''),
+            ('10', '10', ''),
+            ('12', '12', ''),
+            ('16', '16', ''),
+            ('32', '32', '')
+        )
 
     return items
 
@@ -546,31 +556,33 @@ class YSaveAllBakedImages(bpy.types.Operator):
 
     # Define this to tell 'fileselect_add' that we want a directoy
     directory : bpy.props.StringProperty(
-        name="Outdir Path",
-        description="Where I will save my stuff"
+        name = 'Outdir Path',
+        description = 'Where I will save my stuff'
         # subtype='DIR_PATH' is not needed to specify the selection mode.
         # But this will be anyway a directory path.
-        )
+    )
 
     remove_whitespaces : bpy.props.BoolProperty(
-            name="Remove Whitespaces",
-            description="Remove whitespaces from baked image names",
-            default=False
-            )
+        name = 'Remove Whitespaces',
+        description = 'Remove whitespaces from baked image names',
+        default = False
+    )
 
     file_format : EnumProperty(
-            name = 'File Format',
-            items = (
-                    ('PNG', 'PNG', '', 'IMAGE_DATA', 0),
-                    ('TIFF', 'TIFF', '', 'IMAGE_DATA', 1),
-                    ('OPEN_EXR', 'OpenEXR', '', 'IMAGE_DATA', 2)
-                    ),
-            default = 'PNG',
-            )
+        name = 'File Format',
+        items = (
+            ('PNG', 'PNG', '', 'IMAGE_DATA', 0),
+            ('TIFF', 'TIFF', '', 'IMAGE_DATA', 1),
+            ('OPEN_EXR', 'OpenEXR', '', 'IMAGE_DATA', 2)
+        ),
+        default = 'PNG'
+    )
 
-    copy : BoolProperty(name='Copy',
-            description = 'Create a new image file without modifying the current image in Blender',
-            default = False)
+    copy : BoolProperty(
+        name = 'Copy',
+        description = 'Create a new image file without modifying the current image in Blender',
+        default = False
+    )
 
     def invoke(self, context, event):
         # Open browser, take reference to 'self' read the path to selected
@@ -736,20 +748,20 @@ class YSaveAllBakedImages(bpy.types.Operator):
 
 def get_file_format_items():
     items = [
-            ('BMP', 'BMP', '', 'IMAGE_DATA', 0),
-            ('IRIS', 'Iris', '', 'IMAGE_DATA', 1),
-            ('PNG', 'PNG', '', 'IMAGE_DATA', 2),
-            ('JPEG', 'JPEG', '', 'IMAGE_DATA', 3),
-            ('JPEG2000', 'JPEG 2000', '', 'IMAGE_DATA', 4),
-            ('TARGA', 'Targa', '', 'IMAGE_DATA', 5),
-            ('TARGA_RAW', 'Targa Raw', '', 'IMAGE_DATA', 6),
-            ('CINEON', 'Cineon', '', 'IMAGE_DATA', 7),
-            ('DPX', 'DPX', '', 'IMAGE_DATA', 8),
-            ('OPEN_EXR_MULTILAYER', 'OpenEXR Multilayer', '', 'IMAGE_DATA', 9),
-            ('OPEN_EXR', 'OpenEXR', '', 'IMAGE_DATA', 10),
-            ('HDR', 'Radiance HDR', '', 'IMAGE_DATA', 11),
-            ('TIFF', 'TIFF', '', 'IMAGE_DATA', 12)
-            ]
+        ('BMP', 'BMP', '', 'IMAGE_DATA', 0),
+        ('IRIS', 'Iris', '', 'IMAGE_DATA', 1),
+        ('PNG', 'PNG', '', 'IMAGE_DATA', 2),
+        ('JPEG', 'JPEG', '', 'IMAGE_DATA', 3),
+        ('JPEG2000', 'JPEG 2000', '', 'IMAGE_DATA', 4),
+        ('TARGA', 'Targa', '', 'IMAGE_DATA', 5),
+        ('TARGA_RAW', 'Targa Raw', '', 'IMAGE_DATA', 6),
+        ('CINEON', 'Cineon', '', 'IMAGE_DATA', 7),
+        ('DPX', 'DPX', '', 'IMAGE_DATA', 8),
+        ('OPEN_EXR_MULTILAYER', 'OpenEXR Multilayer', '', 'IMAGE_DATA', 9),
+        ('OPEN_EXR', 'OpenEXR', '', 'IMAGE_DATA', 10),
+        ('HDR', 'Radiance HDR', '', 'IMAGE_DATA', 11),
+        ('TIFF', 'TIFF', '', 'IMAGE_DATA', 12)
+    ]
 
     if is_bl_newer_than(3, 2):
         items.append(('WEBP', 'WebP', '', 'IMAGE_DATA', 13))
@@ -763,72 +775,81 @@ class YSaveAsImage(bpy.types.Operator, ExportHelper):
     bl_options = {'REGISTER', 'UNDO'}
 
     file_format : EnumProperty(
-            name = 'File Format',
-            items = get_file_format_items(),
-            default = 'PNG',
-            update = update_save_as_file_format
-            )
+        name = 'File Format',
+        items = get_file_format_items(),
+        default = 'PNG',
+        update = update_save_as_file_format
+    )
 
     # File browser filter
     filter_folder : BoolProperty(default=True, options={'HIDDEN', 'SKIP_SAVE'})
     filter_image : BoolProperty(default=True, options={'HIDDEN', 'SKIP_SAVE'})
     display_type : EnumProperty(
-            items = (('FILE_DEFAULTDISPLAY', 'Default', ''),
-                     ('FILE_SHORTDISLPAY', 'Short List', ''),
-                     ('FILE_LONGDISPLAY', 'Long List', ''),
-                     ('FILE_IMGDISPLAY', 'Thumbnails', '')),
-            default = 'FILE_IMGDISPLAY',
-            options={'HIDDEN', 'SKIP_SAVE'})
+        items = (
+            ('FILE_DEFAULTDISPLAY', 'Default', ''),
+            ('FILE_SHORTDISLPAY', 'Short List', ''),
+            ('FILE_LONGDISPLAY', 'Long List', ''),
+            ('FILE_IMGDISPLAY', 'Thumbnails', '')
+        ),
+        default = 'FILE_IMGDISPLAY',
+        options = {'HIDDEN', 'SKIP_SAVE'}
+    )
 
-    copy : BoolProperty(name='Copy',
-            description = 'Create a new image file without modifying the current image in Blender',
-            default = False)
+    copy : BoolProperty(
+        name = 'Copy',
+        description = 'Create a new image file without modifying the current image in Blender',
+        default = False
+    )
 
-    relative : BoolProperty(name='Relative Path',
-            description = 'Select the file relative to the blend file',
-            default = True)
+    relative : BoolProperty(
+        name = 'Relative Path',
+        description = 'Select the file relative to the blend file',
+        default = True
+    )
 
     color_mode : EnumProperty(
-            name = 'Color Mode',
-            items = color_mode_items)
+        name = 'Color Mode',
+        items = color_mode_items
+    )
 
     color_depth : EnumProperty(
-            name = 'Color Depth',
-            items = color_depth_items)
+        name = 'Color Depth',
+        items = color_depth_items
+    )
 
     tiff_codec : EnumProperty(
-            name = 'Compression',
-            items = (
-                ('NONE', 'None', ''),
-                ('DEFLATE', 'Deflate', ''),
-                ('LZW', 'LZW', ''),
-                ('PACKBITS', 'Pack Bits', ''),
-                ),
-            default = 'DEFLATE'
-            )
+        name = 'Compression',
+        items = (
+            ('NONE', 'None', ''),
+            ('DEFLATE', 'Deflate', ''),
+            ('LZW', 'LZW', ''),
+            ('PACKBITS', 'Pack Bits', ''),
+        ),
+        default = 'DEFLATE'
+    )
 
     exr_codec : EnumProperty(
-            name = 'Codec',
-            items = (
-                ('NONE', 'None', ''),
-                ('PXR24', 'Pxr24 (lossy)', ''),
-                ('ZIP', 'ZIP (lossless)', ''),
-                ('PIZ', 'PIZ (lossless)', ''),
-                ('RLE', 'RLE (lossless)', ''),
-                ('ZIPS', 'ZIPS (lossless)', ''),
-                ('DWAA', 'DWAA (lossy)', ''),
-                ),
-            default = 'ZIP'
-            )
+        name = 'Codec',
+        items = (
+            ('NONE', 'None', ''),
+            ('PXR24', 'Pxr24 (lossy)', ''),
+            ('ZIP', 'ZIP (lossless)', ''),
+            ('PIZ', 'PIZ (lossless)', ''),
+            ('RLE', 'RLE (lossless)', ''),
+            ('ZIPS', 'ZIPS (lossless)', ''),
+            ('DWAA', 'DWAA (lossy)', ''),
+        ),
+        default = 'ZIP'
+    )
 
     jpeg2k_codec : EnumProperty(
-            name = 'Codec',
-            items = (
-                ('JP2', 'JP2', ''),
-                ('J2K', 'J2K', ''),
-                ),
-            default = 'JP2'
-            )
+        name = 'Codec',
+        items = (
+            ('JP2', 'JP2', ''),
+            ('J2K', 'J2K', ''),
+        ),
+        default = 'JP2'
+    )
 
     compression : IntProperty(name='Compression', default=15, min=0, max=100, subtype='PERCENTAGE')
     quality : IntProperty(name='Quality', default=90, min=0, max=100, subtype='PERCENTAGE')
@@ -1148,9 +1169,10 @@ class YConvertImageBitDepth(bpy.types.Operator):
         # Create new image based on original image but with different bit depth
         if image.source == 'TILED':
             tilenums = [tile.number for tile in image.tiles]
-            new_image = bpy.data.images.new(image.name,
-                                    width=image.size[0], height=image.size[1], 
-                                    alpha=True, float_buffer= not image.is_float, tiled=True)
+            new_image = bpy.data.images.new(
+                image.name, width=image.size[0], height=image.size[1], 
+                alpha=True, float_buffer=not image.is_float, tiled=True
+            )
 
             # Fill tiles
             color = (0, 0, 0, 0)
@@ -1161,9 +1183,10 @@ class YConvertImageBitDepth(bpy.types.Operator):
             UDIM.initial_pack_udim(new_image, color)
 
         else:
-            new_image = bpy.data.images.new(image.name,
-                                    width=image.size[0], height=image.size[1], 
-                                    alpha=True, float_buffer= not image.is_float)
+            new_image = bpy.data.images.new(
+                image.name, width=image.size[0], height=image.size[1], 
+                alpha=True, float_buffer=not image.is_float
+            )
 
             if image.filepath != '':
                 new_image.filepath = image.filepath

--- a/input_outputs.py
+++ b/input_outputs.py
@@ -199,15 +199,18 @@ def check_start_end_root_ch_nodes(group_tree, specific_channel=None):
             else: lib_name = lib.CHECK_INPUT_NORMAL
 
             start_normal_filter = replace_new_node(
-                    group_tree, channel, 'start_normal_filter', 'ShaderNodeGroup', 'Start Normal Filter', lib_name)
+                group_tree, channel, 'start_normal_filter', 'ShaderNodeGroup', 'Start Normal Filter', lib_name
+            )
 
             if is_normal_height_input_connected(channel):
                 #if channel.enable_smooth_bump:
                 #    start_bump_process = replace_new_node(group_tree, channel, 'start_bump_process', 
                 #                                            'ShaderNodeGroup', 'Start Bump Process', lib.START_FINE_BUMP_PROCESS, hard_replace=True)
                 #else:
-                start_bump_process = replace_new_node(group_tree, channel, 'start_bump_process', 
-                    'ShaderNodeGroup', 'Start Bump Process', lib.START_BUMP_PROCESS, hard_replace=True)
+                start_bump_process = replace_new_node(
+                    group_tree, channel, 'start_bump_process', 
+                    'ShaderNodeGroup', 'Start Bump Process', lib.START_BUMP_PROCESS, hard_replace=True
+                )
             else:
                 remove_node(group_tree, channel, 'start_bump_process')
 
@@ -234,8 +237,10 @@ def check_start_end_root_ch_nodes(group_tree, specific_channel=None):
                         lib_name = lib.MAX_HEIGHT_TWEAK_SMOOTH
                     else: lib_name = lib.MAX_HEIGHT_TWEAK
 
-                    end_max_height_tweak = replace_new_node(group_tree, channel, 'end_max_height_tweak', 
-                                                            'ShaderNodeGroup', 'Max Height Tweak', lib_name, hard_replace=True)
+                    end_max_height_tweak = replace_new_node(
+                        group_tree, channel, 'end_max_height_tweak', 
+                        'ShaderNodeGroup', 'Max Height Tweak', lib_name, hard_replace=True
+                    )
 
                     # Set height tweak prop to node
                     end_max_height_tweak.inputs['Height Tweak'].default_value = channel.height_tweak
@@ -259,7 +264,8 @@ def check_start_end_root_ch_nodes(group_tree, specific_channel=None):
 
                 lib_name = lib.ENGINE_FILTER if is_bl_newer_than(2, 80) else lib.ENGINE_FILTER_LEGACY
                 end_normal_engine_filter = replace_new_node(
-                        group_tree, channel, 'end_normal_engine_filter', 'ShaderNodeGroup', 'End Engine Filter', lib_name)
+                    group_tree, channel, 'end_normal_engine_filter', 'ShaderNodeGroup', 'End Engine Filter', lib_name
+                )
                 for inp in end_normal_engine_filter.inputs:
                     inp.default_value = (0.5, 0.5, 1.0, 1.0)
             else:
@@ -287,8 +293,10 @@ def check_start_end_root_ch_nodes(group_tree, specific_channel=None):
 
             if process_lib_name != '':
 
-                end_linear = replace_new_node(group_tree, channel, 'end_linear', 'ShaderNodeGroup', 'Bump Process',
-                        process_lib_name, hard_replace=True)
+                end_linear = replace_new_node(
+                    group_tree, channel, 'end_linear', 'ShaderNodeGroup', 'Bump Process',
+                    process_lib_name, hard_replace=True
+                )
 
                 # Smooth normal tweak
                 if channel.enable_smooth_bump and channel.enable_smooth_normal_tweak:
@@ -330,15 +338,21 @@ def check_all_channel_ios(yp, reconnect=True, specific_layer=None, remove_props=
     for ch in yp.channels:
 
         if ch.type == 'VALUE':
-            create_input(group_tree, ch.name, channel_socket_input_bl_idnames[ch.type], 
-                    valid_inputs, input_index, min_value = 0.0, max_value = 1.0)
+            create_input(
+                group_tree, ch.name, channel_socket_input_bl_idnames[ch.type], 
+                valid_inputs, input_index, min_value=0.0, max_value=1.0
+            )
         elif ch.type == 'RGB':
-            create_input(group_tree, ch.name, channel_socket_input_bl_idnames[ch.type], 
-                    valid_inputs, input_index, default_value=(1,1,1,1))
+            create_input(
+                group_tree, ch.name, channel_socket_input_bl_idnames[ch.type], 
+                valid_inputs, input_index, default_value=(1, 1, 1, 1)
+            )
         elif ch.type == 'NORMAL':
             # Use 999 as normal z value so it will fallback to use geometry normal at checking process
-            create_input(group_tree, ch.name, channel_socket_input_bl_idnames[ch.type], 
-                    valid_inputs, input_index, default_value=(999,999,999), hide_value=True, node=yp_node)
+            create_input(
+                group_tree, ch.name, channel_socket_input_bl_idnames[ch.type], 
+                valid_inputs, input_index, default_value=(999, 999, 999), hide_value=True, node=yp_node
+            )
 
         create_output(group_tree, ch.name, channel_socket_output_bl_idnames[ch.type], 
                 valid_outputs, output_index)
@@ -354,8 +368,10 @@ def check_all_channel_ios(yp, reconnect=True, specific_layer=None, remove_props=
 
             name = ch.name + io_suffix['ALPHA']
 
-            create_input(group_tree, name, 'NodeSocketFloatFactor', valid_inputs, input_index, 
-                    min_value = 0.0, max_value = 1.0, default_value = 0.0)
+            create_input(
+                group_tree, name, 'NodeSocketFloatFactor', valid_inputs, input_index, 
+                min_value=0.0, max_value=1.0, default_value=0.0
+            )
 
             create_output(group_tree, name, 'NodeSocketFloat', valid_outputs, output_index)
 
@@ -383,8 +399,10 @@ def check_all_channel_ios(yp, reconnect=True, specific_layer=None, remove_props=
             name = ch.name + io_suffix['HEIGHT']
 
             height_default_value = 0.0
-            create_input(group_tree, name, 'NodeSocketFloatFactor', valid_inputs, input_index, 
-                    min_value = 0.0, max_value = 1.0, default_value = height_default_value, hide_value=True)
+            create_input(
+                group_tree, name, 'NodeSocketFloatFactor', valid_inputs, input_index, 
+                min_value=0.0, max_value=1.0, default_value=height_default_value, hide_value=True
+            )
             if group_node.node_tree == group_tree:
                 group_node.inputs[name].default_value = height_default_value
             input_index += 1
@@ -406,7 +424,7 @@ def check_all_channel_ios(yp, reconnect=True, specific_layer=None, remove_props=
 
             name = ch.name + io_suffix['VDISP']
 
-            create_input(group_tree, name, 'NodeSocketVector', valid_inputs, input_index, default_value=(0,0,0), hide_value=True)
+            create_input(group_tree, name, 'NodeSocketVector', valid_inputs, input_index, default_value=(0, 0, 0), hide_value=True)
             input_index += 1
 
             create_output(group_tree, name, 'NodeSocketVector', valid_outputs, output_index)
@@ -758,10 +776,12 @@ def create_prop_input(entity, prop_name, valid_inputs, input_index, dirty):
     tree = layer_node.node_tree
     input_name = get_entity_input_name(entity, prop_name)
 
-    inp_dirty = create_input(tree, input_name, socket_type, 
-            valid_inputs, input_index, False,
-            min_value=rna.soft_min, max_value=rna.soft_max, default_value=default_value, 
-            description=rna.description)
+    inp_dirty = create_input(
+        tree, input_name, socket_type, 
+        valid_inputs, input_index, False,
+        min_value=rna.soft_min, max_value=rna.soft_max, default_value=default_value, 
+        description=rna.description
+    )
 
     # Set default value
     if inp_dirty:
@@ -1109,16 +1129,20 @@ def check_layer_tree_ios(layer, tree=None, remove_props=False, hard_reset=False)
             if root_ch.type != 'NORMAL' or (layer.type == 'GROUP' and is_layer_using_normal_map(layer, root_ch)):
 
                 name = root_ch.name + io_suffix[layer.type]
-                dirty = create_input(tree, name, channel_socket_input_bl_idnames[root_ch.type],
-                        valid_inputs, input_index, dirty)
+                dirty = create_input(
+                    tree, name, channel_socket_input_bl_idnames[root_ch.type],
+                    valid_inputs, input_index, dirty
+                )
                 input_index += 1
 
                 # Alpha Input
                 if root_ch.enable_alpha or layer.type == 'GROUP':
 
                     name = root_ch.name + io_suffix['ALPHA'] + io_suffix[layer.type]
-                    dirty = create_input(tree, name, 'NodeSocketFloatFactor',
-                            valid_inputs, input_index, dirty)
+                    dirty = create_input(
+                        tree, name, 'NodeSocketFloatFactor',
+                        valid_inputs, input_index, dirty
+                    )
                     input_index += 1
 
             # Displacement Input
@@ -1139,8 +1163,7 @@ def check_layer_tree_ios(layer, tree=None, remove_props=False, hard_reset=False)
                         input_index += 1
 
                 name = root_ch.name + io_suffix['HEIGHT'] + io_suffix['ALPHA'] + io_suffix['GROUP']
-                dirty = create_input(tree, name, 'NodeSocketFloat',
-                        valid_inputs, input_index, dirty)
+                dirty = create_input(tree, name, 'NodeSocketFloat', valid_inputs, input_index, dirty)
                 input_index += 1
 
                 if root_ch.enable_smooth_bump:

--- a/lib.py
+++ b/lib.py
@@ -224,16 +224,16 @@ GLTF_SETTINGS = 'glTF Settings'
 BL278_BSDF = 'bsdf278'
 
 channel_custom_icon_dict = {
-        'RGB' : 'rgb_channel',
-        'VALUE' : 'value_channel',
-        'NORMAL' : 'vector_channel',
-        }
+    'RGB' : 'rgb_channel',
+    'VALUE' : 'value_channel',
+    'NORMAL' : 'vector_channel',
+}
 
 channel_icon_dict = {
-        'RGB' : 'KEYTYPE_KEYFRAME_VEC',
-        'VALUE' : 'HANDLETYPE_FREE_VEC',
-        'NORMAL' : 'KEYTYPE_BREAKDOWN_VEC',
-        }
+    'RGB' : 'KEYTYPE_KEYFRAME_VEC',
+    'VALUE' : 'HANDLETYPE_FREE_VEC',
+    'NORMAL' : 'KEYTYPE_BREAKDOWN_VEC',
+}
 
 def get_icon_folder():
     if not is_bl_newer_than(2, 80):

--- a/modifier_common.py
+++ b/modifier_common.py
@@ -302,7 +302,7 @@ def check_modifier_nodes(m, tree, ref_tree=None):
                 rgb2i.inputs['RGB To Intensity Color'].default_value = m.rgb2i_col
                 if non_color:
                     rgb2i.inputs['Gamma'].default_value = 1.0
-                else: rgb2i.inputs['Gamma'].default_value = 1.0/GAMMA
+                else: rgb2i.inputs['Gamma'].default_value = 1.0 / GAMMA
 
                 load_rgb2i_anim_props(tree, m)
 
@@ -347,7 +347,7 @@ def check_modifier_nodes(m, tree, ref_tree=None):
 
                 if non_color:
                     oc.inputs['Gamma'].default_value = 1.0
-                else: oc.inputs['Gamma'].default_value = 1.0/GAMMA
+                else: oc.inputs['Gamma'].default_value = 1.0 / GAMMA
 
     elif m.type == 'COLOR_RAMP':
 
@@ -430,11 +430,11 @@ def check_modifier_nodes(m, tree, ref_tree=None):
                 remove_node(tree, m, 'color_ramp_linear')
             else: 
                 color_ramp_linear_start.inputs[1].default_value = GAMMA
-                color_ramp_linear.inputs[1].default_value = 1.0/GAMMA
+                color_ramp_linear.inputs[1].default_value = 1.0 / GAMMA
 
             if ramp_dirty:
                 # Set default color if ramp just created
-                color_ramp.color_ramp.elements[0].color = (0,0,0,0) 
+                color_ramp.color_ramp.elements[0].color = (0, 0, 0, 0) 
 
     elif m.type == 'RGB_CURVE':
 

--- a/node_arrangements.py
+++ b/node_arrangements.py
@@ -5,29 +5,29 @@ NO_MODIFIER_Y_OFFSET = 200
 FINE_BUMP_Y_OFFSET = 300
 
 default_y_offsets = {
-        'RGB' : 165,
-        'VALUE' : 220,
-        'NORMAL' : 155,
-        }
+    'RGB' : 165,
+    'VALUE' : 220,
+    'NORMAL' : 155,
+}
 
 mod_y_offsets = {
-        'INVERT' : 330,
-        'RGB_TO_INTENSITY' : 280,
-        'INTENSITY_TO_RGB' : 280,
-        'OVERRIDE_COLOR' : 280,
-        'COLOR_RAMP' : 315,
-        'RGB_CURVE' : 390,
-        'HUE_SATURATION' : 265,
-        'BRIGHT_CONTRAST' : 220,
-        'MULTIPLIER' :  350,
-        'MATH' : 350
-        }
+    'INVERT' : 330,
+    'RGB_TO_INTENSITY' : 280,
+    'INTENSITY_TO_RGB' : 280,
+    'OVERRIDE_COLOR' : 280,
+    'COLOR_RAMP' : 315,
+    'RGB_CURVE' : 390,
+    'HUE_SATURATION' : 265,
+    'BRIGHT_CONTRAST' : 220,
+    'MULTIPLIER' :  350,
+    'MATH' : 350
+}
 
 value_mod_y_offsets = {
-        'INVERT' : 270,
-        'MULTIPLIER' :  270,
-        'MATH' : 270
-        }
+    'INVERT' : 270,
+    'MULTIPLIER' :  270,
+    'MATH' : 270
+}
 
 def get_mod_y_offsets(mod, is_value=False):
     if is_value and mod.type in value_mod_y_offsets:
@@ -481,7 +481,7 @@ def rearrange_source_tree_nodes(layer):
     else:
         if check_set_node_loc(source_tree, layer.mod_group, loc, True):
             mod_group = source_tree.nodes.get(layer.mod_group)
-            arrange_modifier_nodes(mod_group.node_tree, layer, loc=Vector((0,0)))
+            arrange_modifier_nodes(mod_group.node_tree, layer, loc=Vector((0, 0)))
             loc.y -= 40
         if check_set_node_loc(source_tree, layer.mod_group_1, loc, True):
             loc.y += 40
@@ -952,12 +952,14 @@ def rearrange_layer_nodes(layer, tree=None):
         # Modifier loop
         if ch.mod_group != '':
             mod_group = nodes.get(ch.mod_group)
-            arrange_modifier_nodes(mod_group.node_tree, ch, Vector((0,0)))
+            arrange_modifier_nodes(mod_group.node_tree, ch, Vector((0, 0)))
             check_set_node_loc(tree, ch.mod_group, loc, hide=True)
             loc.y -= 40
         else:
-            loc, mod_offset_y = arrange_modifier_nodes(tree, ch, loc, 
-                    is_value = root_ch.type == 'VALUE', return_y_offset = True)
+            loc, mod_offset_y = arrange_modifier_nodes(
+                tree, ch, loc, is_value=root_ch.type == 'VALUE',
+                return_y_offset = True
+            )
 
             if offset_y < mod_offset_y:
                 offset_y = mod_offset_y
@@ -999,8 +1001,10 @@ def rearrange_layer_nodes(layer, tree=None):
                 loc.x = start_x
                 loc.y -= offset_y
 
-            loc, mod_offset_y = arrange_modifier_nodes(tree, ch, loc, 
-                    is_value = root_ch.type == 'VALUE', return_y_offset = True, use_modifier_1=True)
+            loc, mod_offset_y = arrange_modifier_nodes(
+                tree, ch, loc, is_value=root_ch.type == 'VALUE',
+                return_y_offset=True, use_modifier_1=True
+            )
 
             offset_y = mod_offset_y
 
@@ -1020,7 +1024,7 @@ def rearrange_layer_nodes(layer, tree=None):
 
         # If next channel had modifier
         if i+1 < len(layer.channels):
-            next_ch = layer.channels[i+1]
+            next_ch = layer.channels[i + 1]
             if len(next_ch.modifiers) > 0 and next_ch.mod_group == '':
                 loc.y -= 35
 
@@ -1465,7 +1469,7 @@ def rearrange_layer_nodes(layer, tree=None):
                 (ch.enable_transition_ramp and not flip_bump and ch.transition_ramp_intensity_unlink 
                 and ch.transition_ramp_blend_type == 'MIX') or
                 (layer.parent_idx != -1 and layer.type == 'BACKGROUND' and ch.transition_ramp_blend_type == 'MIX')
-                ):
+            ):
             if check_set_node_loc(tree, ch.tr_ramp, loc):
                 loc.x += 200
                 #y_offset += 60
@@ -1921,8 +1925,11 @@ def rearrange_yp_nodes(group_tree):
 
         loc.x = ori_x
 
-        loc, offset_y = arrange_modifier_nodes(group_tree, channel, loc, 
-                is_value = channel.type == 'VALUE', return_y_offset = True)
+        loc, offset_y = arrange_modifier_nodes(
+            group_tree, channel, loc, 
+            is_value = channel.type == 'VALUE',
+            return_y_offset = True
+        )
 
         if loc.x > farthest_x: farthest_x = loc.x
         loc.y -= offset_y

--- a/node_connections.py
+++ b/node_connections.py
@@ -318,34 +318,25 @@ def reconnect_relief_mapping_nodes(yp, node):
 
     loop = node.node_tree.nodes.get('_linear_search')
     if loop:
-        loop_start = loop.node_tree.nodes.get(TREE_START)
-        loop_end = loop.node_tree.nodes.get(TREE_END)
+        tree = loop.node_tree
+        loop_start = tree.nodes.get(TREE_START)
+        loop_end = tree.nodes.get(TREE_END)
         prev_it = None
 
         for i in range (parallax_ch.parallax_num_of_linear_samples):
-            it = loop.node_tree.nodes.get('_iterate_' + str(i))
+            it = tree.nodes.get('_iterate_' + str(i))
             if not prev_it:
-                create_link(loop.node_tree, 
-                        loop_start.outputs['t'], it.inputs['t'])
+                create_link(tree, loop_start.outputs['t'], it.inputs['t'])
             else:
-                create_link(loop.node_tree, 
-                        prev_it.outputs['t'], it.inputs['t'])
+                create_link(tree, prev_it.outputs['t'], it.inputs['t'])
 
-            create_link(loop.node_tree,
-                    loop_start.outputs['tx'], it.inputs['tx'])
+            create_link(tree, loop_start.outputs['tx'], it.inputs['tx'])
+            create_link(tree, loop_start.outputs['v'], it.inputs['v'])
+            create_link(tree, loop_start.outputs['dataz'], it.inputs['dataz'])
+            create_link(tree, loop_start.outputs['size'], it.inputs['size'])
 
-            create_link(loop.node_tree,
-                    loop_start.outputs['v'], it.inputs['v'])
-
-            create_link(loop.node_tree,
-                    loop_start.outputs['dataz'], it.inputs['dataz'])
-
-            create_link(loop.node_tree,
-                    loop_start.outputs['size'], it.inputs['size'])
-
-            if i == parallax_ch.parallax_num_of_linear_samples-1:
-                create_link(loop.node_tree, 
-                        it.outputs['t'], loop_end.inputs['t'])
+            if i == parallax_ch.parallax_num_of_linear_samples - 1:
+                create_link(tree, it.outputs['t'], loop_end.inputs['t'])
 
             prev_it = it
 
@@ -354,34 +345,23 @@ def reconnect_relief_mapping_nodes(yp, node):
         loop_start = loop.node_tree.nodes.get(TREE_START)
         loop_end = loop.node_tree.nodes.get(TREE_END)
         prev_it = None
+        tree = loop.node_tree
 
         for i in range (parallax_ch.parallax_num_of_binary_samples):
-            it = loop.node_tree.nodes.get('_iterate_' + str(i))
+            it = tree.nodes.get('_iterate_' + str(i))
             if not prev_it:
-                create_link(loop.node_tree, 
-                        loop_start.outputs['t'], it.inputs['t'])
-
-                create_link(loop.node_tree, 
-                        loop_start.outputs['size'], it.inputs['size'])
+                create_link(tree, loop_start.outputs['t'], it.inputs['t'])
+                create_link(tree, loop_start.outputs['size'], it.inputs['size'])
             else:
-                create_link(loop.node_tree, 
-                        prev_it.outputs['t'], it.inputs['t'])
+                create_link(tree, prev_it.outputs['t'], it.inputs['t'])
+                create_link(tree, prev_it.outputs['size'], it.inputs['size'])
 
-                create_link(loop.node_tree, 
-                        prev_it.outputs['size'], it.inputs['size'])
+            create_link(tree, loop_start.outputs['tx'], it.inputs['tx'])
+            create_link(tree, loop_start.outputs['v'], it.inputs['v'])
+            create_link(tree, loop_start.outputs['dataz'], it.inputs['dataz'])
 
-            create_link(loop.node_tree,
-                    loop_start.outputs['tx'], it.inputs['tx'])
-
-            create_link(loop.node_tree,
-                    loop_start.outputs['v'], it.inputs['v'])
-
-            create_link(loop.node_tree,
-                    loop_start.outputs['dataz'], it.inputs['dataz'])
-
-            if i == parallax_ch.parallax_num_of_binary_samples-1:
-                create_link(loop.node_tree, 
-                        it.outputs['t'], loop_end.inputs['t'])
+            if i == parallax_ch.parallax_num_of_binary_samples - 1:
+                create_link(tree, it.outputs['t'], loop_end.inputs['t'])
 
             prev_it = it
 
@@ -557,37 +537,26 @@ def reconnect_baked_parallax_layer_nodes(yp, node):
         loop_start = loop.node_tree.nodes.get(TREE_START)
         loop_end = loop.node_tree.nodes.get(TREE_END)
         prev_it = None
+        tree = loop.node_tree
 
         for i in range (num_of_layers):
-            it = loop.node_tree.nodes.get('_iterate_' + str(i))
+            it = tree.nodes.get('_iterate_' + str(i))
             if not prev_it:
-                create_link(loop.node_tree, 
-                        loop_start.outputs['cur_uv'], it.inputs['cur_uv'])
-                create_link(loop.node_tree, 
-                        loop_start.outputs['cur_layer_depth'], it.inputs['cur_layer_depth'])
-                create_link(loop.node_tree, 
-                        loop_start.outputs['depth_from_tex'], it.inputs['depth_from_tex'])
+                create_link(tree, loop_start.outputs['cur_uv'], it.inputs['cur_uv'])
+                create_link(tree, loop_start.outputs['cur_layer_depth'], it.inputs['cur_layer_depth'])
+                create_link(tree, loop_start.outputs['depth_from_tex'], it.inputs['depth_from_tex'])
             else:
-                create_link(loop.node_tree, 
-                        prev_it.outputs['cur_uv'], it.inputs['cur_uv'])
-                create_link(loop.node_tree, 
-                        prev_it.outputs['cur_layer_depth'], it.inputs['cur_layer_depth'])
-                create_link(loop.node_tree, 
-                        prev_it.outputs['depth_from_tex'], it.inputs['depth_from_tex'])
+                create_link(tree, prev_it.outputs['cur_uv'], it.inputs['cur_uv'])
+                create_link(tree, prev_it.outputs['cur_layer_depth'], it.inputs['cur_layer_depth'])
+                create_link(tree, prev_it.outputs['depth_from_tex'], it.inputs['depth_from_tex'])
 
-            create_link(loop.node_tree,
-                    loop_start.outputs['delta_uv'], it.inputs['delta_uv'])
-
-            create_link(loop.node_tree,
-                    loop_start.outputs['layer_depth'], it.inputs['layer_depth'])
+            create_link(tree, loop_start.outputs['delta_uv'], it.inputs['delta_uv'])
+            create_link(tree, loop_start.outputs['layer_depth'], it.inputs['layer_depth'])
 
             if i == num_of_layers-1:
-                create_link(loop.node_tree, 
-                        it.outputs['cur_uv'], loop_end.inputs['cur_uv'])
-                create_link(loop.node_tree, 
-                        it.outputs['cur_layer_depth'], loop_end.inputs['cur_layer_depth'])
-                create_link(loop.node_tree, 
-                        it.outputs['depth_from_tex'], loop_end.inputs['depth_from_tex'])
+                create_link(tree, it.outputs['cur_uv'], loop_end.inputs['cur_uv'])
+                create_link(tree, it.outputs['cur_layer_depth'], loop_end.inputs['cur_layer_depth'])
+                create_link(tree, it.outputs['depth_from_tex'], loop_end.inputs['depth_from_tex'])
 
             prev_it = it
 
@@ -675,10 +644,16 @@ def reconnect_parallax_process_nodes(group_tree, parallax, baked=False, uv_name=
             create_link(depth_source_0.node_tree, height_map.outputs[0], depth_end.inputs[0])
 
         # Inside iteration
-        create_link(iterate.node_tree, 
-                iterate_start.outputs[uv.name + START_UV], iterate_depth.inputs[uv.name + START_UV])
-        create_link(iterate.node_tree, 
-                iterate_start.outputs[uv.name + DELTA_UV], iterate_depth.inputs[uv.name + DELTA_UV])
+        create_link(
+            iterate.node_tree, 
+            iterate_start.outputs[uv.name + START_UV],
+            iterate_depth.inputs[uv.name + START_UV]
+        )
+        create_link(
+            iterate.node_tree, 
+            iterate_start.outputs[uv.name + DELTA_UV],
+            iterate_depth.inputs[uv.name + DELTA_UV]
+        )
 
         if baked: parallax_current_uv_mix = iterate.node_tree.nodes.get(uv.baked_parallax_current_uv_mix)
         else: parallax_current_uv_mix = iterate.node_tree.nodes.get(uv.parallax_current_uv_mix)
@@ -686,13 +661,22 @@ def reconnect_parallax_process_nodes(group_tree, parallax, baked=False, uv_name=
         mixcol0, mixcol1, mixout = get_mix_color_indices(parallax_current_uv_mix)
 
         create_link(iterate.node_tree, iterate_branch.outputs[0], parallax_current_uv_mix.inputs[0])
-        create_link(iterate.node_tree, 
-                iterate_depth.outputs[uv.name + CURRENT_UV], parallax_current_uv_mix.inputs[mixcol0])
-        create_link(iterate.node_tree, 
-                iterate_start.outputs[uv.name + CURRENT_UV], parallax_current_uv_mix.inputs[mixcol1])
 
-        create_link(iterate.node_tree, 
-                parallax_current_uv_mix.outputs[mixout], iterate_end.inputs[uv.name + CURRENT_UV])
+        create_link(
+            iterate.node_tree, 
+            iterate_depth.outputs[uv.name + CURRENT_UV],
+            parallax_current_uv_mix.inputs[mixcol0]
+        )
+        create_link(
+            iterate.node_tree, 
+            iterate_start.outputs[uv.name + CURRENT_UV],
+            parallax_current_uv_mix.inputs[mixcol1]
+        )
+        create_link(
+            iterate.node_tree, 
+            parallax_current_uv_mix.outputs[mixout],
+            iterate_end.inputs[uv.name + CURRENT_UV]
+        )
 
     if not baked:
         for tc in texcoord_lists:
@@ -736,22 +720,37 @@ def reconnect_parallax_process_nodes(group_tree, parallax, baked=False, uv_name=
             create_link(depth_source_0.node_tree, current_uv.outputs[0], depth_end.inputs[base_name + CURRENT_UV])
 
             # Inside iteration
-            create_link(iterate.node_tree, 
-                    iterate_start.outputs[base_name + START_UV], iterate_depth.inputs[base_name + START_UV])
-            create_link(iterate.node_tree, 
-                    iterate_start.outputs[base_name + DELTA_UV], iterate_depth.inputs[base_name + DELTA_UV])
+            create_link(
+                iterate.node_tree, 
+                iterate_start.outputs[base_name + START_UV],
+                iterate_depth.inputs[base_name + START_UV]
+            )
+            create_link(
+                iterate.node_tree, 
+                iterate_start.outputs[base_name + DELTA_UV],
+                iterate_depth.inputs[base_name + DELTA_UV]
+            )
 
             parallax_current_uv_mix = iterate.node_tree.nodes.get(PARALLAX_CURRENT_MIX_PREFIX + base_name)
             mixcol0, mixcol1, mixout = get_mix_color_indices(parallax_current_uv_mix)
 
             create_link(iterate.node_tree, iterate_branch.outputs[0], parallax_current_uv_mix.inputs[0])
-            create_link(iterate.node_tree, 
-                    iterate_depth.outputs[base_name + CURRENT_UV], parallax_current_uv_mix.inputs[mixcol0])
-            create_link(iterate.node_tree, 
-                    iterate_start.outputs[base_name + CURRENT_UV], parallax_current_uv_mix.inputs[mixcol1])
+            create_link(
+                iterate.node_tree, 
+                iterate_depth.outputs[base_name + CURRENT_UV],
+                parallax_current_uv_mix.inputs[mixcol0]
+            )
+            create_link(
+                iterate.node_tree,
+                iterate_start.outputs[base_name + CURRENT_UV],
+                parallax_current_uv_mix.inputs[mixcol1]
+            )
 
-            create_link(iterate.node_tree, 
-                    parallax_current_uv_mix.outputs[mixout], iterate_end.inputs[base_name + CURRENT_UV])
+            create_link(
+                iterate.node_tree, 
+                parallax_current_uv_mix.outputs[mixout],
+                iterate_end.inputs[base_name + CURRENT_UV]
+            )
 
     #reconnect_parallax_layer_nodes(group_tree, parallax, uv_name)
     #reconnect_parallax_layer_nodes_(group_tree, parallax, uv_name)
@@ -1340,11 +1339,20 @@ def reconnect_yp_nodes(tree, merged_layer_ids = []):
                 outputs = create_link(tree, height_w, node.inputs[io_height_w_name])
                 if io_height_w_name in outputs: height_w = outputs[io_height_w_name]
 
-            if height_alpha and io_height_alpha_name in node.inputs: height_alpha = create_link(tree, height_alpha, node.inputs[io_height_alpha_name])[io_height_alpha_name]
-            if height_n_alpha and io_height_n_alpha_name in node.inputs: height_n_alpha = create_link(tree, height_n_alpha, node.inputs[io_height_n_alpha_name])[io_height_n_alpha_name]
-            if height_s_alpha and io_height_s_alpha_name in node.inputs: height_s_alpha = create_link(tree, height_s_alpha, node.inputs[io_height_s_alpha_name])[io_height_s_alpha_name]
-            if height_e_alpha and io_height_e_alpha_name in node.inputs: height_e_alpha = create_link(tree, height_e_alpha, node.inputs[io_height_e_alpha_name])[io_height_e_alpha_name]
-            if height_w_alpha and io_height_w_alpha_name in node.inputs: height_w_alpha = create_link(tree, height_w_alpha, node.inputs[io_height_w_alpha_name])[io_height_w_alpha_name]
+            if height_alpha and io_height_alpha_name in node.inputs:
+                height_alpha = create_link(tree, height_alpha, node.inputs[io_height_alpha_name])[io_height_alpha_name]
+
+            if height_n_alpha and io_height_n_alpha_name in node.inputs:
+                height_n_alpha = create_link(tree, height_n_alpha, node.inputs[io_height_n_alpha_name])[io_height_n_alpha_name]
+
+            if height_s_alpha and io_height_s_alpha_name in node.inputs:
+                height_s_alpha = create_link(tree, height_s_alpha, node.inputs[io_height_s_alpha_name])[io_height_s_alpha_name]
+
+            if height_e_alpha and io_height_e_alpha_name in node.inputs:
+                height_e_alpha = create_link(tree, height_e_alpha, node.inputs[io_height_e_alpha_name])[io_height_e_alpha_name]
+
+            if height_w_alpha and io_height_w_alpha_name in node.inputs:
+                height_w_alpha = create_link(tree, height_w_alpha, node.inputs[io_height_w_alpha_name])[io_height_w_alpha_name]
 
             if max_height and io_max_height_name in node.inputs:
                 outps = create_link(tree, max_height, node.inputs[io_max_height_name])
@@ -1387,11 +1395,20 @@ def reconnect_yp_nodes(tree, merged_layer_ids = []):
                     create_link(tree, max_height, end_linear.inputs['Max Height'])
 
                 if end_max_height_tweak:
-                    if height and 'Height' in end_max_height_tweak.inputs: height = create_link(tree, height, end_max_height_tweak.inputs['Height'])['Height']
-                    if height_n and 'Height N' in end_max_height_tweak.inputs: height_n = create_link(tree, height_n, end_max_height_tweak.inputs['Height N'])['Height N']
-                    if height_s and 'Height S' in end_max_height_tweak.inputs: height_s = create_link(tree, height_s, end_max_height_tweak.inputs['Height S'])['Height S']
-                    if height_e and 'Height E' in end_max_height_tweak.inputs: height_e = create_link(tree, height_e, end_max_height_tweak.inputs['Height E'])['Height E']
-                    if height_w and 'Height W' in end_max_height_tweak.inputs: height_w = create_link(tree, height_w, end_max_height_tweak.inputs['Height W'])['Height W']
+                    if height and 'Height' in end_max_height_tweak.inputs:
+                        height = create_link(tree, height, end_max_height_tweak.inputs['Height'])['Height']
+
+                    if height_n and 'Height N' in end_max_height_tweak.inputs:
+                        height_n = create_link(tree, height_n, end_max_height_tweak.inputs['Height N'])['Height N']
+
+                    if height_s and 'Height S' in end_max_height_tweak.inputs:
+                        height_s = create_link(tree, height_s, end_max_height_tweak.inputs['Height S'])['Height S']
+
+                    if height_e and 'Height E' in end_max_height_tweak.inputs:
+                        height_e = create_link(tree, height_e, end_max_height_tweak.inputs['Height E'])['Height E']
+
+                    if height_w and 'Height W' in end_max_height_tweak.inputs:
+                        height_w = create_link(tree, height_w, end_max_height_tweak.inputs['Height W'])['Height W']
 
                 if height and 'Height' in end_linear.inputs: height = create_link(tree, height, end_linear.inputs['Height'])[1]
                 if height_n and 'Height N' in end_linear.inputs: create_link(tree, height_n, end_linear.inputs['Height N'])
@@ -1900,12 +1917,14 @@ def reconnect_layer_nodes(layer, ch_idx=-1, merge_mask=False):
             pass
         else:
             start_rgb, start_alpha = reconnect_all_modifier_nodes(
-                    tree, layer, start_rgb, start_alpha, mod_group)
+                tree, layer, start_rgb, start_alpha, mod_group
+            )
 
         if layer.type not in {'IMAGE', 'VCOL', 'BACKGROUND', 'COLOR', 'GROUP', 'HEMI', 'OBJECT_INDEX', 'MUSGRAVE'}:
             mod_group_1 = nodes.get(layer.mod_group_1)
             start_rgb_1, start_alpha_1 = reconnect_all_modifier_nodes(
-                    tree, layer, source.outputs[1], get_essential_node(tree, ONE_VALUE)[0], mod_group_1)
+                tree, layer, source.outputs[1], get_essential_node(tree, ONE_VALUE)[0], mod_group_1
+            )
 
     # UV neighbor vertex color
     if layer.type in {'VCOL', 'GROUP', 'HEMI', 'OBJECT_INDEX'} and uv_neighbor:
@@ -3221,11 +3240,20 @@ def reconnect_layer_nodes(layer, ch_idx=-1, merge_mask=False):
                         if prev_height_w: create_link(tree, prev_height_w, height_blend.inputs['Prev Height W'])
 
                     if height_proc: 
-                        if 'Height' in height_proc.outputs and 'Height' in height_blend.inputs: create_link(tree, height_proc.outputs['Height'], height_blend.inputs['Height'])
-                        if 'Height N' in height_proc.outputs and 'Height N' in height_blend.inputs: create_link(tree, height_proc.outputs['Height N'], height_blend.inputs['Height N'])
-                        if 'Height S' in height_proc.outputs and 'Height S' in height_blend.inputs: create_link(tree, height_proc.outputs['Height S'], height_blend.inputs['Height S'])
-                        if 'Height E' in height_proc.outputs and 'Height E' in height_blend.inputs: create_link(tree, height_proc.outputs['Height E'], height_blend.inputs['Height E'])
-                        if 'Height W' in height_proc.outputs and 'Height W' in height_blend.inputs: create_link(tree, height_proc.outputs['Height W'], height_blend.inputs['Height W'])
+                        if 'Height' in height_proc.outputs and 'Height' in height_blend.inputs:
+                            create_link(tree, height_proc.outputs['Height'], height_blend.inputs['Height'])
+
+                        if 'Height N' in height_proc.outputs and 'Height N' in height_blend.inputs:
+                            create_link(tree, height_proc.outputs['Height N'], height_blend.inputs['Height N'])
+
+                        if 'Height S' in height_proc.outputs and 'Height S' in height_blend.inputs:
+                            create_link(tree, height_proc.outputs['Height S'], height_blend.inputs['Height S'])
+
+                        if 'Height E' in height_proc.outputs and 'Height E' in height_blend.inputs:
+                            create_link(tree, height_proc.outputs['Height E'], height_blend.inputs['Height E'])
+
+                        if 'Height W' in height_proc.outputs and 'Height W' in height_blend.inputs:
+                            create_link(tree, height_proc.outputs['Height W'], height_blend.inputs['Height W'])
 
                     create_link(tree, height_alpha, height_blend.inputs['Alpha'])
 
@@ -3253,10 +3281,17 @@ def reconnect_layer_nodes(layer, ch_idx=-1, merge_mask=False):
                         #if 'Height EW' in normal_proc.inputs:
                         #    create_link(tree, height_blend.outputs['Height EW'], normal_proc.inputs['Height EW'])
 
-                        if 'Height N' in normal_proc.inputs and 'Height N' in height_blend.outputs: create_link(tree, height_blend.outputs['Height N'], normal_proc.inputs['Height N'])
-                        if 'Height S' in normal_proc.inputs and 'Height S' in height_blend.outputs: create_link(tree, height_blend.outputs['Height S'], normal_proc.inputs['Height S'])
-                        if 'Height E' in normal_proc.inputs and 'Height E' in height_blend.outputs: create_link(tree, height_blend.outputs['Height E'], normal_proc.inputs['Height E'])
-                        if 'Height W' in normal_proc.inputs and 'Height W' in height_blend.outputs: create_link(tree, height_blend.outputs['Height W'], normal_proc.inputs['Height W'])
+                        if 'Height N' in normal_proc.inputs and 'Height N' in height_blend.outputs:
+                            create_link(tree, height_blend.outputs['Height N'], normal_proc.inputs['Height N'])
+
+                        if 'Height S' in normal_proc.inputs and 'Height S' in height_blend.outputs:
+                            create_link(tree, height_blend.outputs['Height S'], normal_proc.inputs['Height S'])
+
+                        if 'Height E' in normal_proc.inputs and 'Height E' in height_blend.outputs:
+                            create_link(tree, height_blend.outputs['Height E'], normal_proc.inputs['Height E'])
+
+                        if 'Height W' in normal_proc.inputs and 'Height W' in height_blend.outputs:
+                            create_link(tree, height_blend.outputs['Height W'], normal_proc.inputs['Height W'])
 
                 if 'Normal Alpha' in height_blend.outputs:
                     alpha = height_blend.outputs['Normal Alpha']

--- a/preferences.py
+++ b/preferences.py
@@ -17,137 +17,148 @@ class YPaintPreferences(AddonPreferences):
     bl_idname = __package__
 
     default_new_image_size : IntProperty(
-            name = 'Custom Default Image Size',
-            description = 'Default new image size',
-            default = 1024,
-            min=64, max=16384)
+        name = 'Custom Default Image Size',
+        description = 'Default new image size',
+        default=1024, min=64, max=16384
+    )
 
     image_atlas_size : IntProperty(
-            name = 'Image Atlas Size',
-            description = 'Image Atlas Size',
-            default = 8192,
-            min=2048, max=16384)
+        name = 'Image Atlas Size',
+        description = 'Image Atlas Size',
+        default=8192, min=2048, max=16384
+    )
 
     hdr_image_atlas_size : IntProperty(
-            name = 'HDR Image Atlas Size',
-            description = 'HDR Image Atlas Size',
-            default = 4096,
-            min=1024, max=8192)
+        name = 'HDR Image Atlas Size',
+        description = 'HDR Image Atlas Size',
+        default=4096, min=1024, max=8192
+    )
 
     unique_image_atlas_per_yp : BoolProperty(
-            name = 'Use unique Image Atlas per ' + get_addon_title() + ' tree',
-            description = 'Try to use different image atlas per ' + get_addon_title() + ' tree',
-            default = True)
+        name = 'Use unique Image Atlas per ' + get_addon_title() + ' tree',
+        description = 'Try to use different image atlas per ' + get_addon_title() + ' tree',
+        default = True
+    )
 
     developer_mode : BoolProperty(
-            name = 'Developer Mode',
-            description = 'Developer mode will shows several menu intented for developer only',
-            default = False)
+        name = 'Developer Mode',
+        description = 'Developer mode will shows several menu intented for developer only',
+        default = False
+    )
 
     show_experimental : BoolProperty(
-            name = 'Show Experimental Features',
-            description = 'Show unfinished experimental features',
-            default = False)
+        name = 'Show Experimental Features',
+        description = 'Show unfinished experimental features',
+        default = False
+    )
 
     use_image_preview : BoolProperty(
-            name = 'Use Image Preview/Thumbnail',
-            description = 'Use image preview or thumbnail on the layers list',
-            default = False)
+        name = 'Use Image Preview/Thumbnail',
+        description = 'Use image preview or thumbnail on the layers list',
+        default = False
+    )
 
     skip_property_popups : BoolProperty(
-            name = 'Skip Property Popups (Hold Shift to Show)',
-            description = 'Don\'t show property popups unless Shift key is pressed. Will use last invokation properties if skipped',
-            default = False)
+        name = 'Skip Property Popups (Hold Shift to Show)',
+        description = 'Don\'t show property popups unless Shift key is pressed. Will use last invokation properties if skipped',
+        default = False
+    )
 
     icons : EnumProperty(
-            name = 'Icons',
-            description = 'Icon set',
-            items=(('DEFAULT', 'Default', 'Icon set from the current Blender version'),
-                   ('LEGACY', 'Legacy', 'Icon set from the old Blender version')),
-            default='DEFAULT',
-            update=update_icons
-            )
+        name = 'Icons',
+        description = 'Icon set',
+        items = (
+            ('DEFAULT', 'Default', 'Icon set from the current Blender version'),
+            ('LEGACY', 'Legacy', 'Icon set from the old Blender version')
+        ),
+        default = 'DEFAULT',
+        update = update_icons
+    )
 
     make_preview_mode_srgb : BoolProperty(
-            name = 'Make Preview Mode use sRGB',
-            description = 'Make sure preview mode use sRGB color',
-            default = True)
+        name = 'Make Preview Mode use sRGB',
+        description = 'Make sure preview mode use sRGB color',
+        default = True
+    )
 
     parallax_without_baked : BoolProperty(
-            name = 'Parallax Without Use Baked',
-            description = 'Make it possible to use parallax without using baked textures (currently VERY SLOW)',
-            default = False)
+        name = 'Parallax Without Use Baked',
+        description = 'Make it possible to use parallax without using baked textures (currently VERY SLOW)',
+        default = False
+    )
 
     default_bake_device : EnumProperty(
-            name = 'Bake Device',
-            description = 'Default bake device',
-            items = (('DEFAULT', 'Default', 'Use last selected bake device'),
-                     ('CPU', 'CPU', 'Use CPU by default'),
-                     ('GPU', 'GPU Compute', 'Use GPU by default')),
-            default='DEFAULT'
-            )
+        name = 'Bake Device',
+        description = 'Default bake device',
+        items = (
+            ('DEFAULT', 'Default', 'Use last selected bake device'),
+            ('CPU', 'CPU', 'Use CPU by default'),
+            ('GPU', 'GPU Compute', 'Use GPU by default')
+        ),
+        default = 'DEFAULT'
+    )
 
     enable_baked_outside_by_default : BoolProperty(
-            name = 'Enable Baked Outside by default',
-            description = "Enable baked outside by default when creating new "+get_addon_title()+" node.\n(Useful for creating game assets)",
-            default = False
-            )
+        name = 'Enable Baked Outside by default',
+        description = "Enable baked outside by default when creating new " + get_addon_title() + " node.\n(Useful for creating game assets)",
+        default = False
+    )
 
     enable_uniform_uv_scale_by_default : BoolProperty(
-            name = 'Enable Uniform UV Scale by default',
-            description = "Enable uniform UV scale by default in Layer and Mask UVs. This will make all scale axes have the same value",
-            default = False
-            )
+        name = 'Enable Uniform UV Scale by default',
+        description = "Enable uniform UV scale by default in Layer and Mask UVs. This will make all scale axes have the same value",
+        default = False
+    )
 
     enable_auto_udim_detection : BoolProperty(
-            name = 'Enable Auto UDIM Detection',
-            description = "Enable automatic UDIM detection. This will automatically check 'Use UDIM Tiles' checkboxes when UDIM is detected",
-            default = True
-            )
+        name = 'Enable Auto UDIM Detection',
+        description = "Enable automatic UDIM detection. This will automatically check 'Use UDIM Tiles' checkboxes when UDIM is detected",
+        default = True
+    )
     
     # Addon updater preferences.
     auto_check_update : BoolProperty(
-        name="Auto-check for Update",
-        description="If enabled, auto-check for updates using an interval",
-        default=True)
+        name = 'Auto-check for Update',
+        description = 'If enabled, auto-check for updates using an interval',
+        default = True
+    )
     
     updater_interval_months : IntProperty(
-        name='Months',
-        description="Number of months between checking for updates",
-        default=0,
-        min=0)
+        name = 'Months',
+        description = 'Number of months between checking for updates',
+        default=0, min=0
+    )
     
     updater_interval_days : IntProperty(
-        name='Days',
-        description="Number of days between checking for updates",
-        default=1,
-        min=0,
-        max=31)
+        name = 'Days',
+        description = 'Number of days between checking for updates',
+        default=1, min=0, max=31
+    )
     
     updater_interval_hours : IntProperty(
-        name='Hours',
-        description="Number of hours between checking for updates",
-        default=0,
-        min=0,
-        max=23)
+        name = 'Hours',
+        description = 'Number of hours between checking for updates',
+        default=0, min=0, max=23
+    )
     
     updater_interval_minutes : IntProperty(
-        name='Minutes',
-        description="Number of minutes between checking for updates",
-        default=1,
-        min=0,
-        max=59)
+        name = 'Minutes',
+        description = 'Number of minutes between checking for updates',
+        default=1, min=0, max=59
+    )
 
     default_image_resolution : EnumProperty(
         name = 'Default Image Size',
-        items = (('DEFAULT', "Default", 'Use the last selected image size'),
-        ('512', "512", 'Always use a 512x512 image by default'),
-        ('1024', "1024", 'Always use a 1024x1024 image by default'),
-        ('2048', "2048", 'Always use a 2048x2048 image by default'),
-        ('4096', "4096", 'Always use a 4096x4096 image by default'),
-        ('CUSTOM', "Custom Resolution", 'Use a custom resolution by default')),
+        items = (
+            ('DEFAULT', "Default", 'Use the last selected image size'),
+            ('512', "512", 'Always use a 512x512 image by default'),
+            ('1024', "1024", 'Always use a 1024x1024 image by default'),
+            ('2048', "2048", 'Always use a 2048x2048 image by default'),
+            ('4096', "4096", 'Always use a 4096x4096 image by default'),
+            ('CUSTOM', "Custom Resolution", 'Use a custom resolution by default')
+        ),
         default = 'DEFAULT'
-        )
+    )
     
     def draw(self, context):
         if is_bl_newer_than(2, 80):

--- a/subtree.py
+++ b/subtree.py
@@ -100,12 +100,16 @@ def enable_channel_source_tree(layer, root_ch, ch, rearrange = False):
 
     # Create uv neighbor
     if ch.override_type in {'VCOL', 'HEMI'}:
-        uv_neighbor = replace_new_node(layer_tree, ch, 'uv_neighbor', 'ShaderNodeGroup', 'Neighbor UV', 
-                lib.NEIGHBOR_FAKE, hard_replace=True)
+        uv_neighbor = replace_new_node(
+            layer_tree, ch, 'uv_neighbor', 'ShaderNodeGroup', 'Neighbor UV', 
+            lib.NEIGHBOR_FAKE, hard_replace=True
+        )
     #else: 
     elif ch.override_type not in {'DEFAULT'}: 
-        uv_neighbor = replace_new_node(layer_tree, ch, 'uv_neighbor', 'ShaderNodeGroup', 'Neighbor UV', 
-                lib.get_neighbor_uv_tree_name(layer.texcoord_type, entity=layer), hard_replace=True)
+        uv_neighbor = replace_new_node(
+            layer_tree, ch, 'uv_neighbor', 'ShaderNodeGroup', 'Neighbor UV', 
+            lib.get_neighbor_uv_tree_name(layer.texcoord_type, entity=layer), hard_replace=True
+        )
         set_uv_neighbor_resolution(ch, uv_neighbor)
 
     if rearrange:
@@ -181,14 +185,20 @@ def enable_layer_source_tree(layer, rearrange=False):
 
     # Create uv neighbor
     if layer.type in {'VCOL', 'HEMI'}:
-        uv_neighbor = replace_new_node(layer_tree, layer, 'uv_neighbor', 'ShaderNodeGroup', 'Neighbor UV', 
-                lib.NEIGHBOR_FAKE, hard_replace=True)
+        uv_neighbor = replace_new_node(
+            layer_tree, layer, 'uv_neighbor', 'ShaderNodeGroup', 'Neighbor UV', 
+            lib.NEIGHBOR_FAKE, hard_replace=True
+        )
         if layer.type == 'VCOL':
-            uv_neighbor_1 = replace_new_node(layer_tree, layer, 'uv_neighbor_1', 'ShaderNodeGroup', 'Neighbor UV 1', 
-                    lib.NEIGHBOR_FAKE, hard_replace=True)
+            uv_neighbor_1 = replace_new_node(
+                layer_tree, layer, 'uv_neighbor_1', 'ShaderNodeGroup', 'Neighbor UV 1', 
+                lib.NEIGHBOR_FAKE, hard_replace=True
+            )
     elif layer.type not in {'GROUP', 'OBJECT_INDEX', 'BACKFACE'}: 
-        uv_neighbor = replace_new_node(layer_tree, layer, 'uv_neighbor', 'ShaderNodeGroup', 'Neighbor UV', 
-                lib.get_neighbor_uv_tree_name(layer.texcoord_type, entity=layer), hard_replace=True)
+        uv_neighbor = replace_new_node(
+            layer_tree, layer, 'uv_neighbor', 'ShaderNodeGroup', 'Neighbor UV', 
+            lib.get_neighbor_uv_tree_name(layer.texcoord_type, entity=layer), hard_replace=True
+        )
         set_uv_neighbor_resolution(layer, uv_neighbor)
 
     if rearrange:
@@ -329,8 +339,10 @@ def check_layer_bump_process(layer, tree=None):
             lib_name = lib.FINE_BUMP_PROCESS
         else: lib_name = lib.BUMP_PROCESS
 
-        bump_process, dirty = replace_new_node(tree, layer, 'bump_process', 'ShaderNodeGroup', 'Bump Process',
-                lib_name, return_status=True, hard_replace=True)
+        bump_process, dirty = replace_new_node(
+            tree, layer, 'bump_process', 'ShaderNodeGroup', 'Bump Process',
+            lib_name, return_status=True, hard_replace=True
+        )
 
         #update_layer_bump_process_max_height(height_root_ch, layer, tree)
     else:
@@ -366,8 +378,11 @@ def check_mask_uv_neighbor(tree, layer, mask, mask_idx=-1):
         #else: 
         lib_name = lib.get_neighbor_uv_tree_name(mask.texcoord_type, entity=mask)
 
-        uv_neighbor, dirty = replace_new_node(tree, mask, 'uv_neighbor', 
-                'ShaderNodeGroup', 'UV Neighbor', lib_name, return_status=True, hard_replace=True)
+        uv_neighbor, dirty = replace_new_node(
+            tree, mask, 'uv_neighbor', 
+            'ShaderNodeGroup', 'UV Neighbor', lib_name,
+            return_status=True, hard_replace=True
+        )
 
         set_uv_neighbor_resolution(mask, uv_neighbor)
 
@@ -1237,8 +1252,10 @@ def check_parallax_prep_nodes(yp, unused_uvs=[], unused_texcoords=[], baked=Fals
         else:
             parallax_prep = tree.nodes.get(uv.parallax_prep)
             if not parallax_prep:
-                parallax_prep = new_node(tree, uv, 'parallax_prep', 'ShaderNodeGroup', 
-                        uv.name + ' Parallax Preparation')
+                parallax_prep = new_node(
+                    tree, uv, 'parallax_prep', 'ShaderNodeGroup', 
+                    uv.name + ' Parallax Preparation'
+                )
                 parallax_prep.node_tree = get_node_tree_lib(lib.PARALLAX_OCCLUSION_PREP)
 
             #parallax_prep.inputs['depth_scale'].default_value = height_ch.displacement_height_ratio
@@ -1333,10 +1350,11 @@ def check_parallax_node(yp, height_ch, unused_uvs=[], unused_texcoords=[], baked
     parallax = tree.nodes.get(node_name)
     baked_parallax_filter = tree.nodes.get(BAKED_PARALLAX_FILTER)
 
-    if (not is_parallax_enabled(height_ch) or 
+    if (
+            not is_parallax_enabled(height_ch) or 
             (baked and not yp.use_baked) or (not baked and yp.use_baked) or
             (yp.use_baked and height_ch.enable_subdiv_setup and not height_ch.subdiv_adaptive)
-            ):
+        ):
         if parallax:
             clear_parallax_node_data(yp, parallax, baked)
             simple_remove_node(tree, parallax, True)
@@ -1784,7 +1802,9 @@ def check_channel_normal_map_nodes(tree, layer, root_ch, ch, need_reconnect=Fals
         # Bump distance ignorer
         if ch.normal_map_type in {'BUMP_MAP', 'BUMP_NORMAL_MAP'} and not is_bump_distance_relevant(layer, ch):
             bump_distance_ignorer, dirty = check_new_node(
-                    tree, ch, 'bump_distance_ignorer', 'ShaderNodeMath', 'Bump Distance Ignorer', True)
+                tree, ch, 'bump_distance_ignorer', 'ShaderNodeMath',
+                'Bump Distance Ignorer', True
+            )
             if dirty: need_reconnect = True
             bump_distance_ignorer.operation = 'MULTIPLY'
             bump_distance_ignorer.inputs[1].default_value = 0.0
@@ -1794,7 +1814,9 @@ def check_channel_normal_map_nodes(tree, layer, root_ch, ch, need_reconnect=Fals
         # Transition bump flipper
         if ch.enable_transition_bump and ch.transition_bump_flip:
             tb_distance_flipper, dirty = check_new_node(
-                    tree, ch, 'tb_distance_flipper', 'ShaderNodeMath', 'Transition Bump Distance Flipper', True)
+                tree, ch, 'tb_distance_flipper', 'ShaderNodeMath',
+                'Transition Bump Distance Flipper', True
+            )
             if dirty: need_reconnect = True
             tb_distance_flipper.operation = 'MULTIPLY'
             tb_distance_flipper.inputs[1].default_value = -1.0
@@ -1804,7 +1826,9 @@ def check_channel_normal_map_nodes(tree, layer, root_ch, ch, need_reconnect=Fals
         # Delta calculation node
         if ch.normal_map_type in {'BUMP_MAP', 'BUMP_NORMAL_MAP'} and ch.enable_transition_bump:
             tb_delta_calc, dirty = check_new_node(
-                    tree, ch, 'tb_delta_calc', 'ShaderNodeGroup', 'Transition Bump Delta Calculation', True)
+                tree, ch, 'tb_delta_calc', 'ShaderNodeGroup',
+                'Transition Bump Delta Calculation', True
+            )
             if dirty: need_reconnect = True
             tb_delta_calc.node_tree = get_node_tree_lib(lib.TB_DELTA_CALC)
         else:
@@ -1825,8 +1849,9 @@ def check_channel_normal_map_nodes(tree, layer, root_ch, ch, need_reconnect=Fals
 
         if ch.write_height:
             max_height_calc, need_reconnect = replace_new_node(
-                    tree, ch, 'max_height_calc', 'ShaderNodeGroup', 'Max Height Calculation', 
-                    lib_name, return_status = True, hard_replace=True, dirty=need_reconnect)
+                tree, ch, 'max_height_calc', 'ShaderNodeGroup', 'Max Height Calculation', 
+                lib_name, return_status=True, hard_replace=True, dirty=need_reconnect
+            )
 
             inp = max_height_calc.inputs.get('Is Flipped')
             if inp: inp.default_value = 1.0 if ch.enable_transition_bump and ch.transition_bump_flip else 0.0
@@ -1877,8 +1902,9 @@ def check_channel_normal_map_nodes(tree, layer, root_ch, ch, need_reconnect=Fals
                 lib_name += ' Group'
 
         height_proc, need_reconnect = replace_new_node(
-                tree, ch, 'height_proc', 'ShaderNodeGroup', 'Height Process', 
-                lib_name, return_status = True, hard_replace=True, dirty=need_reconnect)
+            tree, ch, 'height_proc', 'ShaderNodeGroup', 'Height Process', 
+            lib_name, return_status=True, hard_replace=True, dirty=need_reconnect
+        )
 
         if ch.normal_map_type == 'NORMAL_MAP':
             if ch.enable_transition_bump:
@@ -1914,8 +1940,9 @@ def check_channel_normal_map_nodes(tree, layer, root_ch, ch, need_reconnect=Fals
                     else: lib_name = lib.STRAIGHT_OVER_HEIGHT_MIX
 
                     height_blend, need_reconnect = replace_new_node(
-                            tree, ch, 'height_blend', 'ShaderNodeGroup', 'Height Blend', 
-                            lib_name, return_status=True, hard_replace=True, dirty=need_reconnect)
+                        tree, ch, 'height_blend', 'ShaderNodeGroup', 'Height Blend', 
+                        lib_name, return_status=True, hard_replace=True, dirty=need_reconnect
+                    )
 
                     if write_height:
                         height_blend.inputs['Divide'].default_value = 1.0
@@ -1923,12 +1950,14 @@ def check_channel_normal_map_nodes(tree, layer, root_ch, ch, need_reconnect=Fals
                 else:
                     if root_ch.enable_smooth_bump:
                         height_blend, need_reconnect = replace_new_node(
-                                tree, ch, 'height_blend', 'ShaderNodeGroup', 'Height Blend', 
-                                lib.HEIGHT_MIX_SMOOTH, return_status=True, hard_replace=True, dirty=need_reconnect)
+                            tree, ch, 'height_blend', 'ShaderNodeGroup', 'Height Blend', 
+                            lib.HEIGHT_MIX_SMOOTH, return_status=True, hard_replace=True, dirty=need_reconnect
+                        )
                     else:
                         height_blend, need_reconnect = replace_new_mix_node(
-                                tree, ch, 'height_blend', 'Height Blend', 
-                                return_status=True, dirty=need_reconnect)
+                            tree, ch, 'height_blend', 'Height Blend', 
+                            return_status=True, dirty=need_reconnect
+                        )
 
                         height_blend.blend_type = 'MIX'
 
@@ -1940,8 +1969,9 @@ def check_channel_normal_map_nodes(tree, layer, root_ch, ch, need_reconnect=Fals
                     else: lib_name = lib.STRAIGHT_OVER_HEIGHT_ADD
 
                     height_blend, need_reconnect = replace_new_node(
-                            tree, ch, 'height_blend', 'ShaderNodeGroup', 'Height Blend', 
-                            lib_name, return_status=True, hard_replace=True, dirty=need_reconnect)
+                        tree, ch, 'height_blend', 'ShaderNodeGroup', 'Height Blend', 
+                        lib_name, return_status=True, hard_replace=True, dirty=need_reconnect
+                    )
 
                     if write_height:
                         height_blend.inputs['Divide'].default_value = 1.0
@@ -1949,12 +1979,14 @@ def check_channel_normal_map_nodes(tree, layer, root_ch, ch, need_reconnect=Fals
                 else:
                     if root_ch.enable_smooth_bump:
                         height_blend, need_reconnect = replace_new_node(
-                                tree, ch, 'height_blend', 'ShaderNodeGroup', 'Height Blend', 
-                                lib.HEIGHT_ADD_SMOOTH, return_status=True, hard_replace=True, dirty=need_reconnect)
+                            tree, ch, 'height_blend', 'ShaderNodeGroup', 'Height Blend', 
+                            lib.HEIGHT_ADD_SMOOTH, return_status=True, hard_replace=True, dirty=need_reconnect
+                        )
                     else:
                         height_blend, need_reconnect = replace_new_mix_node(
-                                tree, ch, 'height_blend', 'Height Blend', 
-                                return_status=True, dirty=need_reconnect)
+                            tree, ch, 'height_blend', 'Height Blend', 
+                            return_status=True, dirty=need_reconnect
+                        )
 
                         height_blend.blend_type = 'ADD'
 
@@ -1970,8 +2002,9 @@ def check_channel_normal_map_nodes(tree, layer, root_ch, ch, need_reconnect=Fals
                 else: lib_name = lib.HEIGHT_COMPARE
 
             height_blend, need_reconnect = replace_new_node(
-                    tree, ch, 'height_blend', 'ShaderNodeGroup', 'Height Blend', 
-                    lib_name, return_status=True, hard_replace=True, dirty=need_reconnect)
+                tree, ch, 'height_blend', 'ShaderNodeGroup', 'Height Blend', 
+                lib_name, return_status=True, hard_replace=True, dirty=need_reconnect
+            )
     else:
         if remove_node(tree, ch, 'height_proc'): need_reconnect = True
         if remove_node(tree, ch, 'height_blend'): need_reconnect = True
@@ -2022,14 +2055,16 @@ def check_channel_normal_map_nodes(tree, layer, root_ch, ch, need_reconnect=Fals
 
         if lib_name == '':
             normal_proc, need_reconnect = replace_new_node(
-                    tree, ch, 'normal_proc', 'ShaderNodeNormalMap', 'Normal Process', 
-                    return_status = True, hard_replace=True, dirty=need_reconnect)
+                tree, ch, 'normal_proc', 'ShaderNodeNormalMap', 'Normal Process', 
+                return_status=True, hard_replace=True, dirty=need_reconnect
+            )
 
             normal_proc.uv_map = layer.uv_name
         else:
             normal_proc, need_reconnect = replace_new_node(
-                    tree, ch, 'normal_proc', 'ShaderNodeGroup', 'Normal Process', 
-                    lib_name, return_status = True, hard_replace=True, dirty=need_reconnect)
+                tree, ch, 'normal_proc', 'ShaderNodeGroup', 'Normal Process', 
+                lib_name, return_status=True, hard_replace=True, dirty=need_reconnect
+            )
 
         if 'Max Height' in normal_proc.inputs:
             normal_proc.inputs['Max Height'].default_value = max_height
@@ -2069,8 +2104,10 @@ def check_channel_normal_map_nodes(tree, layer, root_ch, ch, need_reconnect=Fals
         else:
             if remove_node(tree, ch, 'vdisp_flip_yz'): need_reconnect = True
 
-        vdisp_proc, need_reconnect = replace_new_mix_node(tree, ch, 'vdisp_proc', 
-                'Vector Displacement Process', return_status = True, hard_replace=True, dirty=need_reconnect)
+        vdisp_proc, need_reconnect = replace_new_mix_node(
+            tree, ch, 'vdisp_proc', 'Vector Displacement Process',
+            return_status=True, hard_replace=True, dirty=need_reconnect
+        )
         vdisp_proc.blend_type = 'MULTIPLY'
         vdisp_proc.inputs[0].default_value = 1.0
     else:
@@ -2256,38 +2293,47 @@ def check_blend_type_nodes(root_ch, layer, ch):
             if root_ch.type == 'RGB':
                 if (has_parent or root_ch.enable_alpha) and blend_type == 'MIX':
 
-                    if (layer.type == 'BACKGROUND' and not 
+                    if (
+                            layer.type == 'BACKGROUND' and not 
                             (ch.enable_transition_ramp and ch.transition_ramp_intensity_unlink 
                                 and ch.transition_ramp_blend_type == 'MIX') and not 
                             (ch.enable_transition_ramp and layer.parent_idx != -1 and ch.transition_ramp_blend_type == 'MIX')
-                            ):
-                        blend, need_reconnect = replace_new_node(tree, ch, 'blend', 
-                                'ShaderNodeGroup', 'Blend', lib.STRAIGHT_OVER_BG, return_status = True, 
-                                hard_replace=True, dirty=need_reconnect)
+                        ):
+                        blend, need_reconnect = replace_new_node(
+                            tree, ch, 'blend', 'ShaderNodeGroup', 'Blend', lib.STRAIGHT_OVER_BG,
+                            return_status=True, hard_replace=True, dirty=need_reconnect
+                        )
 
                     else: 
-                        blend, need_reconnect = replace_new_node(tree, ch, 'blend', 
-                                'ShaderNodeGroup', 'Blend', lib.STRAIGHT_OVER, 
-                                return_status = True, hard_replace=True, dirty=need_reconnect)
+                        blend, need_reconnect = replace_new_node(
+                            tree, ch, 'blend',  'ShaderNodeGroup', 'Blend', lib.STRAIGHT_OVER, 
+                            return_status=True, hard_replace=True, dirty=need_reconnect
+                        )
 
                 else:
-                    blend, need_reconnect = replace_new_mix_node(tree, ch, 'blend', 
-                            'Blend', return_status = True, hard_replace=True, dirty=need_reconnect)
+                    blend, need_reconnect = replace_new_mix_node(
+                        tree, ch, 'blend', 'Blend',
+                        return_status=True, hard_replace=True, dirty=need_reconnect
+                    )
             elif root_ch.type == 'VALUE':
 
                 if (has_parent or root_ch.enable_alpha) and blend_type == 'MIX':
                     if layer.type == 'BACKGROUND':
-                        blend, need_reconnect = replace_new_node(tree, ch, 'blend', 
-                                'ShaderNodeGroup', 'Blend', lib.STRAIGHT_OVER_BG_BW, 
-                                return_status = True, hard_replace=True, dirty=need_reconnect)
+                        blend, need_reconnect = replace_new_node(
+                            tree, ch, 'blend', 'ShaderNodeGroup', 'Blend', lib.STRAIGHT_OVER_BG_BW, 
+                            return_status=True, hard_replace=True, dirty=need_reconnect
+                        )
                     else:
-                        blend, need_reconnect = replace_new_node(tree, ch, 'blend', 
-                                'ShaderNodeGroup', 'Blend', lib.STRAIGHT_OVER_BW, 
-                                return_status = True, hard_replace=True, dirty=need_reconnect)
+                        blend, need_reconnect = replace_new_node(
+                            tree, ch, 'blend', 'ShaderNodeGroup', 'Blend', lib.STRAIGHT_OVER_BW, 
+                            return_status=True, hard_replace=True, dirty=need_reconnect
+                        )
                 else:
 
-                    blend, need_reconnect = replace_new_mix_node(tree, ch, 'blend', 
-                            'Blend', return_status = True, hard_replace=True, dirty=need_reconnect)
+                    blend, need_reconnect = replace_new_mix_node(
+                        tree, ch, 'blend', 'Blend',
+                        return_status=True, hard_replace=True, dirty=need_reconnect
+                    )
 
             if blend.type in {'MIX_RGB', 'MIX'} and blend.blend_type != blend_type:
                 blend.blend_type = blend_type
@@ -2317,33 +2363,40 @@ def check_blend_type_nodes(root_ch, layer, ch):
             #if has_parent and ch.normal_blend_type == 'MIX':
             if (has_parent or root_ch.enable_alpha) and ch.normal_blend_type in {'MIX', 'COMPARE'}:
                 if layer.type == 'BACKGROUND':
-                    blend, need_reconnect = replace_new_node(tree, ch, 'blend', 
-                            'ShaderNodeGroup', 'Blend', lib.STRAIGHT_OVER_BG_VEC, 
-                            return_status = True, hard_replace=True, dirty=need_reconnect)
+                    blend, need_reconnect = replace_new_node(
+                        tree, ch, 'blend', 'ShaderNodeGroup', 'Blend', lib.STRAIGHT_OVER_BG_VEC, 
+                        return_status=True, hard_replace=True, dirty=need_reconnect
+                    )
                 else:
-                    blend, need_reconnect = replace_new_node(tree, ch, 'blend', 
-                            'ShaderNodeGroup', 'Blend', lib.STRAIGHT_OVER_VEC, 
-                            return_status = True, hard_replace=True, dirty=need_reconnect)
+                    blend, need_reconnect = replace_new_node(
+                        tree, ch, 'blend', 'ShaderNodeGroup', 'Blend', lib.STRAIGHT_OVER_VEC, 
+                        return_status=True, hard_replace=True, dirty=need_reconnect
+                    )
 
             elif ch.normal_blend_type == 'OVERLAY':
                 if has_parent:
-                    blend, need_reconnect = replace_new_node(tree, ch, 'blend', 
-                            'ShaderNodeGroup', 'Blend', lib.OVERLAY_NORMAL_STRAIGHT_OVER, 
-                            return_status = True, hard_replace=True, dirty=need_reconnect)
+                    blend, need_reconnect = replace_new_node(
+                        tree, ch, 'blend', 'ShaderNodeGroup', 'Blend', lib.OVERLAY_NORMAL_STRAIGHT_OVER, 
+                        return_status=True, hard_replace=True, dirty=need_reconnect
+                    )
                 else:
-                    blend, need_reconnect = replace_new_node(tree, ch, 'blend', 
-                            'ShaderNodeGroup', 'Blend', lib.OVERLAY_NORMAL, 
-                            return_status = True, hard_replace=True, dirty=need_reconnect)
+                    blend, need_reconnect = replace_new_node(
+                        tree, ch, 'blend', 'ShaderNodeGroup', 'Blend', lib.OVERLAY_NORMAL, 
+                        return_status=True, hard_replace=True, dirty=need_reconnect
+                    )
 
             elif ch.normal_blend_type in {'MIX', 'COMPARE'}:
-                blend, need_reconnect = replace_new_node(tree, ch, 'blend', 
-                        'ShaderNodeGroup', 'Blend', lib.VECTOR_MIX, 
-                        return_status = True, hard_replace=True, dirty=need_reconnect)
+                blend, need_reconnect = replace_new_node(
+                    tree, ch, 'blend', 'ShaderNodeGroup', 'Blend', lib.VECTOR_MIX, 
+                    return_status=True, hard_replace=True, dirty=need_reconnect
+                )
 
         elif channel_enabled and ch.normal_map_type == 'VECTOR_DISPLACEMENT_MAP':
 
-            blend, need_reconnect = replace_new_mix_node(tree, ch, 'blend', 
-                    'Blend', return_status = True, hard_replace=True, dirty=need_reconnect)
+            blend, need_reconnect = replace_new_mix_node(
+                tree, ch, 'blend', 'Blend',
+                return_status=True, hard_replace=True, dirty=need_reconnect
+            )
             blend.blend_type = 'ADD' if ch.normal_blend_type == 'OVERLAY' else 'MIX'
 
         else:

--- a/transition.py
+++ b/transition.py
@@ -171,13 +171,14 @@ class YHideTransitionEffect(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     type : EnumProperty(
-            name = 'Type',
-            items = (
-                ('BUMP', 'Bump', ''),
-                ('RAMP', 'Ramp', ''),
-                ('AO', 'AO', ''),
-                ),
-            default = 'BUMP')
+        name = 'Type',
+        items = (
+            ('BUMP', 'Bump', ''),
+            ('RAMP', 'Ramp', ''),
+            ('AO', 'AO', ''),
+        ),
+        default = 'BUMP'
+    )
 
     @classmethod
     def poll(cls, context):

--- a/transition_common.py
+++ b/transition_common.py
@@ -17,7 +17,7 @@ def get_transition_fine_bump_distance(distance, is_curved=False):
     return distance * scale
 
 
-def check_transition_bump_influences_to_other_channels(layer, tree=None, target_ch = None):
+def check_transition_bump_influences_to_other_channels(layer, tree=None, target_ch=None):
 
     yp = layer.id_data.yp
 
@@ -43,11 +43,15 @@ def check_transition_bump_influences_to_other_channels(layer, tree=None, target_
 
         if bump_ch and get_channel_enabled(c):
             if bump_ch.transition_bump_flip:
-                im = replace_new_node(tree, c, 'intensity_multiplier', 'ShaderNodeGroup', 
-                        'Intensity Multiplier', lib.INTENSITY_MULTIPLIER_SHARPEN_INVERT)
+                im = replace_new_node(
+                    tree, c, 'intensity_multiplier', 'ShaderNodeGroup', 
+                    'Intensity Multiplier', lib.INTENSITY_MULTIPLIER_SHARPEN_INVERT
+                )
             else:
-                im = replace_new_node(tree, c, 'intensity_multiplier', 'ShaderNodeGroup', 
-                        'Intensity Multiplier', lib.INTENSITY_MULTIPLIER_SHARPEN)
+                im = replace_new_node(
+                    tree, c, 'intensity_multiplier', 'ShaderNodeGroup',
+                    'Intensity Multiplier', lib.INTENSITY_MULTIPLIER_SHARPEN
+                )
 
         else:
             # Remove node if channel is disabled
@@ -87,25 +91,33 @@ def check_transition_ao_nodes(tree, layer, ch, bump_ch=None):
         #if layer.type == 'BACKGROUND' and ch.transition_ao_blend_type == 'MIX':
         if layer.type == 'BACKGROUND' and bump_ch.transition_bump_flip and ch.transition_ao_blend_type == 'MIX':
 
-            tao, dirty = replace_new_node(tree, ch, 'tao', 'ShaderNodeGroup', 
-                    'Transition AO', lib.TRANSITION_AO_BG_MIX, return_status=True)
+            tao, dirty = replace_new_node(
+                tree, ch, 'tao', 'ShaderNodeGroup', 'Transition AO',
+                lib.TRANSITION_AO_BG_MIX, return_status=True
+            )
             if dirty: duplicate_lib_node_tree(tao)
 
         #elif layer.type == 'BACKGROUND' or bump_ch.transition_bump_flip:
         elif bump_ch.transition_bump_flip:
 
-            tao, dirty = replace_new_node(tree, ch, 'tao', 'ShaderNodeGroup', 
-                    'Transition AO', lib.TRANSITION_AO_FLIP, return_status=True)
+            tao, dirty = replace_new_node(
+                tree, ch, 'tao', 'ShaderNodeGroup', 'Transition AO',
+                lib.TRANSITION_AO_FLIP, return_status=True
+            )
             if dirty: duplicate_lib_node_tree(tao)
 
         elif ch.transition_ao_blend_type == 'MIX' and (
                 layer.parent_idx != -1 or (root_ch.type == 'RGB' and root_ch.enable_alpha)):
-            tao = replace_new_node(tree, ch, 'tao', 
-                    'ShaderNodeGroup', 'Transition AO', lib.TRANSITION_AO_STRAIGHT_OVER)
+            tao = replace_new_node(
+                tree, ch, 'tao', 'ShaderNodeGroup', 'Transition AO',
+                lib.TRANSITION_AO_STRAIGHT_OVER
+            )
 
         else:
-            tao, dirty = replace_new_node(tree, ch, 'tao', 'ShaderNodeGroup', 
-                    'Transition AO', lib.TRANSITION_AO, return_status=True)
+            tao, dirty = replace_new_node(
+                tree, ch, 'tao', 'ShaderNodeGroup', 'Transition AO',
+                lib.TRANSITION_AO, return_status=True
+            )
             if dirty: duplicate_lib_node_tree(tao)
 
         # Blend type
@@ -116,7 +128,7 @@ def check_transition_ao_nodes(tree, layer, ch, bump_ch=None):
         set_transition_ao_intensity_link(ch, tree, layer, tao)
 
         if root_ch.colorspace == 'SRGB':
-            tao.inputs['Gamma'].default_value = 1.0/GAMMA
+            tao.inputs['Gamma'].default_value = 1.0 / GAMMA
         else: tao.inputs['Gamma'].default_value = 1.0
 
 def save_ramp(tree, ch):
@@ -155,17 +167,23 @@ def set_transition_ramp_nodes(tree, layer, ch):
     #if bump_ch and (bump_ch.transition_bump_flip or layer.type == 'BACKGROUND'):
     if bump_ch and bump_ch.transition_bump_flip:
 
-        tr_ramp, dirty = replace_new_node(tree, ch, 'tr_ramp', 
-                'ShaderNodeGroup', 'Transition Ramp', lib.RAMP_FLIP, return_status=True)
+        tr_ramp, dirty = replace_new_node(
+            tree, ch, 'tr_ramp', 'ShaderNodeGroup', 'Transition Ramp',
+            lib.RAMP_FLIP, return_status=True
+        )
         if dirty: duplicate_lib_node_tree(tr_ramp)
 
         if (ch.transition_ramp_blend_type == 'MIX' and 
                 ((root_ch.type == 'RGB' and root_ch.enable_alpha) or layer.parent_idx != -1)):
-            tr_ramp_blend = replace_new_node(tree, ch, 'tr_ramp_blend', 
-                    'ShaderNodeGroup', 'Transition Ramp Blend', lib.RAMP_FLIP_STRAIGHT_OVER_BLEND)
+            tr_ramp_blend = replace_new_node(
+                tree, ch, 'tr_ramp_blend', 'ShaderNodeGroup', 'Transition Ramp Blend',
+                lib.RAMP_FLIP_STRAIGHT_OVER_BLEND
+            )
         else:
-            tr_ramp_blend, dirty = replace_new_node(tree, ch, 'tr_ramp_blend', 
-                    'ShaderNodeGroup', 'Transition Ramp Blend', lib.RAMP_FLIP_BLEND, return_status=True)
+            tr_ramp_blend, dirty = replace_new_node(
+                tree, ch, 'tr_ramp_blend', 'ShaderNodeGroup', 'Transition Ramp Blend',
+                lib.RAMP_FLIP_BLEND, return_status=True
+            )
             if dirty: duplicate_lib_node_tree(tr_ramp_blend)
 
             # Get blend node
@@ -175,20 +193,30 @@ def set_transition_ramp_nodes(tree, layer, ch):
     else:
         if layer.type == 'BACKGROUND' and ch.transition_ramp_blend_type == 'MIX':
             if ch.transition_ramp_intensity_unlink:
-                tr_ramp, dirty = replace_new_node(tree, ch, 'tr_ramp', 
-                        'ShaderNodeGroup', 'Transition Ramp', lib.RAMP_BG_MIX_UNLINK, return_status=True)
+                tr_ramp, dirty = replace_new_node(
+                    tree, ch, 'tr_ramp', 'ShaderNodeGroup', 'Transition Ramp',
+                    lib.RAMP_BG_MIX_UNLINK, return_status=True
+                )
             elif layer.parent_idx != -1:
-                tr_ramp, dirty = replace_new_node(tree, ch, 'tr_ramp', 
-                        'ShaderNodeGroup', 'Transition Ramp', lib.RAMP_BG_MIX_CHILD, return_status=True)
+                tr_ramp, dirty = replace_new_node(
+                    tree, ch, 'tr_ramp', 'ShaderNodeGroup', 'Transition Ramp',
+                    lib.RAMP_BG_MIX_CHILD, return_status=True
+                )
             else:
-                tr_ramp, dirty = replace_new_node(tree, ch, 'tr_ramp', 
-                        'ShaderNodeGroup', 'Transition Ramp', lib.RAMP_BG_MIX, return_status=True)
+                tr_ramp, dirty = replace_new_node(
+                    tree, ch, 'tr_ramp', 'ShaderNodeGroup', 'Transition Ramp',
+                    lib.RAMP_BG_MIX, return_status=True
+                )
         elif ch.transition_ramp_intensity_unlink and ch.transition_ramp_blend_type == 'MIX':
-            tr_ramp, dirty = replace_new_node(tree, ch, 'tr_ramp', 
-                    'ShaderNodeGroup', 'Transition Ramp', lib.RAMP_STRAIGHT_OVER, return_status=True)
+            tr_ramp, dirty = replace_new_node(
+                tree, ch, 'tr_ramp', 'ShaderNodeGroup', 'Transition Ramp',
+                lib.RAMP_STRAIGHT_OVER, return_status=True
+            )
         else:
-            tr_ramp, dirty = replace_new_node(tree, ch, 'tr_ramp', 
-                    'ShaderNodeGroup', 'Transition Ramp', lib.RAMP, return_status=True)
+            tr_ramp, dirty = replace_new_node(
+                tree, ch, 'tr_ramp', 'ShaderNodeGroup', 'Transition Ramp',
+                lib.RAMP, return_status=True
+            )
 
         if dirty: duplicate_lib_node_tree(tr_ramp)
 
@@ -207,7 +235,7 @@ def set_transition_ramp_nodes(tree, layer, ch):
     load_ramp(tree, ch)
 
     if root_ch.colorspace == 'SRGB':
-        tr_ramp.inputs['Gamma'].default_value = 1.0/GAMMA
+        tr_ramp.inputs['Gamma'].default_value = 1.0 / GAMMA
     else: tr_ramp.inputs['Gamma'].default_value = 1.0
 
 def check_transition_ramp_nodes(tree, layer, ch):
@@ -238,13 +266,19 @@ def save_transition_bump_falloff_cache(tree, ch):
     if check_if_node_is_duplicated_from_lib(tb_falloff, lib.FALLOFF_CURVE):
         cache = tree.nodes.get(ch.cache_falloff_curve)
         if not cache:
-            cache = new_node(tree, ch, 'cache_falloff_curve', 'ShaderNodeRGBCurve', 'Falloff Curve Cache')
+            cache = new_node(
+                tree, ch, 'cache_falloff_curve',
+                'ShaderNodeRGBCurve', 'Falloff Curve Cache'
+            )
         curve_ref = tb_falloff.node_tree.nodes.get('_curve')
         copy_node_props(curve_ref, cache)
     elif check_if_node_is_duplicated_from_lib(tb_falloff, lib.FALLOFF_CURVE_SMOOTH):
         cache = tree.nodes.get(ch.cache_falloff_curve)
         if not cache:
-            cache = new_node(tree, ch, 'cache_falloff_curve', 'ShaderNodeRGBCurve', 'Falloff Curve Cache')
+            cache = new_node(
+                tree, ch, 'cache_falloff_curve',
+                'ShaderNodeRGBCurve', 'Falloff Curve Cache'
+            )
         ori = tb_falloff.node_tree.nodes.get('_original')
         curve_ref = ori.node_tree.nodes.get('_curve')
         copy_node_props(curve_ref, cache)
@@ -269,18 +303,26 @@ def check_transition_bump_falloff(layer, tree):
 
             if root_ch.enable_smooth_bump:
                 if ch.transition_bump_flip:
-                    tb_falloff = replace_new_node(tree, ch, 'tb_falloff', 'ShaderNodeGroup', 'Falloff', 
-                            lib.EMULATED_CURVE_SMOOTH_FLIP, hard_replace=True)
+                    tb_falloff = replace_new_node(
+                        tree, ch, 'tb_falloff', 'ShaderNodeGroup', 'Falloff', 
+                        lib.EMULATED_CURVE_SMOOTH_FLIP, hard_replace=True
+                    )
                 else:
-                    tb_falloff = replace_new_node(tree, ch, 'tb_falloff', 'ShaderNodeGroup', 'Falloff', 
-                            lib.EMULATED_CURVE_SMOOTH, hard_replace=True)
+                    tb_falloff = replace_new_node(
+                        tree, ch, 'tb_falloff', 'ShaderNodeGroup', 'Falloff', 
+                        lib.EMULATED_CURVE_SMOOTH, hard_replace=True
+                    )
             else:
                 if ch.transition_bump_flip:
-                    tb_falloff = replace_new_node(tree, ch, 'tb_falloff', 'ShaderNodeGroup', 'Falloff', 
-                            lib.EMULATED_CURVE_FLIP, hard_replace=True)
+                    tb_falloff = replace_new_node(
+                        tree, ch, 'tb_falloff', 'ShaderNodeGroup', 'Falloff',
+                        lib.EMULATED_CURVE_FLIP, hard_replace=True
+                    )
                 else:
-                    tb_falloff = replace_new_node(tree, ch, 'tb_falloff', 'ShaderNodeGroup', 'Falloff', 
-                            lib.EMULATED_CURVE, hard_replace=True)
+                    tb_falloff = replace_new_node(
+                        tree, ch, 'tb_falloff', 'ShaderNodeGroup', 'Falloff', 
+                        lib.EMULATED_CURVE, hard_replace=True
+                    )
 
         elif ch.transition_bump_falloff_type == 'CURVE':
             tb_falloff = ori = tree.nodes.get(ch.tb_falloff)
@@ -288,8 +330,10 @@ def check_transition_bump_falloff(layer, tree):
 
                 if not check_if_node_is_duplicated_from_lib(tb_falloff, lib.FALLOFF_CURVE_SMOOTH):
 
-                    tb_falloff = replace_new_node(tree, ch, 'tb_falloff', 'ShaderNodeGroup', 'Falloff', 
-                            lib.FALLOFF_CURVE_SMOOTH, hard_replace=True)
+                    tb_falloff = replace_new_node(
+                        tree, ch, 'tb_falloff', 'ShaderNodeGroup', 'Falloff', 
+                        lib.FALLOFF_CURVE_SMOOTH, hard_replace=True
+                    )
                     duplicate_lib_node_tree(tb_falloff)
 
                     # Duplicate group inside group
@@ -316,8 +360,10 @@ def check_transition_bump_falloff(layer, tree):
 
             elif not check_if_node_is_duplicated_from_lib(tb_falloff, lib.FALLOFF_CURVE):
 
-                tb_falloff = ori = replace_new_node(tree, ch, 'tb_falloff', 'ShaderNodeGroup', 'Falloff', 
-                        lib.FALLOFF_CURVE, hard_replace=True)
+                tb_falloff = ori = replace_new_node(
+                    tree, ch, 'tb_falloff', 'ShaderNodeGroup', 'Falloff', 
+                    lib.FALLOFF_CURVE, hard_replace=True
+                )
                 duplicate_lib_node_tree(tb_falloff)
 
                 # Check cached curve
@@ -399,17 +445,27 @@ def set_transition_bump_nodes(layer, tree, ch, ch_index):
         tb_inverse.inputs[0].default_value = 1.0
 
     if ch.transition_bump_flip or layer.type == 'BACKGROUND':
-        im = replace_new_node(tree, ch, 'intensity_multiplier', 'ShaderNodeMath', 
-                'Intensity Multiplier')
+        im = replace_new_node(
+            tree, ch, 'intensity_multiplier',
+            'ShaderNodeMath', 'Intensity Multiplier'
+        )
         im.operation = 'MULTIPLY'
         im.use_clamp = True
-        tbim = replace_new_node(tree, ch, 'tb_intensity_multiplier', 'ShaderNodeGroup', 
-                'Intensity Multiplier', lib.INTENSITY_MULTIPLIER_SHARPEN_NO_FACTOR)
+        tbim = replace_new_node(
+            tree, ch, 'tb_intensity_multiplier',
+            'ShaderNodeGroup', 'Intensity Multiplier',
+            lib.INTENSITY_MULTIPLIER_SHARPEN_NO_FACTOR
+        )
     else:
-        im = replace_new_node(tree, ch, 'intensity_multiplier', 'ShaderNodeGroup', 
-                'Intensity Multiplier', lib.INTENSITY_MULTIPLIER_SHARPEN_NO_FACTOR)
-        tbim = replace_new_node(tree, ch, 'tb_intensity_multiplier', 'ShaderNodeMath', 
-                'Intensity Multiplier')
+        im = replace_new_node(
+            tree, ch, 'intensity_multiplier',
+            'ShaderNodeGroup', 'Intensity Multiplier',
+            lib.INTENSITY_MULTIPLIER_SHARPEN_NO_FACTOR
+        )
+        tbim = replace_new_node(
+            tree, ch, 'tb_intensity_multiplier',
+            'ShaderNodeMath', 'Intensity Multiplier'
+        )
         tbim.operation = 'MULTIPLY'
         tbim.use_clamp = True
 

--- a/ui.py
+++ b/ui.py
@@ -250,13 +250,15 @@ def draw_image_props(context, source, layout, entity=None, show_flip_y=False):
             col.label(text='Path: ' + image.filepath)
 
         image_format = 'RGBA'
-        image_bit = int(image.depth/4)
+        image_bit = int(image.depth / 4)
         if image.depth in {24, 48, 96}:
             image_format = 'RGB'
-            image_bit = int(image.depth/3)
+            image_bit = int(image.depth / 3)
 
-        col.label(text='Info: ' + str(image.size[0]) + ' x ' + str(image.size[1]) +
-                ' ' + image_format + ' ' + str(image_bit) + '-bit')
+        col.label(
+            text='Info: ' + str(image.size[0]) + ' x ' + str(image.size[1]) +
+                ' ' + image_format + ' ' + str(image_bit) + '-bit'
+        )
 
     split = split_layout(col, 0.4)
 
@@ -806,8 +808,10 @@ def draw_bake_targets_ui(context, layout, node):
     row = col.row()
 
     rcol = row.column()
-    rcol.template_list("NODE_UL_YPaint_bake_targets", "", yp,
-            "bake_targets", yp, "active_bake_target_index", rows=2, maxrows=5)
+    rcol.template_list(
+        "NODE_UL_YPaint_bake_targets", "", yp, "bake_targets", yp,
+        "active_bake_target_index", rows=2, maxrows=5
+    )
 
     rcol = row.column(align=True)
     #rcol.context_pointer_set('node', node)
@@ -938,7 +942,7 @@ def draw_root_channels_ui(context, layout, node):
                 row.operator('node.y_connect_ypaint_channel', icon='ERROR', text='Fix Unconnected Channel Output')
 
             # Fix for alpha channel missing connection
-            elif channel.type=='RGB' and channel.enable_alpha and is_output_unconnected(node, output_index+1, channel):
+            elif channel.type == 'RGB' and channel.enable_alpha and is_output_unconnected(node, output_index + 1, channel):
                 row = mcol.row(align=True)
                 row.alert = True
                 row.operator('node.y_connect_ypaint_channel_alpha', icon='ERROR', text='Fix Unconnected Alpha Output')
@@ -1348,8 +1352,7 @@ def draw_layer_source(context, layout, layer, layer_tree, source, image, vcol, i
 
     modcol = rcol.column()
     modcol.active = layer.type not in {'BACKGROUND', 'GROUP'}
-    draw_modifier_stack(context, layer, 'RGB', modcol, 
-            lui, layer)
+    draw_modifier_stack(context, layer, 'RGB', modcol, lui, layer)
 
     #if layer.type not in {'VCOL', 'BACKGROUND'}:
     if layer.type not in {'BACKGROUND'}:
@@ -2767,9 +2770,10 @@ def draw_layers_ui(context, layout, node):
         if layer.type in {'IMAGE' , 'VCOL'}:
             src = get_layer_source(layer)
 
-            if ( not src or
-                (layer.type == 'IMAGE' and not src.image) or 
-                (layer.type == 'VCOL' and obj.type == 'MESH' and not get_vcol_from_source(obj, src))
+            if (
+                    not src or
+                    (layer.type == 'IMAGE' and not src.image) or 
+                    (layer.type == 'VCOL' and obj.type == 'MESH' and not get_vcol_from_source(obj, src))
                 ):
                 missing_data = True
                 break
@@ -2779,9 +2783,10 @@ def draw_layers_ui(context, layout, node):
             if mask.type in {'IMAGE' , 'VCOL'}:
                 mask_src = get_mask_source(mask)
 
-                if ( not mask_src or
-                    (mask.type == 'IMAGE' and mask_src and not mask_src.image) or 
-                    (mask.type == 'VCOL' and obj.type == 'MESH' and not get_vcol_from_source(obj, mask_src))
+                if (
+                        not mask_src or
+                        (mask.type == 'IMAGE' and mask_src and not mask_src.image) or 
+                        (mask.type == 'VCOL' and obj.type == 'MESH' and not get_vcol_from_source(obj, mask_src))
                     ):
                     missing_data = True
                     break
@@ -2795,9 +2800,9 @@ def draw_layers_ui(context, layout, node):
             if ch.override and ch.override_type in {'IMAGE', 'VCOL'}:
                 src = get_channel_source(ch, layer)
                 if (
-                    not src or
-                    (ch.override_type == 'IMAGE' and not src.image) or 
-                    (ch.override_type == 'VCOL' and obj.type == 'MESH' and not get_vcol_from_source(obj, src))
+                        not src or
+                        (ch.override_type == 'IMAGE' and not src.image) or 
+                        (ch.override_type == 'VCOL' and obj.type == 'MESH' and not get_vcol_from_source(obj, src))
                     ):
                     missing_data = True
                     break
@@ -3250,9 +3255,11 @@ def main_draw(self, context):
         if "just_updated" in saved_state and saved_state["just_updated"]:
             row_update = layout.row()
             row_update.alert = True
-            row_update.operator("wm.quit_blender",
-                         text="Restart blender to complete update",
-                         icon="ERROR")
+            row_update.operator(
+                "wm.quit_blender",
+                text="Restart blender to complete update",
+                icon="ERROR"
+            )
             return
         
     if updater.update_ready and not ypui.hide_update:
@@ -3262,8 +3269,10 @@ def main_draw(self, context):
             update_now_txt = "Update to latest commit on '{}' branch".format(updater.current_branch)
             row_update.operator(addon_updater_ops.AddonUpdaterUpdateNow.bl_idname, text=update_now_txt)
         else:
-            row_update.operator(addon_updater_ops.AddonUpdaterUpdateNow.bl_idname,
-                        text="Update now to " + str(updater.update_version))
+            row_update.operator(
+                addon_updater_ops.AddonUpdaterUpdateNow.bl_idname,
+                text="Update now to " + str(updater.update_version)
+            )
         row_update.alert = False
 
         row_update.operator(addon_updater_ops.UpdaterPendingUpdate.bl_idname, icon="X", text="")
@@ -3702,11 +3711,11 @@ class NODE_UL_YPaint_channels(bpy.types.UIList):
                 row.label(text='', icon='ERROR')
 
             if item.type=='RGB' and item.enable_alpha:
-                if len(inputs[input_index+1].links) == 0:
-                    row.prop(inputs[input_index+1], 'default_value', text='')
+                if len(inputs[input_index + 1].links) == 0:
+                    row.prop(inputs[input_index + 1], 'default_value', text='')
                 else: row.label(text='', icon='LINKED')
 
-                if is_output_unconnected(group_node, output_index+1, item):
+                if is_output_unconnected(group_node, output_index + 1, item):
                     row.label(text='', icon='ERROR')
 
 class NODE_UL_YPaint_layers(bpy.types.UIList):
@@ -4238,13 +4247,14 @@ def draw_ypaint_about(self, context):
     elif updater.update_ready:
         col.alert = True
         if updater.using_development_build:
-            update_now_txt = "Update to latest commit on '{}' branch".format(
-                updater.current_branch)
+            update_now_txt = "Update to latest commit on '{}' branch".format(updater.current_branch)
             col.operator(addon_updater_ops.AddonUpdaterUpdateNow.bl_idname, text=update_now_txt)
             
         else:
-            col.operator(addon_updater_ops.AddonUpdaterUpdateNow.bl_idname,
-                        text="Update now to " + str(updater.update_version))
+            col.operator(
+                addon_updater_ops.AddonUpdaterUpdateNow.bl_idname,
+                text="Update now to " + str(updater.update_version)
+            )
     elif is_online() or updater.current_branch != None:
         col.operator(addon_updater_ops.RefreshBranchesReleasesNow.bl_idname, text="Check for update", icon="FILE_REFRESH")
         col.label(text="Ucupaint is up to date")
@@ -5651,29 +5661,39 @@ def update_mask_channel_ui(self, context):
 
 class YBakeTargetUI(bpy.types.PropertyGroup):
     expand_content : BoolProperty(
-            name='Bake Target Options',
-            description='Expand bake target options',
-            default=True, update=update_bake_target_ui)
+        name = 'Bake Target Options',
+        description = 'Expand bake target options',
+        default = True,
+        update = update_bake_target_ui
+    )
 
     expand_r : BoolProperty(
-            name='R Channel',
-            description='Expand bake target R channel options',
-            default=False, update=update_bake_target_ui)
+        name = 'R Channel',
+        description = 'Expand bake target R channel options',
+        default = False,
+        update = update_bake_target_ui
+    )
 
     expand_g : BoolProperty(
-            name='G Channel',
-            description='Expand bake target R channel options',
-            default=False, update=update_bake_target_ui)
+        name = 'G Channel',
+        description = 'Expand bake target R channel options',
+        default = False,
+        update = update_bake_target_ui
+    )
 
     expand_b : BoolProperty(
-            name='B Channel',
-            description='Expand bake target B channel options',
-            default=False, update=update_bake_target_ui)
+        name = 'B Channel',
+        description = 'Expand bake target B channel options',
+        default = False,
+        update = update_bake_target_ui
+    )
 
     expand_a : BoolProperty(
-            name='A Channel',
-            description='Expand bake target A channel options',
-            default=False, update=update_bake_target_ui)
+        name = 'A Channel',
+        description = 'Expand bake target A channel options',
+        default = False,
+        update = update_bake_target_ui
+    )
 
 class YModifierUI(bpy.types.PropertyGroup):
     #name : StringProperty(default='')
@@ -5682,115 +5702,156 @@ class YModifierUI(bpy.types.PropertyGroup):
 class YChannelUI(bpy.types.PropertyGroup):
     #name : StringProperty(default='')
     expand_content : BoolProperty(
-            name='Channel Options',
-            description='Expand channel options',
-            default=False, update=update_channel_ui)
+        name = 'Channel Options',
+        description = 'Expand channel options',
+        default = False,
+        update = update_channel_ui
+    )
 
     expand_bump_settings : BoolProperty(
-            name='Bump',
-            description='Expand bump settings',
-            default=False, update=update_channel_ui)
+        name = 'Bump',
+        description = 'Expand bump settings',
+        default = False,
+        update = update_channel_ui
+    )
 
     expand_intensity_settings : BoolProperty(
-            name='Intensity',
-            description='Expand intensity settings',
-            default=False, update=update_channel_ui)
+        name = 'Intensity',
+        description = 'Expand intensity settings',
+        default = False,
+        update = update_channel_ui
+    )
 
     expand_base_vector : BoolProperty(
-            name='Base Vector',
-            description='Expand base vector options',
-            default=True, update=update_channel_ui)
+        name = 'Base Vector',
+        description = 'Expand base vector options',
+        default = True,
+        update = update_channel_ui
+    )
 
     expand_transition_bump_settings : BoolProperty(
-            name='Transition Bump',
-            description='Expand transition bump settings',
-            default=True, update=update_channel_ui)
+        name = 'Transition Bump',
+        description = 'Expand transition bump settings',
+        default = True,
+        update = update_channel_ui
+    )
 
     expand_transition_ramp_settings : BoolProperty(
-            name='Transition Ramp',
-            description='Expand transition ramp settings',
-            default=True, update=update_channel_ui)
+        name = 'Transition Ramp',
+        description = 'Expand transition ramp settings',
+        default = True, update = update_channel_ui
+    )
 
     expand_transition_ao_settings : BoolProperty(
-            name='Transition AO',
-            description='Expand transition AO settings',
-            default=True, update=update_channel_ui)
+        name = 'Transition AO',
+        description = 'Expand transition AO settings',
+        default = True,
+        update = update_channel_ui
+    )
 
     expand_subdiv_settings : BoolProperty(
-            name='Displacement Subdivision',
-            description='Expand displacement subdivision settings',
-            default=False, update=update_channel_ui)
+        name = 'Displacement Subdivision',
+        description = 'Expand displacement subdivision settings',
+        default = False,
+        update = update_channel_ui
+    )
 
     expand_parallax_settings : BoolProperty(
-            name='Parallax',
-            description='Expand parallax settings',
-            default=False, update=update_channel_ui)
+        name = 'Parallax',
+        description = 'Expand parallax settings',
+        default = False,
+        update = update_channel_ui
+    )
 
     expand_alpha_settings : BoolProperty(
-            name='Channel Alpha',
-            description='Expand alpha settings',
-            default=False, update=update_channel_ui)
+        name = 'Channel Alpha',
+        description = 'Expand alpha settings',
+        default = False,
+        update = update_channel_ui
+    )
 
     expand_bake_to_vcol_settings : BoolProperty(
-            name='Bake to Vertex Color',
-            description='Expand bake to vertex color settings',
-            default=False, update=update_channel_ui)
+        name = 'Bake to Vertex Color',
+        description = 'Expand bake to vertex color settings',
+        default = False,
+        update = update_channel_ui
+    )
 
     expand_input_bump_settings : BoolProperty(
-            name='Input Bump',
-            description='Expand input bump settings',
-            default=False, update=update_channel_ui)
+        name = 'Input Bump',
+        description = 'Expand input bump settings',
+        default = False,
+        update = update_channel_ui
+    )
 
     expand_smooth_bump_settings : BoolProperty(
-            name='Smooth Bump',
-            description='Expand smooth bump settings',
-            default=False, update=update_channel_ui)
+        name = 'Smooth Bump',
+        description = 'Expand smooth bump settings',
+        default = False,
+        update = update_channel_ui
+    )
 
     expand_input_settings : BoolProperty(
-            name='Input',
-            description='Expand input settings',
-            default=True, update=update_channel_ui)
+        name = 'Input',
+        description = 'Expand input settings',
+        default = True,
+        update = update_channel_ui
+    )
 
     expand_source : BoolProperty(
-            name='Channel Source',
-            description='Expand channel source settings',
-            default=True, update=update_channel_ui)
+        name = 'Channel Source',
+        description = 'Expand channel source settings',
+        default = True,
+        update = update_channel_ui
+    )
 
     expand_source_1 : BoolProperty(
-            name='Channel Normal Source',
-            description='Expand channel normal source settings',
-            default=True, update=update_channel_ui)
+        name = 'Channel Normal Source',
+        description = 'Expand channel normal source settings',
+        default = True,
+        update = update_channel_ui
+    )
 
     modifiers : CollectionProperty(type=YModifierUI)
     modifiers_1 : CollectionProperty(type=YModifierUI)
 
 class YMaskChannelUI(bpy.types.PropertyGroup):
     expand_content : BoolProperty(
-            name='Mask Channel Options',
-            description='Expand mask channel options',
-            default=False, update=update_mask_channel_ui)
+        name = 'Mask Channel Options',
+        description = 'Expand mask channel options',
+        default = False,
+        update = update_mask_channel_ui
+    )
 
 class YMaskUI(bpy.types.PropertyGroup):
     #name : StringProperty(default='')
     expand_content : BoolProperty(
-            name='Mask Options',
-            description='Expand mask options',
-            default=True, update=update_mask_ui)
+        name = 'Mask Options',
+        description = 'Expand mask options',
+        default = True,
+        update = update_mask_ui
+    )
 
     expand_channels : BoolProperty(
-            name='Mask Channel',
-            description='Expand mask channels',
-            default=True, update=update_mask_ui)
+        name = 'Mask Channel',
+        description = 'Expand mask channels',
+        default = True,
+        update = update_mask_ui
+    )
 
     expand_source : BoolProperty(
-            name='Mask Source',
-            description='Expand mask source options',
-            default=True, update=update_mask_ui)
+        name = 'Mask Source',
+        description = 'Expand mask source options',
+        default = True,
+        update = update_mask_ui
+    )
 
     expand_vector : BoolProperty(
-            name='Mask Vector',
-            description='Expand mask vector options',
-            default=True, update=update_mask_ui)
+        name = 'Mask Vector',
+        description = 'Expand mask vector options',
+        default = True,
+        update = update_mask_ui
+    )
 
     channels : CollectionProperty(type=YMaskChannelUI)
     modifiers : CollectionProperty(type=YModifierUI)
@@ -5799,29 +5860,39 @@ class YLayerUI(bpy.types.PropertyGroup):
     #name : StringProperty(default='')
 
     expand_content : BoolProperty(
-            name='Layer Options',
-            description='Expand layer options',
-            default=False, update=update_layer_ui)
+        name = 'Layer Options',
+        description = 'Expand layer options',
+        default = False,
+        update = update_layer_ui
+    )
 
     expand_vector : BoolProperty(
-            name='Layer Vector',
-            description='Expand layer vector options',
-            default=False, update=update_layer_ui)
+        name = 'Layer Vector',
+        description = 'Expand layer vector options',
+        default = False,
+        update = update_layer_ui
+    )
 
     expand_masks : BoolProperty(
-            name='Masks',
-            description='Expand all masks',
-            default=False, update=update_layer_ui)
+        name = 'Masks',
+        description = 'Expand all masks',
+        default = False,
+        update = update_layer_ui
+    )
 
     expand_source : BoolProperty(
-            name='Layer Source',
-            description='Expand layer source options',
-            default=False, update=update_layer_ui)
+        name = 'Layer Source',
+        description = 'Expand layer source options',
+        default = False,
+        update = update_layer_ui
+    )
 
     expand_channels : BoolProperty(
-            name='Layer Channels',
-            description='Expand layer channels',
-            default=True, update=update_layer_ui)
+        name = 'Layer Channels',
+        description = 'Expand layer channels',
+        default = True,
+        update = update_layer_ui
+    )
 
     channels : CollectionProperty(type=YChannelUI)
     masks : CollectionProperty(type=YMaskUI)
@@ -5836,49 +5907,58 @@ class YMaterialUI(bpy.types.PropertyGroup):
 
 class YPaintUI(bpy.types.PropertyGroup):
     show_object : BoolProperty(
-            name='Active Object',
-            description='Show active object options',
-            default=False)
+        name = 'Active Object',
+        description = 'Show active object options',
+        default = False
+    )
 
     show_materials : BoolProperty(
-            name='Materials',
-            description='Show material lists',
-            default=False)
+        name = 'Materials',
+        description = 'Show material lists',
+        default = False
+    )
 
     show_channels : BoolProperty(
-            name='Channels',
-            description='Show channel lists',
-            default=True)
+        name = 'Channels',
+        description = 'Show channel lists',
+        default = True
+    )
 
     show_layers : BoolProperty(
-            name='Layers',
-            description='Show layer lists',
-            default=True)
+        name = 'Layers',
+        description = 'Show layer lists',
+        default = True
+    )
 
     show_bake_targets : BoolProperty(
-            name='Custom Bake Targets',
-            description='Show custom bake target lists',
-            default=False)
+        name = 'Custom Bake Targets',
+        description = 'Show custom bake target lists',
+        default = False
+    )
 
     show_stats : BoolProperty(
-            name='Stats',
-            description='Show node stats',
-            default=False)
+        name = 'Stats',
+        description = 'Show node stats',
+        default = False
+    )
 
     show_support : BoolProperty(
-            name='Support',
-            description='Show support',
-            default=False)
+        name = 'Support',
+        description = 'Show support',
+        default = False
+    )
 
     expand_channels : BoolProperty(
-            name='Show Channel Toggle',
-            description="Show layer channels toggle",
-            default=False)
+        name = 'Show Channel Toggle',
+        description = "Show layer channels toggle",
+        default = False
+    )
 
     expand_mask_channels : BoolProperty(
-            name='Expand all mask channels',
-            description='Expand all mask channels',
-            default=False)
+        name = 'Expand all mask channels',
+        description = 'Expand all mask channels',
+        default = False
+    )
 
     # To store active node and tree
     tree_name : StringProperty(default='')

--- a/vcol_editor.py
+++ b/vcol_editor.py
@@ -150,11 +150,12 @@ class YSelectFacesByVcol(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     color : FloatVectorProperty(
-            name='Color', size=4,
-            subtype='COLOR',
-            default=(1.0, 0.0, 1.0, 1.0),
-            min=0.0, max=1.0,
-            )
+        name = 'Color',
+        size = 4,
+        subtype = 'COLOR',
+        default = (1.0, 0.0, 1.0, 1.0),
+        min=0.0, max=1.0,
+    )
 
     #deselect : BoolProperty(
     #        name='Deselect Faces',
@@ -237,11 +238,12 @@ class YVcolFillFaceCustom(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     color : FloatVectorProperty(
-            name='Color ID', size=4,
-            subtype='COLOR',
-            default=(1.0, 0.0, 1.0, 1.0),
-            min=0.0, max=1.0,
-            )
+        name = 'Color ID',
+        size = 4,
+        subtype = 'COLOR',
+        default = (1.0, 0.0, 1.0, 1.0),
+        min=0.0, max=1.0,
+    )
 
     @classmethod
     def poll(cls, context):
@@ -341,15 +343,16 @@ class YVcolFill(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     color_option : EnumProperty(
-            name = 'Color Option',
-            description = 'Color Option',
-            items = (
-                ('WHITE', 'White', ''),
-                ('BLACK', 'Black', ''),
-                #('TRANSPARENT', 'Transparent', ''),
-                ('CUSTOM', 'Custom', ''),
-                ),
-            default='WHITE')
+        name = 'Color Option',
+        description = 'Color Option',
+        items = (
+            ('WHITE', 'White', ''),
+            ('BLACK', 'Black', ''),
+            #('TRANSPARENT', 'Transparent', ''),
+            ('CUSTOM', 'Custom', ''),
+        ),
+        default='WHITE'
+    )
 
     @classmethod
     def poll(cls, context):
@@ -409,10 +412,10 @@ class YVcolFill(bpy.types.Operator):
             alpha = context.scene.ve_edit.color[3]
 
             if self.color_option == 'WHITE':
-                color = (1,1,1)
+                color = (1, 1, 1)
                 alpha = 1.0
             elif self.color_option == 'BLACK':
-                color = (0,0,0)
+                color = (0, 0, 0)
                 alpha = 1.0
             elif not is_bl_newer_than(3, 2):
                 color = linear_to_srgb(color)
@@ -566,11 +569,14 @@ class VIEW3D_PT_y_vcol_editor_tools(bpy.types.Panel):
         vcol_editor_draw(self, context)
 
 class YVcolEditorProps(bpy.types.PropertyGroup):
-    color : FloatVectorProperty(name='Color', size=4, subtype='COLOR', default=(1.0,1.0,1.0,1.0), min=0.0, max=1.0)
+    color : FloatVectorProperty(name='Color', size=4, subtype='COLOR', default=(1.0, 1.0, 1.0, 1.0), min=0.0, max=1.0)
     #palette : PointerProperty(type=bpy.types.Palette)
 
-    show_vcol_list : BoolProperty(name='Show Vertex Color List',
-            description='Show vertex color list', default=True)
+    show_vcol_list : BoolProperty(
+        name = 'Show Vertex Color List',
+        description = 'Show vertex color list',
+        default = True
+    )
 
     ori_blending_mode : StringProperty(default='')
     ori_brush : StringProperty(default='')

--- a/vector_displacement.py
+++ b/vector_displacement.py
@@ -96,7 +96,7 @@ def _prepare_bake_settings(book, obj, uv_map='', samples=1, margin=15, bake_devi
     # Set object to active
     bpy.context.view_layer.objects.active = obj
     if obj.mode != 'OBJECT':
-        bpy.ops.object.mode_set(mode = 'OBJECT')
+        bpy.ops.object.mode_set(mode='OBJECT')
     bpy.ops.object.select_all(action='DESELECT')
     obj.select_set(True)
 
@@ -164,15 +164,15 @@ def get_offset_attributes(base, sclupted_mesh, layer_disabled_mesh=None, intensi
         return None, None
 
     # Get coordinates for each vertices
-    base_arr = numpy.zeros(len(base.data.vertices)*3, dtype=numpy.float32)
+    base_arr = numpy.zeros(len(base.data.vertices) * 3, dtype=numpy.float32)
     base.data.vertices.foreach_get('co', base_arr)
 
-    sculpted_arr = numpy.zeros(len(sclupted_mesh.data.vertices)*3, dtype=numpy.float32)
+    sculpted_arr = numpy.zeros(len(sclupted_mesh.data.vertices) * 3, dtype=numpy.float32)
     sclupted_mesh.data.vertices.foreach_get('co', sculpted_arr)
 
     if layer_disabled_mesh:
 
-        layer_disabled_arr = numpy.zeros(len(layer_disabled_mesh.data.vertices)*3, dtype=numpy.float32)
+        layer_disabled_arr = numpy.zeros(len(layer_disabled_mesh.data.vertices) * 3, dtype=numpy.float32)
         layer_disabled_mesh.data.vertices.foreach_get('co', layer_disabled_arr)
     
         sculpted_arr = numpy.subtract(sculpted_arr, base_arr)
@@ -191,7 +191,7 @@ def get_offset_attributes(base, sclupted_mesh, layer_disabled_mesh=None, intensi
         offset = numpy.divide(offset, intensity)
 
     max_value = numpy.abs(offset).max()  
-    offset.shape = (offset.shape[0]//3, 3)
+    offset.shape = (offset.shape[0] // 3, 3)
     
     # Create new attribute to store the offset
     att = base.data.attributes.get(OFFSET_ATTR)
@@ -246,7 +246,7 @@ def bake_multires_image(obj, image, uv_name, intensity=1.0):
     temp0 = obj.copy()
     link_object(scene, temp0)
     temp0.data = temp0.data.copy()
-    temp0.location = obj.location + Vector(((obj.dimensions[0]+0.1)*1, 0.0, 0.0))     
+    temp0.location = obj.location + Vector(((obj.dimensions[0] + 0.1) * 1, 0.0, 0.0))     
 
     # Delete multires and shape keys
     set_active_object(temp0)
@@ -276,7 +276,7 @@ def bake_multires_image(obj, image, uv_name, intensity=1.0):
     temp2 = obj.copy()
     link_object(scene, temp2)
     temp2.data = temp2.data.copy()
-    temp2.location = obj.location + Vector(((obj.dimensions[0]+0.1)*3, 0.0, 0.0))
+    temp2.location = obj.location + Vector(((obj.dimensions[0] + 0.1) * 3, 0.0, 0.0))
     
     # Apply multires
     set_active_object(temp2)
@@ -296,7 +296,7 @@ def bake_multires_image(obj, image, uv_name, intensity=1.0):
         temp1 = temp0.copy()
         link_object(scene, temp1)
         temp1.data = temp1.data.copy()
-        temp1.location = obj.location + Vector(((obj.dimensions[0]+0.1)*2, 0.0, 0.0))
+        temp1.location = obj.location + Vector(((obj.dimensions[0] + 0.1) * 2, 0.0, 0.0))
         set_active_object(temp1)
 
         vdm_loader = get_vdm_loader_geotree(uv_name, layer_disabled_vdm_image, tanimage, bitimage)
@@ -408,9 +408,11 @@ def get_combined_vdm_image(obj, uv_name, width=1024, height=1024, disable_curren
     else: image_name = obj.name + '_' + uv_name + TEMP_COMBINED_VDM_IMAGE_SUFFIX
 
     # Create combined vdm image
-    image = bpy.data.images.new(name=image_name,
-            width=width, height=height, alpha=False, float_buffer=True)
-    image.generated_color = (0,0,0,1)
+    image = bpy.data.images.new(
+        name=image_name, width=width, height=height,
+        alpha=False, float_buffer=True
+    )
+    image.generated_color = (0, 0, 0, 1)
 
     # Get output node and remember original bsdf input
     mat_out = get_active_mat_output_node(mat.node_tree)
@@ -509,7 +511,7 @@ def get_tangent_bitangent_images(obj, uv_name):
         link_object(scene, temp)
         temp.data = temp.data.copy()
         context.view_layer.objects.active = temp
-        temp.location += Vector(((obj.dimensions[0]+0.1)*1, 0.0, 0.0))     
+        temp.location += Vector(((obj.dimensions[0] + 0.1) * 1, 0.0, 0.0))     
 
         # Set active uv
         uv_layers = get_uv_layers(temp)
@@ -569,9 +571,11 @@ def get_tangent_bitangent_images(obj, uv_name):
         _prepare_bake_settings(book, temp, uv_name)     
 
         if not tanimage:
-            tanimage = bpy.data.images.new(name=tanimage_name,
-                    width=1024, height=1024, alpha=False, float_buffer=True)
-            tanimage.generated_color = (0,0,0,1)
+            tanimage = bpy.data.images.new(
+                name=tanimage_name, width=1024, height=1024,
+                alpha=False, float_buffer=True
+            )
+            tanimage.generated_color = (0, 0, 0, 1)
 
             # Set bake tangent material
             temp.data.materials.clear()
@@ -586,9 +590,11 @@ def get_tangent_bitangent_images(obj, uv_name):
 
         if not bitimage:
 
-            bitimage = bpy.data.images.new(name=bitimage_name,
-                    width=1024, height=1024, alpha=False, float_buffer=True)
-            bitimage.generated_color = (0,0,0,1)
+            bitimage = bpy.data.images.new(
+                name=bitimage_name, width=1024, height=1024,
+                alpha=False, float_buffer=True
+            )
+            bitimage.generated_color = (0, 0, 0, 1)
 
             # Set bake bitangent material
             temp.data.materials.clear()
@@ -604,8 +610,8 @@ def get_tangent_bitangent_images(obj, uv_name):
         # Pack tangent and bitangent images so they won't lost their data
         tanimage.pack()
         bitimage.pack()
-        tanimage.use_fake_user=True
-        bitimage.use_fake_user=True
+        tanimage.use_fake_user = True
+        bitimage.use_fake_user = True
 
         # Revover bake settings
         _recover_bake_settings(book, True)
@@ -730,7 +736,7 @@ class YSculptImage(bpy.types.Operator):
         link_object(scene, temp)
         temp.data = temp.data.copy()
         context.view_layer.objects.active = temp
-        temp.location += Vector(((obj.dimensions[0]+0.1)*1, 0.0, 0.0))     
+        temp.location += Vector(((obj.dimensions[0] + 0.1) * 1, 0.0, 0.0))     
 
         # Select temp object
         set_active_object(temp)

--- a/versioning.py
+++ b/versioning.py
@@ -234,7 +234,7 @@ def update_yp_tree(tree):
         for channel in yp.channels:
             channel_tree = get_mod_tree(channel)
             for mod in channel.modifiers:
-                if mod.type == 'MULTIPLIER' :
+                if mod.type == 'MULTIPLIER':
                     mods.append(mod)
                     parents.append(channel)
                     types.append(channel.type)
@@ -242,7 +242,7 @@ def update_yp_tree(tree):
         for layer in yp.layers:
             layer_tree = get_mod_tree(layer)
             for mod in layer.modifiers:
-                if mod.type == 'MULTIPLIER' :
+                if mod.type == 'MULTIPLIER':
                     mods.append(mod)
                     parents.append(layer)
                     types.append('RGB')
@@ -251,7 +251,7 @@ def update_yp_tree(tree):
                 root_ch = yp.channels[i]
                 ch_tree = get_mod_tree(ch)
                 for j, mod in enumerate(ch.modifiers):
-                    if mod.type == 'MULTIPLIER' :
+                    if mod.type == 'MULTIPLIER':
                         mods.append(mod)
                         parents.append(ch)
                         types.append(root_ch.type)
@@ -305,8 +305,10 @@ def update_yp_tree(tree):
                 smooth_bump_ch = get_smooth_bump_channel(layer)
                 if smooth_bump_ch and smooth_bump_ch.enable:
                     layer_tree = get_tree(layer)
-                    uv_neighbor_1 = replace_new_node(layer_tree, layer, 'uv_neighbor_1', 'ShaderNodeGroup', 'Neighbor UV 1', 
-                            NEIGHBOR_FAKE, hard_replace=True)
+                    uv_neighbor_1 = replace_new_node(
+                        layer_tree, layer, 'uv_neighbor_1', 'ShaderNodeGroup', 'Neighbor UV 1', 
+                        NEIGHBOR_FAKE, hard_replace=True
+                    )
 
                 reconnect_layer_nodes(layer)
                 rearrange_layer_nodes(layer)
@@ -519,13 +521,13 @@ def update_yp_tree(tree):
                 height_ch = get_height_channel(layer)
                 if height_ch:
                     if not yp.use_baked and not height_root_ch.enable_subdiv_setup:
-                        set_entity_prop_value(height_ch, 'bump_distance', height_ch.bump_distance*5.0)
-                        set_entity_prop_value(height_ch, 'normal_bump_distance', height_ch.normal_bump_distance*5.0)
-                        set_entity_prop_value(height_ch, 'transition_bump_distance', height_ch.transition_bump_distance*5.0)
+                        set_entity_prop_value(height_ch, 'bump_distance', height_ch.bump_distance * 5.0)
+                        set_entity_prop_value(height_ch, 'normal_bump_distance', height_ch.normal_bump_distance * 5.0)
+                        set_entity_prop_value(height_ch, 'transition_bump_distance', height_ch.transition_bump_distance * 5.0)
                     elif height_root_ch.subdiv_adaptive:
-                        set_entity_prop_value(height_ch, 'bump_distance', height_ch.bump_distance/5.0)
-                        set_entity_prop_value(height_ch, 'normal_bump_distance', height_ch.normal_bump_distance/5.0)
-                        set_entity_prop_value(height_ch, 'transition_bump_distance', height_ch.transition_bump_distance/5.0)
+                        set_entity_prop_value(height_ch, 'bump_distance', height_ch.bump_distance / 5.0)
+                        set_entity_prop_value(height_ch, 'normal_bump_distance', height_ch.normal_bump_distance / 5.0)
+                        set_entity_prop_value(height_ch, 'transition_bump_distance', height_ch.transition_bump_distance / 5.0)
 
             # Transfer channel intensity value to layer intensity value if there's only one enabled channel
             enabled_channels = [c for c in layer.channels if c.enable]


### PR DESCRIPTION
This PR mostly addresses line breaks of multiline properties and function calls but has some smaller whitespace-related changes as well

It adds a noticeable amount of new lines because most property definitions and multiline function calls now take an extra line for the closing bracket and also some function calls and definitions that were previously one-liners are now split into multiple lines for the ease of reading and editing:

<img width="1039" alt="image" src="https://github.com/user-attachments/assets/7bc82dc0-b852-4c64-aaa0-8e93259b0f39"><br>

We'll likely easily be able to offset the increase in lines by refactoring the addon because there's quite a lot of repetition and unused code branches