### PR TITLE
Refactor gamma pipeline (Fix #268)

### DIFF
--- a/Bake.py
+++ b/Bake.py
@@ -2370,7 +2370,6 @@ class YMergeLayer(bpy.types.Operator, BaseBakeOperator):
         # Merge image layers
         if (layer.type == 'IMAGE' and layer.texcoord_type == 'UV'): # and neighbor_layer.type == 'IMAGE'):
 
-
             book = remember_before_bake(yp)
             prepare_bake_settings(
                 book, objs, yp, samples=1, margin=5, 
@@ -2543,6 +2542,15 @@ class YMergeLayer(bpy.types.Operator, BaseBakeOperator):
 
             # Refresh index routine
             yp.active_layer_index = min(layer_idx, neighbor_idx)
+
+            # HACK: To make the result correct, multiply rgb by alpha if image alpha mode is premultiplied
+            layer = yp.layers[yp.active_layer_index]
+            if layer.type == 'IMAGE':
+                source = get_layer_source(layer)
+                if source and source.image:
+                    image = source.image
+                    if image.is_float and image.alpha_mode == 'PREMUL':
+                        multiply_image_rgb_by_alpha(image)
 
             # Update list items
             ListItem.refresh_list_items(yp, repoint_active=True)

--- a/ImageAtlas.py
+++ b/ImageAtlas.py
@@ -71,8 +71,11 @@ def create_image_atlas(color='BLACK', size=8192, hdr=False, name=''):
     img.yia.is_image_atlas = True
     img.yia.color = color
     #img.yia.float_buffer = hdr
-    #if hdr:
-    #img.colorspace_settings.name = get_noncolor_name()
+
+    # Float image atlas always use premultiplied alpha
+    if hdr:
+        #img.colorspace_settings.name = get_noncolor_name()
+        img.alpha_mode = 'PREMUL'
 
     return img
 
@@ -653,6 +656,8 @@ class YConvertToStandardImage(bpy.types.Operator):
                     name=entities[i][0].name, width=segment.width, height=segment.height,
                     alpha=True, float_buffer=image.is_float
                 )
+                if image.is_float:
+                    new_image.alpha_mode = 'PREMUL'
             else:
                 new_image = bpy.data.images.new(
                     name=entities[i][0].name, width=image.size[0], height=image.size[1],

--- a/Layer.py
+++ b/Layer.py
@@ -1540,9 +1540,9 @@ class YNewLayer(bpy.types.Operator):
                     if hasattr(img, 'use_alpha'):
                         img.use_alpha = True
 
-                    # Set alpha mode to premultiplied to make sure alpha will be packed correctly
-                    if img.is_float:
-                        img.alpha_mode = 'PREMUL'
+                # Set alpha mode to premultiplied to make sure alpha will be packed correctly
+                if img.is_float:
+                    img.alpha_mode = 'PREMUL'
 
             update_image_editor_image(context, img)
 

--- a/Layer.py
+++ b/Layer.py
@@ -1494,6 +1494,13 @@ class YNewLayer(bpy.types.Operator):
         img_atlas = self.get_to_be_cleared_image_atlas(context, yp)
         if img_atlas: ImageAtlas.clear_unused_segments(img_atlas.yia)
 
+        # Get channel index
+        try: channel_idx = int(self.channel_idx)
+        except: channel_idx = 0
+
+        # Check if srgb channel is selected
+        srgb_ch_selected = any([ch for i, ch in enumerate(yp.channels) if (i == channel_idx or channel_idx == -1) and ch.colorspace == 'SRGB'])
+
         img = None
         segment = None
         if self.type == 'IMAGE':
@@ -1536,8 +1543,9 @@ class YNewLayer(bpy.types.Operator):
                     if hasattr(img, 'use_alpha'):
                         img.use_alpha = True
 
-            #if img.colorspace_settings.name != get_noncolor_name():
-            #    img.colorspace_settings.name = get_noncolor_name()
+                # Use srgb if srgb channel is selected
+                if srgb_ch_selected:
+                    img.colorspace_settings.name = get_srgb_name()
 
             update_image_editor_image(context, img)
 
@@ -1563,9 +1571,6 @@ class YNewLayer(bpy.types.Operator):
                     set_active_vertex_color(o, vcol)
 
         yp.halt_update = True
-
-        try: channel_idx = int(self.channel_idx)
-        except: channel_idx = 0
 
         layer = add_new_layer(
             node.node_tree, self.name, self.type, 

--- a/Layer.py
+++ b/Layer.py
@@ -1498,9 +1498,6 @@ class YNewLayer(bpy.types.Operator):
         try: channel_idx = int(self.channel_idx)
         except: channel_idx = 0
 
-        # Check if srgb channel is selected
-        srgb_ch_selected = any([ch for i, ch in enumerate(yp.channels) if (i == channel_idx or channel_idx == -1) and ch.colorspace == 'SRGB'])
-
         img = None
         segment = None
         if self.type == 'IMAGE':
@@ -1543,9 +1540,10 @@ class YNewLayer(bpy.types.Operator):
                     if hasattr(img, 'use_alpha'):
                         img.use_alpha = True
 
-                # Use srgb if srgb channel is selected
-                if srgb_ch_selected:
-                    img.colorspace_settings.name = get_srgb_name()
+                    # Immidiately pack new float image to avoid color problem
+                    if img.is_float and is_bl_newer_than(2, 80):
+                        set_image_pixels(img, color)
+                        img.pack()
 
             update_image_editor_image(context, img)
 

--- a/Layer.py
+++ b/Layer.py
@@ -1540,10 +1540,13 @@ class YNewLayer(bpy.types.Operator):
                     if hasattr(img, 'use_alpha'):
                         img.use_alpha = True
 
-                    # Immidiately pack new float image to avoid color problem
                     if img.is_float and is_bl_newer_than(2, 80):
+                        # Immidiately pack new float image to avoid color problem
                         set_image_pixels(img, color)
                         img.pack()
+
+                        # Set alpha mode to premultiplied to make sure alpha will be saved correctly
+                        img.alpha_mode = 'PREMUL'
 
             update_image_editor_image(context, img)
 

--- a/Layer.py
+++ b/Layer.py
@@ -1540,12 +1540,8 @@ class YNewLayer(bpy.types.Operator):
                     if hasattr(img, 'use_alpha'):
                         img.use_alpha = True
 
-                    if img.is_float and is_bl_newer_than(2, 80):
-                        # Immidiately pack new float image to avoid color problem
-                        set_image_pixels(img, color)
-                        img.pack()
-
-                        # Set alpha mode to premultiplied to make sure alpha will be saved correctly
+                    # Set alpha mode to premultiplied to make sure alpha will be packed correctly
+                    if img.is_float:
                         img.alpha_mode = 'PREMUL'
 
             update_image_editor_image(context, img)

--- a/UDIM.py
+++ b/UDIM.py
@@ -60,6 +60,16 @@ def fill_tile(image, tilenum, color=None, width=0, height=0, empty_only=False):
 
     return True
 
+def preserve_copied_image_color_hack(image, ori_image):
+    if image.is_float:
+        set_image_pixels_to_linear(image)
+        if ori_image.source != 'GENERATED':
+            multiply_image_rgb_by_alpha(image)
+            set_image_pixels_to_linear(image)
+    else:
+        divide_image_rgb_by_alpha(image)
+        set_image_pixels_to_srgb(image)
+
 def copy_udim_pixels(src, dest):
     for tile in src.tiles:
         # Check if tile number exists on both images and has same sizes
@@ -74,6 +84,10 @@ def copy_udim_pixels(src, dest):
 
         # Set pixels
         dest.pixels = list(src.pixels)
+
+        # HACK: Need to do some image operations if the bit depth is different
+        if src.is_float != dest.is_float:
+            preserve_copied_image_color_hack(dest, src)
 
         # Swap back
         if tile.number != 1001:

--- a/UDIM.py
+++ b/UDIM.py
@@ -670,6 +670,10 @@ def create_udim_atlas(tilenums, name='', width=1024, height=1024, color=(0, 0, 0
     image.yua.is_udim_atlas = True
     image.yui.base_color = color
 
+    # Float image atlas always use premultipled alpha
+    if hdr:
+        image.alpha_mode = 'PREMUL'
+
     # Pack image
     initial_pack_udim(image)
 
@@ -1161,6 +1165,10 @@ class YConvertImageTiled(bpy.types.Operator):
 
     def execute(self, context):
         image = context.image
+
+        if image.yua.is_udim_atlas or image.yia.is_image_atlas:
+            self.report({'ERROR'}, 'Converting image atlas to/from UDIM is not supported yet!')
+            return {'CANCELLED'}
 
         # Create new image
         new_image = bpy.data.images.new(

--- a/UDIM.py
+++ b/UDIM.py
@@ -60,17 +60,17 @@ def fill_tile(image, tilenum, color=None, width=0, height=0, empty_only=False):
 
     return True
 
-def preserve_copied_image_color_hack(image, ori_image):
+def preserve_image_color_after_changing_bit_depth(image, ori_image):
+    # HACK: This hack are tested on linear premultiplied float and srgb straight byte
+    # It's not 100% preserved exactly, but close enough
     if image.is_float:
-        set_image_pixels_to_linear(image)
-        if ori_image.source != 'GENERATED':
-            multiply_image_rgb_by_alpha(image)
-            set_image_pixels_to_linear(image)
+        set_image_pixels_to_linear(image, power=2)
+        multiply_image_rgb_by_alpha(image, power=3)
     else:
         divide_image_rgb_by_alpha(image)
         set_image_pixels_to_srgb(image)
 
-def copy_udim_pixels(src, dest):
+def copy_udim_pixels(src, dest, convert_colorspace=False):
     for tile in src.tiles:
         # Check if tile number exists on both images and has same sizes
         dtile = dest.tiles.get(tile.number)
@@ -86,8 +86,8 @@ def copy_udim_pixels(src, dest):
         dest.pixels = list(src.pixels)
 
         # HACK: Need to do some image operations if the bit depth is different
-        if src.is_float != dest.is_float:
-            preserve_copied_image_color_hack(dest, src)
+        if convert_colorspace and src.is_float != dest.is_float:
+            preserve_image_color_after_changing_bit_depth(dest, src)
 
         # Swap back
         if tile.number != 1001:

--- a/UDIM.py
+++ b/UDIM.py
@@ -61,16 +61,21 @@ def fill_tile(image, tilenum, color=None, width=0, height=0, empty_only=False):
     return True
 
 def copy_udim_pixels(src, dest, convert_colorspace=False):
-    for tile in src.tiles:
+
+    tilenums = [tile.number for tile in src.tiles]
+
+    for tilenum in tilenums:
+        tile = src.tiles.get(tilenum)
+
         # Check if tile number exists on both images and has same sizes
-        dtile = dest.tiles.get(tile.number)
+        dtile = dest.tiles.get(tilenum)
         if not dtile: continue
         if tile.size[0] != dtile.size[0] or tile.size[1] != dtile.size[1]: continue
 
         # Swap first
-        if tile.number != 1001:
-            swap_tile(src, 1001, tile.number)
-            swap_tile(dest, 1001, tile.number)
+        if tilenum != 1001:
+            swap_tile(src, 1001, tilenum)
+            swap_tile(dest, 1001, tilenum)
 
         # Set pixels
         if convert_colorspace:
@@ -78,9 +83,9 @@ def copy_udim_pixels(src, dest, convert_colorspace=False):
         else: dest.pixels = list(src.pixels)
 
         # Swap back
-        if tile.number != 1001:
-            swap_tile(src, 1001, tile.number)
-            swap_tile(dest, 1001, tile.number)
+        if tilenum != 1001:
+            swap_tile(src, 1001, tilenum)
+            swap_tile(dest, 1001, tilenum)
 
 def get_tile_numbers(objs, uv_name):
 

--- a/UDIM.py
+++ b/UDIM.py
@@ -60,16 +60,6 @@ def fill_tile(image, tilenum, color=None, width=0, height=0, empty_only=False):
 
     return True
 
-def preserve_image_color_after_changing_bit_depth(image, ori_image):
-    # HACK: This hack are tested on linear premultiplied float and srgb straight byte
-    # It's not 100% preserved exactly, but close enough
-    if image.is_float:
-        set_image_pixels_to_linear(image, power=2)
-        multiply_image_rgb_by_alpha(image, power=3)
-    else:
-        divide_image_rgb_by_alpha(image)
-        set_image_pixels_to_srgb(image)
-
 def copy_udim_pixels(src, dest, convert_colorspace=False):
     for tile in src.tiles:
         # Check if tile number exists on both images and has same sizes
@@ -83,11 +73,9 @@ def copy_udim_pixels(src, dest, convert_colorspace=False):
             swap_tile(dest, 1001, tile.number)
 
         # Set pixels
-        dest.pixels = list(src.pixels)
-
-        # HACK: Need to do some image operations if the bit depth is different
-        if convert_colorspace and src.is_float != dest.is_float:
-            preserve_image_color_after_changing_bit_depth(dest, src)
+        if convert_colorspace:
+            copy_image_pixels_with_conversion(src, dest)
+        else: dest.pixels = list(src.pixels)
 
         # Swap back
         if tile.number != 1001:

--- a/UDIM.py
+++ b/UDIM.py
@@ -1184,6 +1184,10 @@ class YConvertImageTiled(bpy.types.Operator):
 
             initial_pack_udim(new_image, color)
 
+        # Copy colorspace and alpha mode
+        new_image.colorspace_settings.name = image.colorspace_settings.name
+        new_image.alpha_mode = image.alpha_mode
+
         # Copy image pixels
         copy_image_pixels(image, new_image)
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Ucupaint",
     "author": "Yusuf Umar, Agni Rakai Sahakarya, Jan Bláha, Ahmad Rifai, morirain, Patrick W. Crawford, neomonkeus, Kareem Haddad, passivestar",
-    "version": (2, 2, 2),
+    "version": (2, 2, 3),
     "blender": (2, 80, 0),
     "location": "Node Editor > Properties > Ucupaint",
     "warning": "",

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "ucupaint"
-version = "2.2.2"
+version = "2.2.3"
 name = "Ucupaint"
 tagline = "Layer based painting for Eevee and Cycles"
 maintainer = "Yusuf Umar <yusufumaris@gmail.com>"

--- a/common.py
+++ b/common.py
@@ -5887,6 +5887,100 @@ def is_image_source_srgb(image, source, root_ch=None):
 
     return image.colorspace_settings.name == get_srgb_name()
 
+def get_layer_and_root_ch_from_layer_ch(ch):
+    yp = ch.id_data.yp
+    layer = None
+    root_ch = None
+    
+    match = re.match(r'yp\.layers\[(\d+)\]\.channels\[(\d+)\]', ch.path_from_id())
+    if match:
+        layer = yp.layers[int(match.group(1))]
+        root_ch = yp.channels[int(match.group(2))]
+
+    return layer, root_ch
+
+def get_layer_channel_gamma_value(ch, layer=None, root_ch=None):
+    yp = ch.id_data.yp
+    if not layer or not root_ch: layer, root_ch = get_layer_and_root_ch_from_layer_ch(ch)
+
+    channel_enabled = get_channel_enabled(ch, layer, root_ch)
+    if not channel_enabled: return 1.0
+
+    #layer_source_tree = get_source_tree(layer)
+    source_tree = get_channel_source_tree(ch, layer)
+
+    image = None
+    source = None
+    if ch.override and ch.override_type == 'IMAGE':
+        source = source_tree.nodes.get(ch.source)
+        if source: image = source.image
+    elif layer.type == 'IMAGE':
+        source = get_layer_source(layer)
+        if source: image = source.image
+
+    if not source or not image: return 1.0
+
+    if yp.use_linear_blending:
+        if (
+            not ch.override_1
+            and root_ch.type == 'NORMAL'
+            and ch.normal_map_type in {'NORMAL_MAP', 'BUMP_NORMAL_MAP'}
+            #and not image.is_float #and is_image_source_srgb(image, source) # NOTE: No need for channel linear if the image is float
+        ):
+            return 1.0 / GAMMA
+
+        elif (root_ch.type != 'NORMAL' 
+            and root_ch.colorspace == 'SRGB' 
+            and (
+                (ch.gamma_space and ch.layer_input == 'RGB' and layer.type not in {'IMAGE', 'BACKGROUND', 'GROUP'})
+                #or (layer.type == 'IMAGE' and image.is_float and image.colorspace_settings.name == get_srgb_name()) 
+                )
+        ):
+            return GAMMA
+
+        # TODO: Layer image loaded into linear channel
+
+    else:
+        if (
+            ch.override and (
+                (image and is_image_source_srgb(image, source, root_ch)) or 
+                (ch.override_type not in {'IMAGE'} and root_ch.type != 'NORMAL' and root_ch.colorspace == 'SRGB')
+            )
+        ):
+            return 1.0 / GAMMA
+
+        elif (
+            not ch.override 
+            and root_ch.type != 'NORMAL' 
+            and root_ch.colorspace == 'SRGB' 
+            and (
+                (not ch.gamma_space and ch.layer_input == 'RGB' and layer.type not in {'IMAGE', 'BACKGROUND', 'GROUP'})
+                #or (layer.type == 'IMAGE' and image.is_float and image.colorspace_settings.name != get_srgb_name()) # Float images need to converted to linear for some reason in Blender
+            )
+        ):
+            return 1.0 / GAMMA
+
+    return 1.0
+
+def get_layer_channel_normal_gamma_value(ch, layer=None, root_ch=None):
+    yp = ch.id_data.yp
+    if not layer or not root_ch: layer, root_ch = get_layer_and_root_ch_from_layer_ch(ch)
+
+    channel_enabled = get_channel_enabled(ch, layer, root_ch)
+    if not channel_enabled: return 1.0
+
+    image = None
+    source = None
+    layer_tree = get_tree(layer)
+    if ch.override_1 and ch.override_1_type == 'IMAGE':
+        source = layer_tree.nodes.get(ch.source_1)
+        if source: image = source.image
+
+    if ch.override_1 and image and is_image_source_srgb(image, source):
+        return 1.0 / GAMMA
+
+    return 1.0
+
 def get_layer_gamma_value(layer):
     yp = layer.id_data.yp
 
@@ -5895,11 +5989,13 @@ def get_layer_gamma_value(layer):
         source = source_tree.nodes.get(layer.source)
         image = source.image
         if image:
+            # For some reason, generated float image act like a srgb image
             if image.is_float and image.source == 'GENERATED' and not is_image_source_srgb(image, source):
-                #return GAMMA if yp.use_linear_blending else 1.0 / GAMMA
                 return 1.0
+
             elif not yp.use_linear_blending and is_image_source_srgb(image, source):
                 return 1.0 / GAMMA
+
             elif yp.use_linear_blending and not is_image_source_srgb(image, source):
                 return GAMMA
 
@@ -5912,34 +6008,54 @@ def any_linear_images_problem(yp):
 
         for i, ch in enumerate(layer.channels):
             root_ch = yp.channels[i]
-            if not get_channel_enabled(ch, layer, root_ch): continue
+            #if not get_channel_enabled(ch, layer, root_ch): continue
 
-            if not yp.use_linear_blending and ch.override and ch.override_type == 'IMAGE':
-                source_tree = get_channel_source_tree(ch)
-                linear = source_tree.nodes.get(ch.linear)
-                source = source_tree.nodes.get(ch.source)
-                if not source: continue
+            gamma = get_layer_channel_gamma_value(ch, layer, root_ch)
+            source_tree = get_channel_source_tree(ch, layer)
+            linear = source_tree.nodes.get(ch.linear)
 
-                image = source.image
-                if not image: continue
-                if (
-                    (is_image_source_srgb(image, source, root_ch) and not linear) or
-                    (not is_image_source_srgb(image, source, root_ch) and linear)
-                    ):
-                    return True
 
-            if ch.override_1 and ch.override_1_type == 'IMAGE':
+            if (
+                (gamma == 1.0 and linear) or
+                (gamma != 1.0 and (not linear or not isclose(linear.inputs[1].default_value, gamma, rel_tol=1e-5)))
+                ):
+                return True
+
+            #if not yp.use_linear_blending and ch.override and ch.override_type == 'IMAGE':
+            #    source_tree = get_channel_source_tree(ch)
+            #    linear = source_tree.nodes.get(ch.linear)
+            #    source = source_tree.nodes.get(ch.source)
+            #    if not source: continue
+
+            #    image = source.image
+            #    if not image: continue
+            #    if (
+            #        (is_image_source_srgb(image, source, root_ch) and not linear) or
+            #        (not is_image_source_srgb(image, source, root_ch) and linear)
+            #        ):
+            #        return True
+
+            if root_ch.type == 'NORMAL':
+                gamma_1 = get_layer_channel_normal_gamma_value(ch, layer, root_ch)
                 linear_1 = layer_tree.nodes.get(ch.linear_1)
-                source_1 = layer_tree.nodes.get(ch.source_1)
-                if not source_1: continue
-
-                image = source_1.image
-                if not image: continue
                 if (
-                    (is_image_source_srgb(image, source_1) and not linear_1) or
-                    (not is_image_source_srgb(image, source_1) and linear_1)
+                    (gamma_1 == 1.0 and linear_1) or
+                    (gamma_1 != 1.0 and (not linear_1 or not isclose(linear_1.inputs[1].default_value, gamma_1, rel_tol=1e-5)))
                     ):
                     return True
+
+            #if ch.override_1 and ch.override_1_type == 'IMAGE':
+            #    linear_1 = layer_tree.nodes.get(ch.linear_1)
+            #    source_1 = layer_tree.nodes.get(ch.source_1)
+            #    if not source_1: continue
+
+            #    image = source_1.image
+            #    if not image: continue
+            #    if (
+            #        (is_image_source_srgb(image, source_1) and not linear_1) or
+            #        (not is_image_source_srgb(image, source_1) and linear_1)
+            #        ):
+            #        return True
 
         for mask in layer.masks:
             if not get_mask_enabled(mask, layer): continue
@@ -5966,39 +6082,39 @@ def any_linear_images_problem(yp):
             ):
             return True
 
-        elif layer.type == 'IMAGE':
-            source = source_tree.nodes.get(layer.source)
-            if not source: continue
-            image = source.image
-            if not image: continue
+        #elif layer.type == 'IMAGE':
+        #    source = source_tree.nodes.get(layer.source)
+        #    if not source: continue
+        #    image = source.image
+        #    if not image: continue
 
-            if yp.use_linear_blending:
-                normal_ch = get_height_channel(layer)
-                normal_root_ch = get_root_height_channel(yp)
-                if normal_ch and get_channel_enabled(normal_ch, layer, normal_root_ch) and not normal_ch.override_1 and normal_ch.normal_map_type in {'NORMAL_MAP', 'BUMP_NORMAL_MAP'}:
-                    ch_linear = layer_tree.nodes.get(normal_ch.linear)
-                    #if ((is_image_source_srgb(image, source) and not ch_linear) or
-                    #    (not is_image_source_srgb(image, source) and ch_linear)
-                    #    ):
-                    # NOTE: Float image is pretended to be sRGB even if it's using linear colorspace
-                    if (image.is_float and ch_linear) or (not image.is_float and not ch_linear):
-                        return True
+        #    if yp.use_linear_blending:
+        #        normal_ch = get_height_channel(layer)
+        #        normal_root_ch = get_root_height_channel(yp)
+        #        if normal_ch and get_channel_enabled(normal_ch, layer, normal_root_ch) and not normal_ch.override_1 and normal_ch.normal_map_type in {'NORMAL_MAP', 'BUMP_NORMAL_MAP'}:
+        #            ch_linear = layer_tree.nodes.get(normal_ch.linear)
+        #            #if ((is_image_source_srgb(image, source) and not ch_linear) or
+        #            #    (not is_image_source_srgb(image, source) and ch_linear)
+        #            #    ):
+        #            # NOTE: Float image is pretended to be sRGB even if it's using linear colorspace
+        #            if (image.is_float and ch_linear) or (not image.is_float and not ch_linear):
+        #                return True
 
-                #if not image.is_float and ((is_image_source_srgb(image, source) and linear) or
-                #    (not is_image_source_srgb(image, source) and not linear)
-                #    ):
-                #    return True
+        #        #if not image.is_float and ((is_image_source_srgb(image, source) and linear) or
+        #        #    (not is_image_source_srgb(image, source) and not linear)
+        #        #    ):
+        #        #    return True
 
-                #if image.is_float and ((is_image_source_srgb(image, source) and not linear) or
-                #    (not is_image_source_srgb(image, source) and linear)
-                #    ):
-                #    return True
+        #        #if image.is_float and ((is_image_source_srgb(image, source) and not linear) or
+        #        #    (not is_image_source_srgb(image, source) and linear)
+        #        #    ):
+        #        #    return True
 
-            else:
-                if ((is_image_source_srgb(image, source) and not linear) or
-                    (not is_image_source_srgb(image, source) and linear)
-                    ):
-                    return True
+        #    else:
+        #        if ((is_image_source_srgb(image, source) and not linear) or
+        #            (not is_image_source_srgb(image, source) and linear)
+        #            ):
+        #            return True
 
     return False
 

--- a/common.py
+++ b/common.py
@@ -7099,7 +7099,7 @@ def set_image_pixels_to_linear(image, segment=None):
 
         image.pixels = pxs
 
-def multiply_image_rgb_by_alpha(image, segment=None):
+def multiply_image_rgb_by_alpha(image, segment=None, power=1):
 
     start_x = 0
     start_y = 0
@@ -7123,7 +7123,7 @@ def multiply_image_rgb_by_alpha(image, segment=None):
 
         # Do linear conversion
         for i in range(3):
-            pxs[start_y:start_y+height, start_x:start_x+width, i] *= pxs[start_y:start_y+height, start_x:start_x+width, 3]
+            pxs[start_y:start_y+height, start_x:start_x+width, i] *= pow(pxs[start_y:start_y+height, start_x:start_x+width, 3], power)
 
         image.pixels.foreach_set(pxs.ravel())
 
@@ -7137,9 +7137,12 @@ def multiply_image_rgb_by_alpha(image, segment=None):
                 source_offset_x = 4 * x
                 offset_x = 4 * (x + start_x)
                 for i in range(3):
-                    pxs[offset_y + offset_x + i] *= pxs[offset_y + offset_x + 3]
+                    pxs[offset_y + offset_x + i] *= pow(pxs[offset_y + offset_x + 3], power)
 
         image.pixels = pxs
+
+def safe_divider(divider):
+    return max(divider, 0.00001)
 
 def divide_image_rgb_by_alpha(image, segment=None):
 
@@ -7165,7 +7168,8 @@ def divide_image_rgb_by_alpha(image, segment=None):
 
         # Do linear conversion
         for i in range(3):
-            pxs[start_y:start_y+height, start_x:start_x+width, i] /= pxs[start_y:start_y+height, start_x:start_x+width, 3]
+            vecfunc = numpy.vectorize(safe_divider)
+            pxs[start_y:start_y+height, start_x:start_x+width, i] /= vecfunc(pxs[start_y:start_y+height, start_x:start_x+width, 3])
 
         image.pixels.foreach_set(pxs.ravel())
 
@@ -7179,7 +7183,7 @@ def divide_image_rgb_by_alpha(image, segment=None):
                 source_offset_x = 4 * x
                 offset_x = 4 * (x + start_x)
                 for i in range(3):
-                    pxs[offset_y + offset_x + i] /= max(pxs[offset_y + offset_x + 3], 0.0001)
+                    pxs[offset_y + offset_x + i] /= safe_divider(pxs[offset_y + offset_x + 3])
 
         image.pixels = pxs
 

--- a/common.py
+++ b/common.py
@@ -6026,9 +6026,17 @@ def get_layer_gamma_value(layer):
         image = source.image
         if image:
 
-            # Not using linear blending ironically meant all data should be in linear space
-            if not yp.use_linear_blending and is_image_source_srgb(image, source):
-                return 1.0 / GAMMA
+            # Should linearize srgb image and float image
+            if not yp.use_linear_blending:
+                if image.is_float:
+
+                    # Float image with srgb will use double gamma calculation
+                    if is_image_source_srgb(image, source):
+                        return pow(1.0 / GAMMA, 2.0)
+                    else: return 1.0 / GAMMA
+
+                elif is_image_source_srgb(image, source):
+                    return 1.0 / GAMMA
 
     return 1.0
 

--- a/common.py
+++ b/common.py
@@ -5882,8 +5882,8 @@ def is_image_source_srgb(image, source):
         return True
 
     # Generated float images is behaving like srgb for some reason in blender
-    if image.is_float and image.colorspace_settings.name != get_srgb_name() and image.source == 'GENERATED':
-        return True
+    #if image.is_float and image.colorspace_settings.name != get_srgb_name() and image.source == 'GENERATED':
+    #    return True
 
     return image.colorspace_settings.name == get_srgb_name()
 
@@ -7059,7 +7059,7 @@ def set_image_pixels_to_linear(image, segment=None):
         # Do linear conversion
         vecfunc = numpy.vectorize(srgb_to_linear_per_element)
         for i in range(3):
-            pxs[start_y:start_y+height, start_x:start_x+width, i] = vecfunc(pxs[start_y:start_y+height, start_x:start_x+width], i)
+            pxs[start_y:start_y+height, start_x:start_x+width, i] = vecfunc(pxs[start_y:start_y+height, start_x:start_x+width, i])
 
         image.pixels.foreach_set(pxs.ravel())
 

--- a/common.py
+++ b/common.py
@@ -897,6 +897,9 @@ def is_layer_collection_hidden(obj):
 def get_addon_filepath():
     return os.path.dirname(bpy.path.abspath(__file__)) + os.sep
 
+def isclose(a, b, rel_tol=1e-09, abs_tol=0.0):
+    return abs(a-b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
+
 def srgb_to_linear_per_element(e):
     if e <= 0.03928:
         return e / 12.92
@@ -5884,6 +5887,24 @@ def is_image_source_srgb(image, source, root_ch=None):
 
     return image.colorspace_settings.name == get_srgb_name()
 
+def get_layer_gamma_value(layer):
+    yp = layer.id_data.yp
+
+    if get_layer_enabled(layer) and layer.type == 'IMAGE':
+        source_tree = get_source_tree(layer)
+        source = source_tree.nodes.get(layer.source)
+        image = source.image
+        if image:
+            if image.is_float and image.source == 'GENERATED' and not is_image_source_srgb(image, source):
+                #return GAMMA if yp.use_linear_blending else 1.0 / GAMMA
+                return 1.0
+            elif not yp.use_linear_blending and is_image_source_srgb(image, source):
+                return 1.0 / GAMMA
+            elif yp.use_linear_blending and not is_image_source_srgb(image, source):
+                return GAMMA
+
+    return 1.0
+
 def any_linear_images_problem(yp):
     for layer in yp.layers:
         if not get_layer_enabled(layer): continue
@@ -5935,9 +5956,17 @@ def any_linear_images_problem(yp):
                     ):
                     return True
 
-        if layer.type == 'IMAGE':
-            source_tree = get_source_tree(layer)
-            linear = source_tree.nodes.get(layer.linear)
+        layer_gamma = get_layer_gamma_value(layer)
+        source_tree = get_source_tree(layer)
+        linear = source_tree.nodes.get(layer.linear)
+
+        if (
+            (layer_gamma == 1.0 and linear) or
+            (layer_gamma != 1.0 and (not linear or not isclose(linear.inputs[1].default_value, layer_gamma, rel_tol=1e-5)))
+            ):
+            return True
+
+        elif layer.type == 'IMAGE':
             source = source_tree.nodes.get(layer.source)
             if not source: continue
             image = source.image
@@ -5955,15 +5984,15 @@ def any_linear_images_problem(yp):
                     if (image.is_float and ch_linear) or (not image.is_float and not ch_linear):
                         return True
 
-                if not image.is_float and ((is_image_source_srgb(image, source) and linear) or
-                    (not is_image_source_srgb(image, source) and not linear)
-                    ):
-                    return True
+                #if not image.is_float and ((is_image_source_srgb(image, source) and linear) or
+                #    (not is_image_source_srgb(image, source) and not linear)
+                #    ):
+                #    return True
 
-                if image.is_float and ((is_image_source_srgb(image, source) and not linear) or
-                    (not is_image_source_srgb(image, source) and linear)
-                    ):
-                    return True
+                #if image.is_float and ((is_image_source_srgb(image, source) and not linear) or
+                #    (not is_image_source_srgb(image, source) and linear)
+                #    ):
+                #    return True
 
             else:
                 if ((is_image_source_srgb(image, source) and not linear) or
@@ -6895,6 +6924,84 @@ def set_image_pixels(image, color, segment=None):
                     pxs[offset_y + offset_x + i] = color[i]
 
         image.pixels = pxs
+
+def set_image_pixels_to_srgb(image, segment=None):
+
+    start_x = 0
+    start_y = 0
+
+    width = image.size[0]
+    height = image.size[1]
+
+    if segment:
+        start_x = width * segment.tile_x
+        start_y = height * segment.tile_y
+
+        width = segment.width
+        height = segment.height
+
+    #if is_bl_newer_than(2, 83):
+    #    pxs = numpy.empty(shape=image.size[0]*image.size[1]*4, dtype=numpy.float32)
+    #    image.pixels.foreach_get(pxs)
+
+    #    # Set array to 3d
+    #    pxs.shape = (-1, image.size[0], 4)
+
+    #    pxs[start_y:start_y+height, start_x:start_x+width] = linear_to_srgb_per_element(pxs[start_y:start_y+height, start_x:start_x+width])
+    #    image.pixels.foreach_set(pxs.ravel())
+
+    #else:
+    pxs = list(image.pixels)
+
+    for y in range(height):
+        source_offset_y = width * 4 * y
+        offset_y = image.size[0] * 4 * (y + start_y)
+        for x in range(width):
+            source_offset_x = 4 * x
+            offset_x = 4 * (x + start_x)
+            for i in range(4):
+                pxs[offset_y + offset_x + i] = linear_to_srgb_per_element(pxs[offset_y + offset_x + i])
+
+    image.pixels = pxs
+
+def set_image_pixels_to_linear(image, segment=None):
+
+    start_x = 0
+    start_y = 0
+
+    width = image.size[0]
+    height = image.size[1]
+
+    if segment:
+        start_x = width * segment.tile_x
+        start_y = height * segment.tile_y
+
+        width = segment.width
+        height = segment.height
+
+    #if is_bl_newer_than(2, 83):
+    #    pxs = numpy.empty(shape=image.size[0]*image.size[1]*4, dtype=numpy.float32)
+    #    image.pixels.foreach_get(pxs)
+
+    #    # Set array to 3d
+    #    pxs.shape = (-1, image.size[0], 4)
+
+    #    pxs[start_y:start_y+height, start_x:start_x+width] = srgb_to_linear_per_element(pxs[start_y:start_y+height, start_x:start_x+width])
+    #    image.pixels.foreach_set(pxs.ravel())
+
+    #else:
+    pxs = list(image.pixels)
+
+    for y in range(height):
+        source_offset_y = width * 4 * y
+        offset_y = image.size[0] * 4 * (y + start_y)
+        for x in range(width):
+            source_offset_x = 4 * x
+            offset_x = 4 * (x + start_x)
+            for i in range(4):
+                pxs[offset_y + offset_x + i] = srgb_to_linear_per_element(pxs[offset_y + offset_x + i])
+
+    image.pixels = pxs
 
 def is_image_filepath_unique(filepath, check_disk=True):
     abspath = bpy.path.abspath(filepath)

--- a/common.py
+++ b/common.py
@@ -730,6 +730,20 @@ def get_noncolor_name():
 
     return 'Non-Color'
 
+def get_linear_color_name():
+    names = bpy.types.Image.bl_rna.properties['colorspace_settings'].fixed_type.properties['name'].enum_items.keys()
+    linear_name = 'Linear Rec.709' if is_bl_newer_than(4) else 'Linear'
+
+    if linear_name not in names:
+
+        # Try to get 'linear' in a name
+        for name in names:
+            if 'linear' in name.lower():
+                linear_name = name
+                break
+
+    return linear_name
+
 def remove_datablock(blocks, block, user=None, user_prop=''):
     if is_bl_newer_than(2, 79):
         blocks.remove(block)
@@ -7118,7 +7132,48 @@ def multiply_image_rgb_by_alpha(image, segment=None):
                     pxs[offset_y + offset_x + i] *= pxs[offset_y + offset_x + 3]
 
         image.pixels = pxs
-    pass
+
+def divide_image_rgb_by_alpha(image, segment=None):
+
+    start_x = 0
+    start_y = 0
+
+    width = image.size[0]
+    height = image.size[1]
+
+    if segment:
+        start_x = width * segment.tile_x
+        start_y = height * segment.tile_y
+
+        width = segment.width
+        height = segment.height
+
+    if is_bl_newer_than(2, 83):
+        pxs = numpy.empty(shape=image.size[0]*image.size[1]*4, dtype=numpy.float32)
+        image.pixels.foreach_get(pxs)
+
+        # Set array to 3d
+        pxs.shape = (-1, image.size[0], 4)
+
+        # Do linear conversion
+        for i in range(3):
+            pxs[start_y:start_y+height, start_x:start_x+width, i] /= pxs[start_y:start_y+height, start_x:start_x+width, 3]
+
+        image.pixels.foreach_set(pxs.ravel())
+
+    else:
+        pxs = list(image.pixels)
+
+        for y in range(height):
+            source_offset_y = width * 4 * y
+            offset_y = image.size[0] * 4 * (y + start_y)
+            for x in range(width):
+                source_offset_x = 4 * x
+                offset_x = 4 * (x + start_x)
+                for i in range(3):
+                    pxs[offset_y + offset_x + i] /= max(pxs[offset_y + offset_x + 3], 0.0001)
+
+        image.pixels = pxs
 
 def is_image_filepath_unique(filepath, check_disk=True):
     abspath = bpy.path.abspath(filepath)

--- a/common.py
+++ b/common.py
@@ -6979,6 +6979,20 @@ def copy_image_pixels(src, dest, segment=None, segment_src=None):
 
         dest.pixels = target_pxs
 
+def copy_image_pixels_with_conversion(src, dest, segment=None, segment_src=None):
+
+    copy_image_pixels(src, dest, segment, segment_src)
+
+    # Convert image colors after copying if destination image and source image has different bit depth
+    if dest.is_float and not src.is_float:
+        # Byte to float
+        set_image_pixels_to_linear(dest, power=1)
+        multiply_image_rgb_by_alpha(dest, power=1)
+    else:
+        # Float to byte
+        divide_image_rgb_by_alpha(dest)
+        set_image_pixels_to_srgb(dest)
+
 def set_image_pixels(image, color, segment=None):
 
     start_x = 0

--- a/image_ops.py
+++ b/image_ops.py
@@ -141,9 +141,7 @@ def pack_image(image, reload_float=False, do_hack=True):
         preserve_float_color_hack_before_packing(image)
 
     if is_bl_newer_than(2, 80):
-        if image.source == 'TILED':
-            UDIM.pack_udim(image)
-        else: image.pack()
+        image.pack()
     else:
         if image.is_float:
             pack_float_image_27x(image)
@@ -1336,7 +1334,7 @@ def toggle_image_bit_depth(image, no_copy=False, force_srgb=False, convert_color
             else: copy_image_pixels(image, new_image)
 
     # Pack image
-    if image.packed_file or (image.source == 'GENERATED' and image.filepath == ''):
+    if image.source != 'TILED' and image.packed_file:
         pack_image(new_image, reload_float=True)
 
     # Replace image

--- a/image_ops.py
+++ b/image_ops.py
@@ -1285,20 +1285,15 @@ def toggle_image_bit_depth(image, no_copy=False, force_srgb=False):
             copy_image_pixels(image, new_image)
 
             # HACK: Need to do some image operations to make the result correct
-            if image.packed_file:
-
-                if new_image.is_float:
-                    set_image_pixels_to_linear(new_image)
-                    multiply_image_rgb_by_alpha(new_image)
-                    set_image_pixels_to_linear(new_image)
-                else:
-                    divide_image_rgb_by_alpha(new_image)
-                    set_image_pixels_to_srgb(new_image)
+            #if image.packed_file:
+            UDIM.preserve_copied_image_color_hack(new_image, image)
 
     # Pack image
     if image.packed_file and image.source != 'TILED':
         pack_image(new_image)
 
+    # Set colorspace and alpha mode
+    if not new_image.is_dirty:
         if new_image.is_float:
             # Float image will use linear color and premultiplied alpha
             new_image.colorspace_settings.name = get_linear_color_name()

--- a/image_ops.py
+++ b/image_ops.py
@@ -1278,9 +1278,7 @@ class YSavePackAll(bpy.types.Operator):
 
 def toggle_image_bit_depth(image, no_copy=False, force_srgb=False, convert_colorspace=False):
 
-    if image.yua.is_udim_atlas or image.yia.is_image_atlas:
-        self.report({'ERROR'}, 'Cannot convert image atlas segment to different bit depth!')
-        return {'CANCELLED'}
+    if image.yua.is_udim_atlas or image.yia.is_image_atlas: return
 
     # Create new image based on original image but with different bit depth
     if image.source == 'TILED':
@@ -1373,6 +1371,11 @@ class YConvertImageBitDepth(bpy.types.Operator):
             return {'CANCELLED'}
 
         image = context.image
+
+        if image.yua.is_udim_atlas or image.yia.is_image_atlas:
+            self.report({'ERROR'}, 'Cannot convert image atlas segment to different bit depth!')
+            return {'CANCELLED'}
+
         toggle_image_bit_depth(image, convert_colorspace=convert_colorspace)
 
         # Update image editor by setting active layer index

--- a/subtree.py
+++ b/subtree.py
@@ -2476,94 +2476,116 @@ def check_extra_alpha(layer, need_reconnect=False):
 def check_layer_channel_linear_node(ch, layer=None, root_ch=None, reconnect=False):
 
     yp = ch.id_data.yp
-
-    if not layer or not root_ch:
-        match = re.match(r'yp\.layers\[(\d+)\]\.channels\[(\d+)\]', ch.path_from_id())
-        layer = yp.layers[int(match.group(1))]
-        root_ch = yp.channels[int(match.group(2))]
+    if not layer or not root_ch: layer, root_ch = get_layer_and_root_ch_from_layer_ch(ch)
 
     source_tree = get_channel_source_tree(ch, layer)
 
-    image = None
-    source = None
-    if ch.override and ch.override_type == 'IMAGE':
-        source = source_tree.nodes.get(ch.source)
-        if source: image = source.image
-    elif layer.type == 'IMAGE':
-        source = get_layer_source(layer)
-        if source: image = source.image
+    gamma = get_layer_channel_gamma_value(ch, layer, root_ch)
 
-    channel_enabled = get_channel_enabled(ch, layer, root_ch)
-
-    if channel_enabled and ((
-            not yp.use_linear_blending 
-            and ch.override 
-            and (
-                (image and is_image_source_srgb(image, source, root_ch)) or 
-                (
-                    ch.override_type not in {'IMAGE'}
-                    and root_ch.type != 'NORMAL' 
-                    and root_ch.colorspace == 'SRGB' 
-                ))
-        ) or (
-            not yp.use_linear_blending
-            and not ch.override 
-            and root_ch.type != 'NORMAL' 
-            and root_ch.colorspace == 'SRGB' 
-            and (
-                (not ch.gamma_space and ch.layer_input == 'RGB' and layer.type not in {'IMAGE', 'BACKGROUND', 'GROUP'})
-                or (layer.type == 'IMAGE' and image.is_float and image.colorspace_settings.name != get_srgb_name()) # Float images need to converted to linear for some reason in Blender
-                )
-        ) or (
-            yp.use_linear_blending
-            and not ch.override_1
-            and root_ch.type == 'NORMAL'
-            and ch.normal_map_type in {'NORMAL_MAP', 'BUMP_NORMAL_MAP'}
-            and source and source.image and not source.image.is_float #and is_image_source_srgb(image, source) # NOTE: No need for channel linear if the image is float
-        )):
+    if gamma != 1.0:
+        # Create linear node
         if root_ch.type == 'VALUE':
             linear = replace_new_node(source_tree, ch, 'linear', 'ShaderNodeMath', 'Linear')
             linear.operation = 'POWER'
         else: linear = replace_new_node(source_tree, ch, 'linear', 'ShaderNodeGamma', 'Linear')
-
-        linear.inputs[1].default_value = 1.0 / GAMMA
-
-    elif channel_enabled and (
-            yp.use_linear_blending
-            and root_ch.type != 'NORMAL' 
-            and root_ch.colorspace == 'SRGB' 
-            and (
-                (ch.gamma_space and ch.layer_input == 'RGB' and layer.type not in {'IMAGE', 'BACKGROUND', 'GROUP'})
-                #or (layer.type == 'IMAGE' and image.is_float and image.colorspace_settings.name == get_srgb_name()) 
-                )
-        ):
-        if root_ch.type == 'VALUE':
-            linear = replace_new_node(source_tree, ch, 'linear', 'ShaderNodeMath', 'Linear')
-            linear.operation = 'POWER'
-        else: linear = replace_new_node(source_tree, ch, 'linear', 'ShaderNodeGamma', 'Linear')
-
-        linear.inputs[1].default_value = GAMMA
-
+        linear.inputs[1].default_value = gamma
     else:
+        # Delete linear node
         remove_node(source_tree, ch, 'linear')
 
-    image_1 = None
-    layer_tree = get_tree(layer)
-    if ch.override_1 and ch.override_1_type == 'IMAGE':
-        source_1 = layer_tree.nodes.get(ch.source_1)
-        if source_1: image_1 = source_1.image
+    #image = None
+    #source = None
+    #if ch.override and ch.override_type == 'IMAGE':
+    #    source = source_tree.nodes.get(ch.source)
+    #    if source: image = source.image
+    #elif layer.type == 'IMAGE':
+    #    source = get_layer_source(layer)
+    #    if source: image = source.image
 
-    if channel_enabled and ch.override_1 and image_1 and is_image_source_srgb(image_1, source_1):
-        linear_1 = replace_new_node(layer_tree, ch, 'linear_1', 'ShaderNodeGamma', 'Linear 1')
-        linear_1.inputs[1].default_value = 1.0 / GAMMA
-    else:
-        remove_node(layer_tree, ch, 'linear_1')
+    #channel_enabled = get_channel_enabled(ch, layer, root_ch)
+
+    #if channel_enabled and ((
+    #        not yp.use_linear_blending 
+    #        and ch.override 
+    #        and (
+    #            (image and is_image_source_srgb(image, source, root_ch)) or 
+    #            (
+    #                ch.override_type not in {'IMAGE'}
+    #                and root_ch.type != 'NORMAL' 
+    #                and root_ch.colorspace == 'SRGB' 
+    #            ))
+    #    ) or (
+    #        not yp.use_linear_blending
+    #        and not ch.override 
+    #        and root_ch.type != 'NORMAL' 
+    #        and root_ch.colorspace == 'SRGB' 
+    #        and (
+    #            (not ch.gamma_space and ch.layer_input == 'RGB' and layer.type not in {'IMAGE', 'BACKGROUND', 'GROUP'})
+    #            or (layer.type == 'IMAGE' and image.is_float and image.colorspace_settings.name != get_srgb_name()) # Float images need to converted to linear for some reason in Blender
+    #            )
+    #    ) or (
+    #        yp.use_linear_blending
+    #        and not ch.override_1
+    #        and root_ch.type == 'NORMAL'
+    #        and ch.normal_map_type in {'NORMAL_MAP', 'BUMP_NORMAL_MAP'}
+    #        and source and source.image and not source.image.is_float #and is_image_source_srgb(image, source) # NOTE: No need for channel linear if the image is float
+    #    )):
+    #    if root_ch.type == 'VALUE':
+    #        linear = replace_new_node(source_tree, ch, 'linear', 'ShaderNodeMath', 'Linear')
+    #        linear.operation = 'POWER'
+    #    else: linear = replace_new_node(source_tree, ch, 'linear', 'ShaderNodeGamma', 'Linear')
+
+    #    linear.inputs[1].default_value = 1.0 / GAMMA
+
+    #elif channel_enabled and (
+    #        yp.use_linear_blending
+    #        and root_ch.type != 'NORMAL' 
+    #        and root_ch.colorspace == 'SRGB' 
+    #        and (
+    #            (ch.gamma_space and ch.layer_input == 'RGB' and layer.type not in {'IMAGE', 'BACKGROUND', 'GROUP'})
+    #            #or (layer.type == 'IMAGE' and image.is_float and image.colorspace_settings.name == get_srgb_name()) 
+    #            )
+    #    ):
+    #    if root_ch.type == 'VALUE':
+    #        linear = replace_new_node(source_tree, ch, 'linear', 'ShaderNodeMath', 'Linear')
+    #        linear.operation = 'POWER'
+    #    else: linear = replace_new_node(source_tree, ch, 'linear', 'ShaderNodeGamma', 'Linear')
+
+    #    linear.inputs[1].default_value = GAMMA
+
+    #else:
+    #    remove_node(source_tree, ch, 'linear')
+
+    if root_ch.type == 'NORMAL':
+        gamma_1 = get_layer_channel_normal_gamma_value(ch, layer, root_ch)
+        if gamma_1 != 1.0:
+            # Create linear node
+            layer_tree = get_tree(layer)
+            linear_1 = replace_new_node(layer_tree, ch, 'linear_1', 'ShaderNodeGamma', 'Linear 1')
+            linear_1.inputs[1].default_value = gamma_1
+        else:
+            # Delete linear node
+            remove_node(source_tree, ch, 'linear_1')
+
+        #channel_enabled = get_channel_enabled(ch, layer, root_ch)
+
+        #image_1 = None
+        #layer_tree = get_tree(layer)
+        #if ch.override_1 and ch.override_1_type == 'IMAGE':
+        #    source_1 = layer_tree.nodes.get(ch.source_1)
+        #    if source_1: image_1 = source_1.image
+
+        #if channel_enabled and ch.override_1 and image_1 and is_image_source_srgb(image_1, source_1):
+        #    linear_1 = replace_new_node(layer_tree, ch, 'linear_1', 'ShaderNodeGamma', 'Linear 1')
+        #    linear_1.inputs[1].default_value = 1.0 / GAMMA
+        #else:
+        #    remove_node(layer_tree, ch, 'linear_1')
 
     if reconnect:
         reconnect_layer_nodes(layer)
         rearrange_layer_nodes(layer)
 
-    return image
+    #return image
 
 def check_layer_image_linear_node(layer, source_tree=None):
 
@@ -2571,12 +2593,12 @@ def check_layer_image_linear_node(layer, source_tree=None):
 
     if not source_tree: source_tree = get_source_tree(layer)
 
-    layer_gamma = get_layer_gamma_value(layer)
+    gamma = get_layer_gamma_value(layer)
 
-    if layer_gamma != 1.0:
+    if gamma != 1.0:
         # Create linear node
         linear = check_new_node(source_tree, layer, 'linear', 'ShaderNodeGamma', 'Linear')
-        linear.inputs[1].default_value = layer_gamma
+        linear.inputs[1].default_value = gamma
     else:
         # Delete linear node
         remove_node(source_tree, layer, 'linear')
@@ -2635,18 +2657,19 @@ def check_mask_image_linear_node(mask, mask_tree=None):
 def check_yp_linear_nodes(yp, specific_layer=None, reconnect=True):
     for layer in yp.layers:
         if specific_layer and layer != specific_layer: continue
-        image_found = False
+        #image_found = False
         if layer.type == 'IMAGE':
             check_layer_image_linear_node(layer)
-            image_found = True
+            #image_found = True
         for ch in layer.channels:
             #if ch.override_type == 'IMAGE' or ch.override_1_type == 'IMAGE':
             if check_layer_channel_linear_node(ch):
-                image_found = True
+                pass
+                #image_found = True
         for mask in layer.masks:
             if mask.type == 'IMAGE':
                 check_mask_image_linear_node(mask)
-                image_found = True
+                #image_found = True
 
         #if image_found and reconnect:
         if reconnect:

--- a/subtree.py
+++ b/subtree.py
@@ -2571,31 +2571,43 @@ def check_layer_image_linear_node(layer, source_tree=None):
 
     if not source_tree: source_tree = get_source_tree(layer)
 
-    if get_layer_enabled(layer) and layer.type == 'IMAGE':
+    layer_gamma = get_layer_gamma_value(layer)
 
-        source = source_tree.nodes.get(layer.source)
-        image = source.image
-        if not image: return
+    if layer_gamma != 1.0:
+        # Create linear node
+        linear = check_new_node(source_tree, layer, 'linear', 'ShaderNodeGamma', 'Linear')
+        linear.inputs[1].default_value = layer_gamma
+    else:
+        # Delete linear node
+        remove_node(source_tree, layer, 'linear')
 
-        # Create linear if image type is srgb or float image
-        if is_image_source_srgb(image, source) and (not yp.use_linear_blending or (yp.use_linear_blending and image.is_float)):
-            linear = source_tree.nodes.get(layer.linear)
-            if not linear:
-                linear = new_node(source_tree, layer, 'linear', 'ShaderNodeGamma', 'Linear')
-                linear.inputs[1].default_value = 1.0 / GAMMA
+    #if get_layer_enabled(layer) and layer.type == 'IMAGE':
 
-            return
+    #    source = source_tree.nodes.get(layer.source)
+    #    image = source.image
+    #    if not image: return
 
-        elif yp.use_linear_blending and not image.is_float and not is_image_source_srgb(image, source):
-            linear = source_tree.nodes.get(layer.linear)
-            if not linear:
-                linear = new_node(source_tree, layer, 'linear', 'ShaderNodeGamma', 'Linear')
-                linear.inputs[1].default_value = GAMMA
+    #    # Create linear if image type is srgb or float image
+    #    #if is_image_source_srgb(image, source) and (not yp.use_linear_blending or (yp.use_linear_blending and image.is_float)):
+    #    if is_image_source_srgb(image, source) and not yp.use_linear_blending:
+    #        linear = source_tree.nodes.get(layer.linear)
+    #        if not linear:
+    #            linear = new_node(source_tree, layer, 'linear', 'ShaderNodeGamma', 'Linear')
+    #            linear.inputs[1].default_value = 1.0 / GAMMA
 
-            return
+    #        return
 
-    # Delete linear
-    remove_node(source_tree, layer, 'linear')
+    #    #elif yp.use_linear_blending and not image.is_float and not is_image_source_srgb(image, source):
+    #    elif yp.use_linear_blending and not is_image_source_srgb(image, source):
+    #        linear = source_tree.nodes.get(layer.linear)
+    #        if not linear:
+    #            linear = new_node(source_tree, layer, 'linear', 'ShaderNodeGamma', 'Linear')
+    #            linear.inputs[1].default_value = GAMMA
+
+    #        return
+
+    ## Delete linear
+    #remove_node(source_tree, layer, 'linear')
 
 def check_mask_image_linear_node(mask, mask_tree=None):
 

--- a/subtree.py
+++ b/subtree.py
@@ -2635,24 +2635,34 @@ def check_mask_image_linear_node(mask, mask_tree=None):
 
     if not mask_tree: mask_tree = get_mask_tree(mask)
 
-    if get_mask_enabled(mask) and mask.type == 'IMAGE':
+    gamma = get_layer_mask_gamma_value(mask, mask_tree)
 
-        source = mask_tree.nodes.get(mask.source)
-        image = source.image
+    if gamma != 1.0:
+        # Create linear node
+        linear = check_new_node(mask_tree, mask, 'linear', 'ShaderNodeGamma', 'Linear')
+        linear.inputs[1].default_value = gamma
+    else:
+        # Delete linear node
+        remove_node(mask_tree, mask, 'linear')
 
-        if not image: return
+    #if get_mask_enabled(mask) and mask.type == 'IMAGE':
 
-        # Create linear if image type is srgb
-        if is_image_source_srgb(image, source):
-            linear = mask_tree.nodes.get(mask.linear)
-            if not linear:
-                linear = new_node(mask_tree, mask, 'linear', 'ShaderNodeGamma', 'Linear')
-                linear.inputs[1].default_value = 1.0 / GAMMA
+    #    source = mask_tree.nodes.get(mask.source)
+    #    image = source.image
 
-            return
+    #    if not image: return
 
-    # Delete linear
-    remove_node(mask_tree, mask, 'linear')
+    #    # Create linear if image type is srgb
+    #    if is_image_source_srgb(image, source):
+    #        linear = mask_tree.nodes.get(mask.linear)
+    #        if not linear:
+    #            linear = new_node(mask_tree, mask, 'linear', 'ShaderNodeGamma', 'Linear')
+    #            linear.inputs[1].default_value = 1.0 / GAMMA
+
+    #        return
+
+    ## Delete linear
+    #remove_node(mask_tree, mask, 'linear')
 
 def check_yp_linear_nodes(yp, specific_layer=None, reconnect=True):
     for layer in yp.layers:

--- a/subtree.py
+++ b/subtree.py
@@ -2493,68 +2493,6 @@ def check_layer_channel_linear_node(ch, layer=None, root_ch=None, reconnect=Fals
         # Delete linear node
         remove_node(source_tree, ch, 'linear')
 
-    #image = None
-    #source = None
-    #if ch.override and ch.override_type == 'IMAGE':
-    #    source = source_tree.nodes.get(ch.source)
-    #    if source: image = source.image
-    #elif layer.type == 'IMAGE':
-    #    source = get_layer_source(layer)
-    #    if source: image = source.image
-
-    #channel_enabled = get_channel_enabled(ch, layer, root_ch)
-
-    #if channel_enabled and ((
-    #        not yp.use_linear_blending 
-    #        and ch.override 
-    #        and (
-    #            (image and is_image_source_srgb(image, source, root_ch)) or 
-    #            (
-    #                ch.override_type not in {'IMAGE'}
-    #                and root_ch.type != 'NORMAL' 
-    #                and root_ch.colorspace == 'SRGB' 
-    #            ))
-    #    ) or (
-    #        not yp.use_linear_blending
-    #        and not ch.override 
-    #        and root_ch.type != 'NORMAL' 
-    #        and root_ch.colorspace == 'SRGB' 
-    #        and (
-    #            (not ch.gamma_space and ch.layer_input == 'RGB' and layer.type not in {'IMAGE', 'BACKGROUND', 'GROUP'})
-    #            or (layer.type == 'IMAGE' and image.is_float and image.colorspace_settings.name != get_srgb_name()) # Float images need to converted to linear for some reason in Blender
-    #            )
-    #    ) or (
-    #        yp.use_linear_blending
-    #        and not ch.override_1
-    #        and root_ch.type == 'NORMAL'
-    #        and ch.normal_map_type in {'NORMAL_MAP', 'BUMP_NORMAL_MAP'}
-    #        and source and source.image and not source.image.is_float #and is_image_source_srgb(image, source) # NOTE: No need for channel linear if the image is float
-    #    )):
-    #    if root_ch.type == 'VALUE':
-    #        linear = replace_new_node(source_tree, ch, 'linear', 'ShaderNodeMath', 'Linear')
-    #        linear.operation = 'POWER'
-    #    else: linear = replace_new_node(source_tree, ch, 'linear', 'ShaderNodeGamma', 'Linear')
-
-    #    linear.inputs[1].default_value = 1.0 / GAMMA
-
-    #elif channel_enabled and (
-    #        yp.use_linear_blending
-    #        and root_ch.type != 'NORMAL' 
-    #        and root_ch.colorspace == 'SRGB' 
-    #        and (
-    #            (ch.gamma_space and ch.layer_input == 'RGB' and layer.type not in {'IMAGE', 'BACKGROUND', 'GROUP'})
-    #            #or (layer.type == 'IMAGE' and image.is_float and image.colorspace_settings.name == get_srgb_name()) 
-    #            )
-    #    ):
-    #    if root_ch.type == 'VALUE':
-    #        linear = replace_new_node(source_tree, ch, 'linear', 'ShaderNodeMath', 'Linear')
-    #        linear.operation = 'POWER'
-    #    else: linear = replace_new_node(source_tree, ch, 'linear', 'ShaderNodeGamma', 'Linear')
-
-    #    linear.inputs[1].default_value = GAMMA
-
-    #else:
-    #    remove_node(source_tree, ch, 'linear')
 
     if root_ch.type == 'NORMAL':
         gamma_1 = get_layer_channel_normal_gamma_value(ch, layer, root_ch)
@@ -2567,25 +2505,9 @@ def check_layer_channel_linear_node(ch, layer=None, root_ch=None, reconnect=Fals
             # Delete linear node
             remove_node(source_tree, ch, 'linear_1')
 
-        #channel_enabled = get_channel_enabled(ch, layer, root_ch)
-
-        #image_1 = None
-        #layer_tree = get_tree(layer)
-        #if ch.override_1 and ch.override_1_type == 'IMAGE':
-        #    source_1 = layer_tree.nodes.get(ch.source_1)
-        #    if source_1: image_1 = source_1.image
-
-        #if channel_enabled and ch.override_1 and image_1 and is_image_source_srgb(image_1, source_1):
-        #    linear_1 = replace_new_node(layer_tree, ch, 'linear_1', 'ShaderNodeGamma', 'Linear 1')
-        #    linear_1.inputs[1].default_value = 1.0 / GAMMA
-        #else:
-        #    remove_node(layer_tree, ch, 'linear_1')
-
     if reconnect:
         reconnect_layer_nodes(layer)
         rearrange_layer_nodes(layer)
-
-    #return image
 
 def check_layer_image_linear_node(layer, source_tree=None):
 
@@ -2603,34 +2525,6 @@ def check_layer_image_linear_node(layer, source_tree=None):
         # Delete linear node
         remove_node(source_tree, layer, 'linear')
 
-    #if get_layer_enabled(layer) and layer.type == 'IMAGE':
-
-    #    source = source_tree.nodes.get(layer.source)
-    #    image = source.image
-    #    if not image: return
-
-    #    # Create linear if image type is srgb or float image
-    #    #if is_image_source_srgb(image, source) and (not yp.use_linear_blending or (yp.use_linear_blending and image.is_float)):
-    #    if is_image_source_srgb(image, source) and not yp.use_linear_blending:
-    #        linear = source_tree.nodes.get(layer.linear)
-    #        if not linear:
-    #            linear = new_node(source_tree, layer, 'linear', 'ShaderNodeGamma', 'Linear')
-    #            linear.inputs[1].default_value = 1.0 / GAMMA
-
-    #        return
-
-    #    #elif yp.use_linear_blending and not image.is_float and not is_image_source_srgb(image, source):
-    #    elif yp.use_linear_blending and not is_image_source_srgb(image, source):
-    #        linear = source_tree.nodes.get(layer.linear)
-    #        if not linear:
-    #            linear = new_node(source_tree, layer, 'linear', 'ShaderNodeGamma', 'Linear')
-    #            linear.inputs[1].default_value = GAMMA
-
-    #        return
-
-    ## Delete linear
-    #remove_node(source_tree, layer, 'linear')
-
 def check_mask_image_linear_node(mask, mask_tree=None):
 
     if not mask_tree: mask_tree = get_mask_tree(mask)
@@ -2645,43 +2539,17 @@ def check_mask_image_linear_node(mask, mask_tree=None):
         # Delete linear node
         remove_node(mask_tree, mask, 'linear')
 
-    #if get_mask_enabled(mask) and mask.type == 'IMAGE':
-
-    #    source = mask_tree.nodes.get(mask.source)
-    #    image = source.image
-
-    #    if not image: return
-
-    #    # Create linear if image type is srgb
-    #    if is_image_source_srgb(image, source):
-    #        linear = mask_tree.nodes.get(mask.linear)
-    #        if not linear:
-    #            linear = new_node(mask_tree, mask, 'linear', 'ShaderNodeGamma', 'Linear')
-    #            linear.inputs[1].default_value = 1.0 / GAMMA
-
-    #        return
-
-    ## Delete linear
-    #remove_node(mask_tree, mask, 'linear')
-
 def check_yp_linear_nodes(yp, specific_layer=None, reconnect=True):
     for layer in yp.layers:
         if specific_layer and layer != specific_layer: continue
-        #image_found = False
         if layer.type == 'IMAGE':
             check_layer_image_linear_node(layer)
-            #image_found = True
         for ch in layer.channels:
-            #if ch.override_type == 'IMAGE' or ch.override_1_type == 'IMAGE':
-            if check_layer_channel_linear_node(ch):
-                pass
-                #image_found = True
+            check_layer_channel_linear_node(ch)
         for mask in layer.masks:
             if mask.type == 'IMAGE':
                 check_mask_image_linear_node(mask)
-                #image_found = True
 
-        #if image_found and reconnect:
         if reconnect:
             reconnect_layer_nodes(layer)
             rearrange_layer_nodes(layer)

--- a/versioning.py
+++ b/versioning.py
@@ -853,6 +853,15 @@ def update_yp_tree(tree):
     if version_tuple(yp.version) < (2, 2, 2):
         update_bake_info_baked_entity_props(yp)
 
+    # Version 2.2.3 use premultiplied alpha for float image atlas
+    if version_tuple(yp.version) < (2, 2, 3):
+        for image in bpy.data.images:
+            if not image.is_float: continue
+            if image.yia.is_image_atlas or image.yua.is_udim_atlas:
+                if not image.is_dirty and image.alpha_mode != 'PREMUL':
+                    image.alpha_mode = 'PREMUL'
+                    print("INFO: Image atlas named '"+image.name+"' is now using premultiplied alpha!")
+
     # SECTION II: Updates based on the blender version
 
     # Blender 2.92 can finally access it's vertex color alpha


### PR DESCRIPTION
There are a few changes in how the gamma pipeline works on this PR:
- New standardized function to get how much the gamma value will be used in the layer/ layer channel
- Float image will be used as is if linear color blending is enabled (except if it will be used for a normal map)
- New float image layer will use premultiplied alpha by default because it has no alpha artifacts