### PR TITLE
Add Thickness bake type

### DIFF
--- a/BakeToLayer.py
+++ b/BakeToLayer.py
@@ -448,6 +448,10 @@ class YBakeToLayer(bpy.types.Operator, BaseBakeOperator):
             self.blend_type = 'MIX'
         elif self.type == 'PAINT_BASE':
             self.blend_type = 'MIX'
+        elif self.type == 'THICKNESS':
+            self.blend_type = 'MIX'
+            self.samples = 32
+            self.only_local = True
         elif self.type == 'BEVEL_NORMAL':
             self.blend_type = 'MIX'
             self.normal_blend_type = 'OVERLAY'
@@ -719,6 +723,9 @@ class YBakeToLayer(bpy.types.Operator, BaseBakeOperator):
         elif self.type == 'AO':
             col.label(text='AO Distance:')
             col.label(text='')
+        elif self.type == 'THICKNESS':
+            col.label(text='Distance:')
+            col.label(text='')
         elif self.type in {'BEVEL_NORMAL', 'BEVEL_MASK'}:
             col.label(text='Bevel Samples:')
             col.label(text='Bevel Radius:')
@@ -809,6 +816,9 @@ class YBakeToLayer(bpy.types.Operator, BaseBakeOperator):
         elif self.type == 'AO':
             col.prop(self, 'ao_distance', text='')
             col.prop(self, 'only_local')
+        elif self.type == 'THICKNESS':
+            col.prop(self, 'ao_distance', text='')
+            col.prop(self, 'only_local')
         elif self.type in {'BEVEL_NORMAL', 'BEVEL_MASK'}:
             col.prop(self, 'bevel_samples', text='')
             col.prop(self, 'bevel_radius', text='')
@@ -852,7 +862,7 @@ class YBakeToLayer(bpy.types.Operator, BaseBakeOperator):
             col.prop(self, 'ssaa')
         else: col.prop(self, 'fxaa')
 
-        if self.type in {'AO', 'BEVEL_MASK', 'BEVEL_NORMAL'} and is_bl_newer_than(2, 81):
+        if self.type in {'AO', 'THICKNESS', 'BEVEL_MASK', 'BEVEL_NORMAL'} and is_bl_newer_than(2, 81):
             col.prop(self, 'denoise')
 
         col.separator()

--- a/bake_common.py
+++ b/bake_common.py
@@ -2880,7 +2880,7 @@ def bake_to_entity(bprops, overwrite_img=None, segment=None):
         rdict['message'] = "Mask need active layer!"
         return rdict
 
-    if bprops.type in {'BEVEL_NORMAL', 'BEVEL_MASK'} and not is_bl_newer_than(2, 80):
+    if bprops.type in {'THICKNESS', 'BEVEL_NORMAL', 'BEVEL_MASK'} and not is_bl_newer_than(2, 80):
         rdict['message'] = "Blender 2.80+ is needed to use this feature!"
         return rdict
 
@@ -3003,7 +3003,7 @@ def bake_to_entity(bprops, overwrite_img=None, segment=None):
     use_ssaa = bprops.ssaa and bprops.type.startswith('OTHER_OBJECT_')
 
     # Denoising only available for AO bake for now
-    use_denoise = bprops.denoise and bprops.type in {'AO', 'BEVEL_MASK', 'BEVEL_NORMAL'} and is_bl_newer_than(2, 81)
+    use_denoise = bprops.denoise and bprops.type in {'AO', 'THICKNESS', 'BEVEL_MASK', 'BEVEL_NORMAL'} and is_bl_newer_than(2, 81)
 
     # SSAA will multiply size by 2 then resize it back
     if use_ssaa:
@@ -3179,7 +3179,7 @@ def bake_to_entity(bprops, overwrite_img=None, segment=None):
         bake_type = 'EMIT'
 
     # If use only local, hide other objects
-    hide_other_objs = bprops.type != 'AO' or bprops.only_local
+    hide_other_objs = bprops.type not in {'AO', 'THICKNESS'} or bprops.only_local
 
     # Fit tilesize to bake resolution if samples is equal 1
     if bprops.samples <= 1:
