### PR TITLE
Channel subsocket connection fix. Fix #307

### DIFF
--- a/Bake.py
+++ b/Bake.py
@@ -3594,19 +3594,27 @@ def check_displacement_node(mat, node, set_one=False, unset_one=False, set_outsi
                 create_link(mat.node_tree, height_outp, disp.inputs['Height'])
                 create_link(mat.node_tree, max_height_outp, disp.inputs['Scale'])
 
-    if disp and unset_one:
-        height_inp = node.inputs.get(height_ch.name + io_suffix['HEIGHT'])
-        max_height_inp = node.inputs.get(height_ch.name + io_suffix['MAX_HEIGHT'])
+    if unset_one:
+        if disp:
+            height_inp = node.inputs.get(height_ch.name + io_suffix['HEIGHT'])
+            max_height_inp = node.inputs.get(height_ch.name + io_suffix['MAX_HEIGHT'])
 
-        if height_inp and len(height_inp.links) > 0:
-            soc = height_inp.links[0].from_socket
-            create_link(mat.node_tree, soc, disp.inputs['Height'])
-            break_input_link(mat.node_tree, height_inp)
+            if height_inp and len(height_inp.links) > 0:
+                soc = height_inp.links[0].from_socket
+                create_link(mat.node_tree, soc, disp.inputs['Height'])
+                break_input_link(mat.node_tree, height_inp)
 
-        if max_height_inp and len(max_height_inp.links) > 0:
-            soc = max_height_inp.links[0].from_socket
-            create_link(mat.node_tree, soc, disp.inputs['Scale'])
-            break_input_link(mat.node_tree, max_height_inp)
+            if max_height_inp and len(max_height_inp.links) > 0:
+                soc = max_height_inp.links[0].from_socket
+                create_link(mat.node_tree, soc, disp.inputs['Scale'])
+                break_input_link(mat.node_tree, max_height_inp)
+
+        if vdisp:
+            vdisp_inp = node.inputs.get(height_ch.name + io_suffix['VDISP'])
+            if vdisp_inp and len(vdisp_inp.links) > 0:
+                soc = vdisp_inp.links[0].from_socket
+                create_link(mat.node_tree, soc, vdisp.inputs['Vector'])
+                break_input_link(mat.node_tree, height_inp)
 
     return disp
 

--- a/Root.py
+++ b/Root.py
@@ -3247,7 +3247,7 @@ def update_channel_alpha(self, context):
 
         # Set node default_value
         node = get_active_ypaint_node()
-        node.inputs[alpha_name].default_value = 0.0
+        node.inputs[alpha_name].default_value = self.ori_alpha_value
 
         alpha_connected = False
 
@@ -3820,6 +3820,10 @@ class YPaintChannel(bpy.types.PropertyGroup):
     ori_to : CollectionProperty(type=YNodeConnections)
     ori_height_to : CollectionProperty(type=YNodeConnections)
     ori_max_height_to : CollectionProperty(type=YNodeConnections)
+
+    # Default value related
+    ori_alpha_value : FloatProperty(default=0.0)
+    ori_max_height_value : FloatProperty(default=0.1)
 
 class YPaintUV(bpy.types.PropertyGroup):
     name : StringProperty(default='')

--- a/bake_common.py
+++ b/bake_common.py
@@ -1645,11 +1645,9 @@ def get_valid_filepath(img, use_hdr):
     return img.filepath
 
 def is_baked_normal_without_bump_needed(root_ch):
-    yp = root_ch.id_data.yp
-
     return (
-        (not is_overlay_normal_empty(yp) and (any_layers_using_disp(yp) or any_layers_using_vdisp(yp))) or
-        (root_ch.enable_subdiv_setup and (any_layers_using_disp(yp) or any_layers_using_vdisp(yp)))
+        (not is_overlay_normal_empty(root_ch) and (any_layers_using_disp(root_ch) or any_layers_using_vdisp(root_ch))) or
+        (root_ch.enable_subdiv_setup and (any_layers_using_disp(root_ch) or any_layers_using_vdisp(root_ch)))
     )
 
 def bake_channel(
@@ -2052,7 +2050,7 @@ def bake_channel(
                             mat.node_tree.links.new(soc, mat_out.inputs['Displacement'])
 
             ### Vector Displacement
-            if not any_layers_using_vdisp(yp):
+            if not any_layers_using_vdisp(root_ch):
                 # Remove baked_vdisp
                 remove_node(tree, root_ch, 'baked_vdisp')
             else:
@@ -2117,7 +2115,7 @@ def bake_channel(
                 else:
                     baked_vdisp.image = vdisp_img
 
-            if not any_layers_using_disp(yp):
+            if not any_layers_using_disp(root_ch):
                 # Remove baked_disp
                 remove_node(tree, root_ch, 'baked_disp')
                 remove_node(tree, root_ch, 'end_max_height')
@@ -2144,7 +2142,9 @@ def bake_channel(
                 start = tree.nodes.get(TREE_START)
                 end = tree.nodes.get(TREE_END)
                 ori_soc = end.inputs[root_ch.name].links[0].from_socket
-                max_height = start.outputs.get(root_ch.name + io_suffix['HEIGHT'])
+                if root_ch.name + io_suffix['MAX_HEIGHT'] in start.outputs:
+                    max_height = start.outputs.get(root_ch.name + io_suffix['MAX_HEIGHT'])
+                else: max_height = start.outputs.get(root_ch.name + io_suffix['HEIGHT'])
                 # Get the last layer that output max height
                 for l in yp.layers:
                     if not l.enable or not l.channels[get_channel_index(root_ch)].enable: continue

--- a/common.py
+++ b/common.py
@@ -5507,9 +5507,13 @@ def is_any_layer_using_channel(root_ch, node=None):
         inp = node.inputs.get(root_ch.name + io_suffix['ALPHA'])
         if inp and len(inp.links):
             return True
-        inp = node.inputs.get(root_ch.name + io_suffix['HEIGHT'])
-        if inp and len(inp.links):
-            return True
+        if root_ch.type == 'NORMAL':
+            inp = node.inputs.get(root_ch.name + io_suffix['HEIGHT'])
+            if inp and len(inp.links):
+                return True
+            inp = node.inputs.get(root_ch.name + io_suffix['VDISP'])
+            if inp and len(inp.links):
+                return True
 
     for layer in yp.layers:
         if layer.type in {'GROUP', 'BACKGROUND'}: continue
@@ -5732,7 +5736,7 @@ def get_yp_images(yp, udim_only=False, get_baked_channels=False, check_overlay_n
                 if baked_vdisp and baked_vdisp.image and baked_vdisp.image not in images:
                     images.append(baked_vdisp.image)
 
-                if not check_overlay_normal or not is_overlay_normal_empty(yp):
+                if not check_overlay_normal or not is_overlay_normal_empty(ch):
                     baked_normal_overlay = tree.nodes.get(ch.baked_normal_overlay)
                     if baked_normal_overlay and baked_normal_overlay.image and baked_normal_overlay.image not in images:
                         images.append(baked_normal_overlay.image)
@@ -5939,6 +5943,15 @@ def get_node(tree, name, parent=None):
 
     return node
 
+def is_normal_vdisp_input_connected(root_normal_ch):
+    # NOTE: Assuming that the active node is using the input tree
+    node = get_active_ypaint_node()
+    if not node: return False
+
+    io_vdisp_name = root_normal_ch.name + io_suffix['VDISP']
+    vdisp_inp = node.inputs.get(io_vdisp_name)
+    return vdisp_inp and len(vdisp_inp.links) > 0
+
 def is_normal_height_input_connected(root_normal_ch):
     # NOTE: Assuming that the active node is using the input tree
     node = get_active_ypaint_node()
@@ -5956,36 +5969,52 @@ def is_normal_input_connected(root_normal_ch):
     normal_inp = node.inputs.get(root_normal_ch.name)
     return normal_inp and len(normal_inp.links) > 0
 
-def is_overlay_normal_empty(yp):
+def is_overlay_normal_empty(root_ch):
+    yp = root_ch.id_data.yp
+    channel_index = get_channel_index(root_ch)
 
-    root_ch = get_root_height_channel(yp)
-    if root_ch and is_normal_input_connected(root_ch):
+    if is_normal_input_connected(root_ch):
         return False
 
     for l in yp.layers:
-        c = get_height_channel(l)
-        if not c or not get_channel_enabled(c, l): continue
+        if l.type in {'GROUP', 'BACKGROUND'}: continue
+        if channel_index >= len(l.channels): continue
+        c = l.channels[channel_index]
+        if not get_channel_enabled(c, l): continue
         if c.normal_map_type == 'NORMAL_MAP' or (c.normal_map_type == 'BUMP_MAP' and not c.write_height):
             return False
 
     return True
 
-def any_layers_using_vdisp(yp):
+def any_layers_using_vdisp(root_ch):
+    yp = root_ch.id_data.yp
+    channel_index = get_channel_index(root_ch)
+
+    if is_normal_vdisp_input_connected(root_ch):
+        return True
 
     for l in yp.layers:
-        c = get_height_channel(l)
-        if not c or not get_channel_enabled(c, l): continue
+        if l.type in {'GROUP', 'BACKGROUND'}: continue
+        if channel_index >= len(l.channels): continue
+        c = l.channels[channel_index]
+        if not get_channel_enabled(c, l): continue
         if c.normal_map_type == 'VECTOR_DISPLACEMENT_MAP':
             return True
 
     return False
 
-def any_layers_using_disp(yp):
+def any_layers_using_disp(root_ch):
+    yp = root_ch.id_data.yp
+    channel_index = get_channel_index(root_ch)
+
+    if is_normal_height_input_connected(root_ch):
+        return True
 
     for l in yp.layers:
         if l.type in {'GROUP', 'BACKGROUND'}: continue
-        c = get_height_channel(l)
-        if not c or not get_channel_enabled(c, l): continue
+        if channel_index >= len(l.channels): continue
+        c = l.channels[channel_index]
+        if not get_channel_enabled(c, l): continue
         if c.normal_map_type in {'BUMP_MAP', 'BUMP_NORMAL_MAP'} and c.write_height:
             return True
 

--- a/image_ops.py
+++ b/image_ops.py
@@ -506,7 +506,7 @@ class YPackImage(bpy.types.Operator):
                     pack_image(baked_vdisp.image)
                     baked_vdisp.image.filepath = ''
 
-                if not is_overlay_normal_empty(yp):
+                if not is_overlay_normal_empty(ch):
                     baked_normal_overlay = tree.nodes.get(ch.baked_normal_overlay)
                     if baked_normal_overlay and baked_normal_overlay.image and not baked_normal_overlay.image.packed_file:
                         pack_image(baked_normal_overlay.image)
@@ -775,7 +775,7 @@ class YSaveAllBakedImages(bpy.types.Operator):
                     images.append(baked_vdisp.image)
                     baked_vdisp_image = baked_vdisp.image
 
-                if not is_overlay_normal_empty(yp):
+                if not is_overlay_normal_empty(ch):
                     baked_normal_overlay = tree.nodes.get(ch.baked_normal_overlay)
                     if baked_normal_overlay and baked_normal_overlay.image:
                         images.append(baked_normal_overlay.image)

--- a/input_outputs.py
+++ b/input_outputs.py
@@ -260,7 +260,7 @@ def check_start_end_root_ch_nodes(group_tree, specific_channel=None):
                 remove_node(group_tree, channel, 'end_max_height_tweak')
 
             # Engine filter is needed if subdiv is on and channel is baked
-            if yp.use_baked and channel.enable_subdiv_setup and any_layers_using_displacement(channel):
+            if yp.use_baked and channel.enable_subdiv_setup and (any_layers_using_disp(channel) or any_layers_using_vdisp(channel)):
 
                 lib_name = lib.ENGINE_FILTER if is_bl_newer_than(2, 80) else lib.ENGINE_FILTER_LEGACY
                 end_normal_engine_filter = replace_new_node(


### PR DESCRIPTION
This PR fixes a few issues
- Alpha socket default value gets reset after enabling/disabling channels' alpha
- Max height on node input always gets reset to 0.1, causing a wrong bake result
- Vector displacement input socket won't get properly reconnected after enabling/disabling `Displacement Setup`
- #307 