### PR TITLE
Improve other objects baking workflow

### DIFF
--- a/BakeToLayer.py
+++ b/BakeToLayer.py
@@ -1408,6 +1408,60 @@ class YRebakeSpecificLayers(bpy.types.Operator, BaseBakeOperator):
 
         return {'FINISHED'}
 
+class YSelectAllOtherObjects(bpy.types.Operator):
+    bl_idname = "wm.y_select_all_other_objects"
+    bl_label = "Select All Other Objects"
+    bl_description = "Select all objects in the other objects list"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    @classmethod
+    def poll(cls, context):
+        return get_active_ypaint_node() and hasattr(context, 'bake_info')
+
+    def execute(self, context):
+        bpy.ops.object.select_all(action='DESELECT')
+
+        for i in range(len(context.bake_info.other_objects)):
+            so = context.bake_info.other_objects[i]
+            if so.object:
+                so_object = so.object
+                so_object.hide_viewport = False
+                set_object_select(so_object, True)
+        if so_object:
+            set_active_object(so_object)
+
+        return {'FINISHED'}
+
+class YToggleOtherObjectsVisibility(bpy.types.Operator):
+    bl_idname = "wm.y_toggle_other_objects_visibility"
+    bl_label = "Toggle Other Objects Visibility"
+    bl_description = "Toggle visibility of all objects in the other objects list"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    @classmethod
+    def poll(cls, context):
+        return get_active_ypaint_node() and hasattr(context, 'bake_info')
+
+    def execute(self, context):
+        bi = context.bake_info
+
+        reference_obj = None
+        for oo in bi.other_objects:
+            if oo.object:
+                reference_obj = oo.object
+                break
+
+        if not reference_obj:
+            return {'CANCELLED'}
+
+        current_hidden_state = reference_obj.hide_viewport
+
+        for oo in bi.other_objects:
+            if oo.object:
+                oo.object.hide_viewport = not current_hidden_state
+
+        return {'FINISHED'}
+
 def register():
     bpy.utils.register_class(YBakeToLayer)
     bpy.utils.register_class(YBakeEntityToImage)
@@ -1416,6 +1470,8 @@ def register():
     bpy.utils.register_class(YRemoveBakedEntity)
     bpy.utils.register_class(YRebakeBakedImages)
     bpy.utils.register_class(YRebakeSpecificLayers)
+    bpy.utils.register_class(YSelectAllOtherObjects)
+    bpy.utils.register_class(YToggleOtherObjectsVisibility)
 
 def unregister():
     bpy.utils.unregister_class(YBakeToLayer)
@@ -1425,3 +1481,5 @@ def unregister():
     bpy.utils.unregister_class(YRemoveBakedEntity)
     bpy.utils.unregister_class(YRebakeBakedImages)
     bpy.utils.unregister_class(YRebakeSpecificLayers)
+    bpy.utils.unregister_class(YSelectAllOtherObjects)
+    bpy.utils.unregister_class(YToggleOtherObjectsVisibility)

--- a/bake_common.py
+++ b/bake_common.py
@@ -3994,6 +3994,11 @@ def bake_to_entity(bprops, overwrite_img=None, segment=None):
     # Recover bake settings
     recover_bake_settings(book, yp, mat=mat)
 
+    # Hide other objects after baking
+    if is_bl_newer_than(2, 79) and bprops.type.startswith('OTHER_OBJECT_') and other_objs:
+        for oo in other_objs:
+            oo.hide_viewport = True
+
     # Remove temporary objects
     if temp_objs:
         for o in temp_objs:

--- a/ui.py
+++ b/ui.py
@@ -180,17 +180,22 @@ def draw_bake_info(bake_info, layout, entity):
         layout.label(text='List of Objects:')
         box = layout.box()
         bcol = box.column()
+        bcol.context_pointer_set('bake_info', bi)
 
         if num_oos > 0:
             for oo in bi.other_objects:
                 if is_bl_newer_than(2,79) and not oo.object: continue
                 brow = bcol.row()
                 brow.context_pointer_set('other_object', oo)
-                brow.context_pointer_set('bake_info', bi)
                 if is_bl_newer_than(2, 79):
                     brow.label(text=oo.object.name, icon_value=lib.get_icon('object_index'))
                 else: brow.label(text=oo.object_name, icon_value=lib.get_icon('object_index'))
                 brow.operator('wm.y_remove_bake_info_other_object', text='', icon_value=lib.get_icon('close'))
+
+            if is_bl_newer_than(2, 79):
+                bbcol = bcol.column(align=True)
+                bbcol.operator('wm.y_select_all_other_objects', text='Select All', icon='RESTRICT_SELECT_OFF')
+                bbcol.operator('wm.y_toggle_other_objects_visibility', text='Toggle Hide', icon='RESTRICT_VIEW_OFF')
         else:
             brow = bcol.row()
             brow.label(text='No source objects found!', icon='ERROR')


### PR DESCRIPTION
Adds select all and toggle hide buttons to the object list:

<img width="363" height="294" alt="image" src="https://github.com/user-attachments/assets/fa1f480d-42d4-4ed2-8046-f43cce4ebe5f" /><br>

Also hides other objects after bake. Was thinking if that should be an option but I can't think of a scenario where not hiding them would be preferable, they always obstruct view because they need to be close to the surface. They can be easily shown with the new toggle button

Implemented for 2.79+ because there seems to be some api differences and I'm not ready to jump into that rabbit hole (and it's been 8 years) 😅