@@ -3346,6 +3346,7 @@ def bake_to_entity(bprops, overwrite_img=None, segment=None):
     tex = mat.node_tree.nodes.new('ShaderNodeTexImage')
     bsdf = None
     map_range = None
+    invert = None
     geometry = None
     vector_math = None
     vector_math_1 = None
@@ -3398,6 +3399,21 @@ def bake_to_entity(bprops, overwrite_img=None, segment=None):
 
                 if bprops.flip_normals:
                     src.inside = True
+
+    elif bprops.type == 'THICKNESS':
+        src = mat.node_tree.nodes.new('ShaderNodeAmbientOcclusion')
+        src.inside = True
+        src.only_local = bprops.only_local
+        src.inputs['Distance'].default_value = bprops.ao_distance
+
+        # Invert the inside ambient occlusion to get the thickness
+        invert = mat.node_tree.nodes.new('ShaderNodeMath')
+        invert.operation = 'SUBTRACT'
+        invert.inputs[0].default_value = 1.0
+
+        mat.node_tree.links.new(src.outputs['AO'], invert.inputs[1])
+        mat.node_tree.links.new(invert.outputs[0], bsdf.inputs[0])
+        mat.node_tree.links.new(bsdf.outputs[0], output.inputs[0])
 
     elif bprops.type == 'POINTINESS':
         src = mat.node_tree.nodes.new('ShaderNodeNewGeometry')
@@ -4176,6 +4192,7 @@ def bake_to_entity(bprops, overwrite_img=None, segment=None):
     if src: simple_remove_node(mat.node_tree, src)
     if geometry: simple_remove_node(mat.node_tree, geometry)
     if map_range: simple_remove_node(mat.node_tree, map_range)
+    if invert: simple_remove_node(mat.node_tree, invert)
     if vector_math: simple_remove_node(mat.node_tree, vector_math)
     if vector_math_1: simple_remove_node(mat.node_tree, vector_math_1)
 

