### PR TITLE
Add issue templates for bug reports and enhancements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -6,7 +6,7 @@ body:
     id: ucupaintversion
     attributes:
       label: UCUPAINT Version
-      description: Type the version from `Edit > Preferences > Get Extensions > Ucupaint` here.
+      description: Type the version from [Edit > Preferences > Get Extensions > Ucupaint] here.
       placeholder: ex. 2.2.0
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,39 @@
+name: 🐞 Bug report
+description: Create a report to help us improve.
+labels: ["bug"]
+body:
+  - type: input
+    id: ucupaintversion
+    attributes:
+      label: UCUPAINT Version
+      description: Type the version from Edit > Preferences > Get Extensions > Ucupaint here.
+      placeholder: ex. 2.2.0
+    validations:
+      required: true
+  - type: textarea
+    id: describebug
+    attributes:
+      label: Describe The Bug
+      description: A clear and concise description of what the bug is.
+      placeholder: ex. This should happen, but that happens instead.
+    validations:
+      required: true
+  - type: textarea
+    id: reproducebug
+    attributes:
+      label: To Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: incaseofcrash
+    attributes:
+      label: In the case of a crash or when relevant include the logs
+      description: Please include the logs (https://docs.blender.org/manual/en/latest/troubleshooting/crash.html#crash-log)
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -6,7 +6,7 @@ body:
     id: ucupaintversion
     attributes:
       label: UCUPAINT Version
-      description: Type the version from Edit > Preferences > Get Extensions > Ucupaint here.
+      description: Type the version from `Edit > Preferences > Get Extensions > Ucupaint` here.
       placeholder: ex. 2.2.0
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,26 @@
+name: 🚀 Feature Request
+description: Suggest an idea for this project.
+labels: ["enhancement"]
+body:
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Pre-Flight checklist
+      description: Make sure these are correct before submitting
+      options:
+        - label: Did you check to see if this issue already exists?
+          required: true
+        - label: This is a single feature request. (Do not put multiple feature requests in one issue)
+          required: true
+  - type: textarea
+    id: describefeaturerequest
+    attributes:
+      label: Describe The Feature Request Below
+      description: A clear and concise description of what the feature request is.
+      placeholder: |
+        EXAMPLES: 
+        - Normally this happens, but that could happen instead
+        - This functionality should be added
+        - This functionality should be changed
+    validations:
+      required: true


### PR DESCRIPTION
## Why
This forces people to go through these forms when they create issues for bugs or enhancements. Very helpful for encouraging people to submit more information in their bug reports, like reproduction steps, crash logs, etc.

## Bug reports Issue (with validation)
![image](https://github.com/user-attachments/assets/683c06fe-ad8e-4a5e-a9a6-0b91008d4ddc)

## Feature requests issue (with validation)
![image](https://github.com/user-attachments/assets/c95dff8c-6eae-43ea-8839-5ad8a045e38f)