--- a/common.py
+++ b/common.py
@@ -415,6 +415,8 @@ bake_type_items = (
     ('FLOW', 'Flow Map based on straight UVMap', ''),
 
     ('OBJECT_SPACE_NORMAL', 'Object Space Normal', ''),
+
+    ('THICKNESS', 'Thickness', ''),
 )
 
 image_resolution_items = (
@@ -461,7 +463,9 @@ bake_type_labels = {
 
     'FLOW': 'Flow',
 
-    'OBJECT_SPACE_NORMAL' : 'Object Space Normal'
+    'OBJECT_SPACE_NORMAL' : 'Object Space Normal',
+
+    'THICKNESS': 'Thickness'
 }
 
 bake_type_suffixes = {
@@ -485,7 +489,9 @@ bake_type_suffixes = {
 
     'FLOW': 'Flow',
 
-    'OBJECT_SPACE_NORMAL' : 'Object Space Normal'
+    'OBJECT_SPACE_NORMAL' : 'Object Space Normal',
+
+    'THICKNESS': 'Thickness'
 }
 
 texcoord_lists = [

--- a/common.py
+++ b/common.py
@@ -399,7 +399,6 @@ bake_type_items = (
     ('CAVITY', 'Cavity', ''),
     ('DUST', 'Dust', ''),
     ('PAINT_BASE', 'Paint Base', ''),
-    ('THICKNESS', 'Thickness', ''),
 
     ('BEVEL_NORMAL', 'Bevel Normal', ''),
     ('BEVEL_MASK', 'Bevel Grayscale', ''),
@@ -449,7 +448,6 @@ bake_type_labels = {
     'CAVITY': 'Cavity',
     'DUST': 'Dust',
     'PAINT_BASE': 'Paint Base',
-    'THICKNESS': 'Thickness',
 
     'BEVEL_NORMAL': 'Bevel Normal',
     'BEVEL_MASK': 'Bevel Grayscale',
@@ -476,7 +474,6 @@ bake_type_suffixes = {
     'CAVITY': 'Cavity',
     'DUST': 'Dust',
     'PAINT_BASE': 'Paint Base',
-    'THICKNESS': 'Thickness',
 
     'BEVEL_NORMAL': 'Bevel Normal',
     'BEVEL_MASK': 'Bevel Grayscale',

--- a/common.py
+++ b/common.py
@@ -399,6 +399,7 @@ bake_type_items = (
     ('CAVITY', 'Cavity', ''),
     ('DUST', 'Dust', ''),
     ('PAINT_BASE', 'Paint Base', ''),
+    ('THICKNESS', 'Thickness', ''),
 
     ('BEVEL_NORMAL', 'Bevel Normal', ''),
     ('BEVEL_MASK', 'Bevel Grayscale', ''),
@@ -446,6 +447,7 @@ bake_type_labels = {
     'CAVITY': 'Cavity',
     'DUST': 'Dust',
     'PAINT_BASE': 'Paint Base',
+    'THICKNESS': 'Thickness',
 
     'BEVEL_NORMAL': 'Bevel Normal',
     'BEVEL_MASK': 'Bevel Grayscale',
@@ -470,6 +472,7 @@ bake_type_suffixes = {
     'CAVITY': 'Cavity',
     'DUST': 'Dust',
     'PAINT_BASE': 'Paint Base',
+    'THICKNESS': 'Thickness',
 
     'BEVEL_NORMAL': 'Bevel Normal',
     'BEVEL_MASK': 'Bevel Grayscale',

--- a/ui.py
+++ b/ui.py
@@ -6045,6 +6045,11 @@ class YNewLayerMenu(bpy.types.Menu):
         c.overwrite_current = False
 
         if is_bl_newer_than(2, 80):
+            c = col.operator("wm.y_bake_to_layer", text='Thickness')
+            c.type = 'THICKNESS'
+            c.target_type = 'LAYER'
+            c.overwrite_current = False
+
             c = col.operator("wm.y_bake_to_layer", text='Bevel Normal')
             c.type = 'BEVEL_NORMAL'
             c.target_type = 'LAYER'
@@ -6844,6 +6849,7 @@ class YAddLayerMaskMenu(bpy.types.Menu):
         new_mask_button(col, 'wm.y_bake_to_layer', 'Cavity', otype='CAVITY', target_type='MASK', overwrite_current=False)
         new_mask_button(col, 'wm.y_bake_to_layer', 'Dust', otype='DUST', target_type='MASK', overwrite_current=False)
         new_mask_button(col, 'wm.y_bake_to_layer', 'Paint Base', otype='PAINT_BASE', target_type='MASK', overwrite_current=False)
+        new_mask_button(col, 'wm.y_bake_to_layer', 'Thickness', otype='THICKNESS', target_type='MASK', overwrite_current=False)
         new_mask_button(col, 'wm.y_bake_to_layer', 'Bevel Grayscale', otype='BEVEL_MASK', target_type='MASK', overwrite_current=False)
         new_mask_button(col, 'wm.y_bake_to_layer', 'Selected Vertices', otype='SELECTED_VERTICES', target_type='MASK', overwrite_current=False)
         if is_bl_newer_than(2, 77):


### PR DESCRIPTION
This adds a Thickness mesh-derived bake type to Bake as Layer / Bake as Mask, following the existing bake type conventions.

### Thickness
Inverted inside ambient occlusion (white = thin), like the classic Substance Painter mesh map. Reuses the existing `ao_distance` and `only_local` properties, supports denoise. Blender 2.80+.

![Thickness bake on Suzanne](https://raw.githubusercontent.com/jakeblakeley/ucupaint/pr-images/pr-images/thickness.webp)

Thickness measures the material *behind* each point (inverted inside-facing occlusion), which is a genuinely different signal from AO's outward exposure — reproducing it from the AO baker requires disabling alpha scene-wide, flipping a hidden inside-sampling toggle, matching the `only_local` flag, and inverting, so a dedicated bake type is well worth it.

### Notes
- Tested on Apple and Nvidia cards. I don't have an AMD to verify, but since its using Blender operators it should work fine.
- Wireframe and Curvature bake types are in separate PRs: #410 (Wireframe) and #411 (Curvature)
